### PR TITLE
scan create: show users which fields are missing

### DIFF
--- a/src/commands/scan/create.ts
+++ b/src/commands/scan/create.ts
@@ -163,6 +163,7 @@ async function setupCommand(
         })
       }
     )
+
   const packagePaths = await getPackageFilesFullScans(
     cwd,
     cli.input,
@@ -172,9 +173,9 @@ async function setupCommand(
   if (!repoName || !branchName || !packagePaths.length) {
     showHelp = true
     console.error(`${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:\n
-    - Repository name using --repo\n
-    - Branch name using --branch\n
-    - At least one file path (e.g. ./package.json)`)
+    - Repository name using --repo ${!repoName ? colors.red('(missing!)') : colors.green('(ok)')}\n
+    - Branch name using --branch ${!branchName ? colors.red('(missing!)') : colors.green('(ok)')}\n
+    - At least one file path (e.g. ./package.json) ${!packagePaths.length ? colors.red('(missing or no matching/supported files found!)') : colors.green('(ok)')}`)
   }
   if (showHelp) {
     cli.showHelp()


### PR DESCRIPTION
Added an explicit hint to tell you which part you are missing from the command.

Before:
![image](https://github.com/user-attachments/assets/5fb4424e-7c87-4a35-840d-b320489371aa)

After:
![image](https://github.com/user-attachments/assets/20a8d926-fad6-4482-a3f7-7ecd6a46c9b5)

![image](https://github.com/user-attachments/assets/cbbe11d9-37f1-4ef0-a160-d50eb42b81bd)

![image](https://github.com/user-attachments/assets/c5eb9680-c477-4a11-bd7d-26b1ab836837)
