### PR TITLE
Abstract the meow function

### DIFF
--- a/src/commands/action/cmd-action.ts
+++ b/src/commands/action/cmd-action.ts
@@ -1,9 +1,10 @@
 // https://github.com/SocketDev/socket-python-cli/blob/6d4fc56faee68d3a4764f1f80f84710635bdaf05/socketsecurity/socketcli.py
-import meowOrExit from 'meow'
 
 import { runAction } from './run-action.ts'
-import { type CliCommandConfig } from '../../utils/meow-with-subcommands'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting.ts'
+
+import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
 const config: CliCommandConfig = {
   commandName: 'action',
@@ -47,11 +48,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags
+    parentName
   })
 
   const githubEventBefore = String(cli.flags['githubEventBefore'] || '')

--- a/src/commands/analytics/cmd-analytics.ts
+++ b/src/commands/analytics/cmd-analytics.ts
@@ -1,9 +1,9 @@
-import meowOrExit from 'meow'
 import colors from 'yoctocolors-cjs'
 
 import { displayAnalytics } from './display-analytics.ts'
 import { commonFlags, outputFlags } from '../../flags'
 import { AuthError } from '../../utils/errors'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk.ts'
 
@@ -70,11 +70,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags
+    parentName
   })
 
   const { repo, scope, time } = cli.flags

--- a/src/commands/audit-log/cmd-audit-log.ts
+++ b/src/commands/audit-log/cmd-audit-log.ts
@@ -1,9 +1,9 @@
-import meowOrExit from 'meow'
 import colors from 'yoctocolors-cjs'
 
 import { getAuditLog } from './get-audit-log.ts'
 import { commonFlags, outputFlags } from '../../flags'
 import { AuthError } from '../../utils/errors'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
 
@@ -35,15 +35,15 @@ const config: CliCommandConfig = {
     ...commonFlags,
     ...outputFlags
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} <org slug>
+      $ ${command} <org slug>
 
     Options
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName} FakeOrg
+      $ ${command} FakeOrg
   `
 }
 
@@ -58,11 +58,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags
+    parentName
   })
 
   const type = String(cli.flags['type'] || '')

--- a/src/commands/cdxgen/cmd-cdxgen.ts
+++ b/src/commands/cdxgen/cmd-cdxgen.ts
@@ -1,4 +1,4 @@
-// import meowOrExit from 'meow'
+// import { meowOrExit } from '../../utils/meow-with-subcommands'
 import process from 'node:process'
 
 import yargsParse from 'yargs-parser'
@@ -6,9 +6,8 @@ import yargsParse from 'yargs-parser'
 import { pluralize } from '@socketsecurity/registry/lib/words'
 
 import { runCycloneDX } from './run-cyclonedx.ts'
+import { CliCommandConfig } from '../../utils/meow-with-subcommands.ts'
 import { getFlagListOutput } from '../../utils/output-formatting.ts'
-
-import type { CliCommandConfig } from '../../utils/meow-with-subcommands.ts'
 
 // TODO: convert yargs to meow. Or convert all the other things to yargs.
 const toLower = (arg: string) => arg.toLowerCase()
@@ -110,9 +109,9 @@ const config: CliCommandConfig = {
   flags: {
     // TODO: convert from yargsConfig
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} [options]
+      $ ${command} [options]
 
     Options
       ${getFlagListOutput(config.flags, 6)}
@@ -130,12 +129,12 @@ async function run(
   _importMeta: ImportMeta,
   { parentName: _parentName }: { parentName: string }
 ): Promise<void> {
-  // const cli = meowOrExit(config.help(parentName, config), {
+  // const cli = meowOrExit({
+  //   allowUnknownFlags: true,
   //   argv,
-  //   description: config.description,
+  //   config,
   //   importMeta,
-  //   // Note: we pass the args through so unknown args are allowed for this command
-  //   flags: config.flags
+  //   parentName,
   // })
   //
   //

--- a/src/commands/dependencies/cmd-dependencies.ts
+++ b/src/commands/dependencies/cmd-dependencies.ts
@@ -1,7 +1,6 @@
-import meowOrExit from 'meow'
-
 import { findDependencies } from './find-dependencies.ts'
 import { commonFlags, outputFlags } from '../../flags'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.ts'
@@ -27,15 +26,15 @@ const config: CliCommandConfig = {
     },
     ...outputFlags
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      ${parentName} ${config.commandName}
+      ${command}
 
     Options
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      ${parentName} ${config.commandName}
+      ${command} --limit 20 --offset 10
   `
 }
 
@@ -50,11 +49,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags
+    parentName
   })
 
   // TODO: markdown flag is ignored

--- a/src/commands/diff-scan/cmd-diff-scan-get.ts
+++ b/src/commands/diff-scan/cmd-diff-scan-get.ts
@@ -1,9 +1,9 @@
-import meowOrExit from 'meow'
 import colors from 'yoctocolors-cjs'
 
 import { getDiffScan } from './get-diff-scan.ts'
 import { commonFlags, outputFlags } from '../../flags'
 import { AuthError } from '../../utils/errors'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
 
@@ -41,15 +41,15 @@ const config: CliCommandConfig = {
     },
     ...outputFlags
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} <org slug> --before=<before> --after=<after>
+      $ ${command} <org slug> --before=<before> --after=<after>
 
     Options
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName} FakeCorp --before=aaa0aa0a-aaaa-0000-0a0a-0000000a00a0 --after=aaa1aa1a-aaaa-1111-1a1a-1111111a11a1
+      $ ${command} FakeCorp --before=aaa0aa0a-aaaa-0000-0a0a-0000000a00a0 --after=aaa1aa1a-aaaa-1111-1a1a-1111111a11a1
   `
 }
 
@@ -64,12 +64,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags,
-    allowUnknownFlags: false
+    parentName
   })
 
   const before = String(cli.flags['before'] || '')

--- a/src/commands/fix/cmd-fix.ts
+++ b/src/commands/fix/cmd-fix.ts
@@ -1,6 +1,5 @@
-import meowOrExit from 'meow'
-
 import { runFix } from './run-fix.ts'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting.ts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.ts'
@@ -10,9 +9,9 @@ const config: CliCommandConfig = {
   description: 'Fix "fixable" Socket alerts',
   hidden: true,
   flags: {},
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName}
+      $ ${command}
 
     Options
       ${getFlagListOutput(config.flags, 6)}
@@ -30,11 +29,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  meowOrExit(config.help(parentName, config), {
+  meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags
+    parentName
   })
 
   await runFix()

--- a/src/commands/info/cmd-info.ts
+++ b/src/commands/info/cmd-info.ts
@@ -1,8 +1,7 @@
-import meowOrExit from 'meow'
-
 import { getPackageInfo } from './get-package-info.ts'
 import { commonFlags, outputFlags, validationFlags } from '../../flags'
 import { InputError } from '../../utils/errors'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.ts'
@@ -16,16 +15,16 @@ const config: CliCommandConfig = {
     ...outputFlags,
     ...validationFlags
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} <name>
+      $ ${command} <name>
 
     Options
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName} webtorrent
-      $ ${parentName} ${config.commandName} webtorrent@1.9.1
+      $ ${command} webtorrent
+      $ ${command} webtorrent@1.9.1
   `
 }
 
@@ -40,11 +39,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags
+    parentName
   })
 
   if (cli.input.length > 1) {

--- a/src/commands/login/cmd-login.ts
+++ b/src/commands/login/cmd-login.ts
@@ -1,9 +1,8 @@
-import meowOrExit from 'meow'
-
 import isInteractive from '@socketregistry/is-interactive/index.cjs'
 
 import { attemptLogin } from './attempt-login.ts'
 import { InputError } from '../../utils/errors'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.ts'
@@ -22,9 +21,9 @@ const config: CliCommandConfig = {
       description: 'Proxy to use when making connection to API server'
     }
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName}
+      $ ${command}
 
     Logs into the Socket API by prompting for an API key
 
@@ -32,7 +31,8 @@ const config: CliCommandConfig = {
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName}
+      $ ${command}
+      $ ${command} --api-proxy=http://localhost:1234
   `
 }
 
@@ -47,11 +47,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags
+    parentName
   })
 
   if (!isInteractive()) {

--- a/src/commands/logout/cmd-logout.ts
+++ b/src/commands/logout/cmd-logout.ts
@@ -1,6 +1,5 @@
-import meowOrExit from 'meow'
-
 import { attemptLogout } from './attempt-logout.ts'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.ts'
 
@@ -9,14 +8,11 @@ const config: CliCommandConfig = {
   description: 'Socket API logout',
   hidden: false,
   flags: {},
-  help: (parentName, config) => `
+  help: (command, _config) => `
     Usage
-      $ ${parentName} ${config.commandName}
+      $ ${command}
 
     Logs out of the Socket API and clears all Socket credentials from disk
-
-    Examples
-      $ ${parentName} ${config.commandName}
   `
 }
 
@@ -31,11 +27,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  meowOrExit(config.help(parentName, config), {
+  meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags
+    parentName
   })
 
   attemptLogout()

--- a/src/commands/manifest/cmd-manifest-auto.ts
+++ b/src/commands/manifest/cmd-manifest-auto.ts
@@ -27,9 +27,9 @@ const config: CliCommandConfig = {
     }
     // TODO: support output flags
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName}
+      $ ${command}
 
     Options
       ${getFlagListOutput(config.flags, 6)}

--- a/src/commands/manifest/cmd-manifest-gradle.ts
+++ b/src/commands/manifest/cmd-manifest-gradle.ts
@@ -51,9 +51,9 @@ const config: CliCommandConfig = {
       description: 'Print debug messages'
     }
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} [--gradle=path/to/gradle/binary] [--out=path/to/result] DIR
+      $ ${command} [--gradle=path/to/gradle/binary] [--out=path/to/result] DIR
 
     Options
       ${getFlagListOutput(config.flags, 6)}
@@ -80,8 +80,8 @@ const config: CliCommandConfig = {
 
     Examples
 
-      $ ${parentName} ${config.commandName} .
-      $ ${parentName} ${config.commandName} --gradlew=../gradlew .
+      $ ${command} .
+      $ ${command} --gradlew=../gradlew .
   `
 }
 

--- a/src/commands/manifest/cmd-manifest-kotlin.ts
+++ b/src/commands/manifest/cmd-manifest-kotlin.ts
@@ -56,9 +56,9 @@ const config: CliCommandConfig = {
       description: 'Print debug messages'
     }
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} [--gradle=path/to/gradle/binary] [--out=path/to/result] DIR
+      $ ${command} [--gradle=path/to/gradle/binary] [--out=path/to/result] DIR
 
     Options
       ${getFlagListOutput(config.flags, 6)}
@@ -85,8 +85,8 @@ const config: CliCommandConfig = {
 
     Examples
 
-      $ ${parentName} ${config.commandName} .
-      $ ${parentName} ${config.commandName} --gradlew=../gradlew .
+      $ ${command} .
+      $ ${command} --gradlew=../gradlew .
   `
 }
 

--- a/src/commands/manifest/cmd-manifest-scala.ts
+++ b/src/commands/manifest/cmd-manifest-scala.ts
@@ -44,9 +44,9 @@ const config: CliCommandConfig = {
       description: 'Print debug messages'
     }
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} [--sbt=path/to/sbt/binary] [--out=path/to/result] FILE|DIR
+      $ ${command} [--sbt=path/to/sbt/binary] [--out=path/to/result] FILE|DIR
 
     Options
       ${getFlagListOutput(config.flags, 6)}
@@ -75,8 +75,8 @@ const config: CliCommandConfig = {
 
     Examples
 
-      $ ${parentName} ${config.commandName} ./build.sbt
-      $ ${parentName} ${config.commandName} --bin=/usr/bin/sbt ./build.sbt
+      $ ${command} ./build.sbt
+      $ ${command} --bin=/usr/bin/sbt ./build.sbt
   `
 }
 

--- a/src/commands/manifest/cmd-manifest.ts
+++ b/src/commands/manifest/cmd-manifest.ts
@@ -3,10 +3,10 @@ import { cmdManifestGradle } from './cmd-manifest-gradle.ts'
 import { cmdManifestKotlin } from './cmd-manifest-kotlin.ts'
 import { cmdManifestScala } from './cmd-manifest-scala.ts'
 import { commonFlags } from '../../flags.ts'
-import {
-  type CliCommandConfig,
-  meowWithSubcommands
-} from '../../utils/meow-with-subcommands'
+import { meowWithSubcommands } from '../../utils/meow-with-subcommands'
+import { getFlagListOutput } from '../../utils/output-formatting.ts'
+
+import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
 const config: CliCommandConfig = {
   commandName: 'manifest',
@@ -15,10 +15,12 @@ const config: CliCommandConfig = {
   flags: {
     ...commonFlags
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
+      $ ${command} <language> <target>
 
-      $ ${parentName} ${config.commandName} <language> <target>
+    Options
+      ${getFlagListOutput(config.flags, 6)}
 
     Generates a declarative dependency manifest (like a package.json for Node.JS
     or requirements.txt for PyPi), but for certain supported ecosystems
@@ -33,11 +35,11 @@ const config: CliCommandConfig = {
 
     Examples
 
-      $ ${parentName} ${config.commandName} scala .
+      $ ${command} scala .
 
     To have it auto-detect and attempt to run:
 
-      $ ${parentName} ${config.commandName} yolo
+      $ ${command} yolo
   `
 }
 

--- a/src/commands/npm/cmd-npm.ts
+++ b/src/commands/npm/cmd-npm.ts
@@ -1,7 +1,6 @@
-import meowOrExit from 'meow'
-
 import { wrapNpm } from './wrap-npm.ts'
 import constants from '../../constants'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -12,9 +11,9 @@ const config: CliCommandConfig = {
   description: `${NPM} wrapper functionality`,
   hidden: false,
   flags: {},
-  help: (parentName, config) => `
+  help: (command, _config) => `
     Usage
-      $ ${parentName} ${config.commandName}
+      $ ${command}
   `
 }
 
@@ -29,11 +28,12 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  meowOrExit(config.help(parentName, config), {
+  meowOrExit({
+    allowUnknownFlags: true,
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags
+    parentName
   })
 
   await wrapNpm(argv)

--- a/src/commands/npx/cmd-npx.ts
+++ b/src/commands/npx/cmd-npx.ts
@@ -1,7 +1,6 @@
-import meowOrExit from 'meow'
-
 import { wrapNpx } from './wrap-npx.ts'
 import constants from '../../constants'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.ts'
 
@@ -12,9 +11,9 @@ const config: CliCommandConfig = {
   description: `${NPX} wrapper functionality`,
   hidden: false,
   flags: {},
-  help: (parentName, config) => `
+  help: (command, _config) => `
     Usage
-      $ ${parentName} ${config.commandName}
+      $ ${command}
   `
 }
 
@@ -29,11 +28,12 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  meowOrExit(config.help(parentName, config), {
+  meowOrExit({
+    allowUnknownFlags: true,
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags
+    parentName
   })
 
   await wrapNpx(argv)

--- a/src/commands/optimize/cmd-optimize.ts
+++ b/src/commands/optimize/cmd-optimize.ts
@@ -1,9 +1,8 @@
 import process from 'node:process'
 
-import meowOrExit from 'meow'
-
 import { applyOptimization } from './apply-optimization.ts'
 import { commonFlags } from '../../flags'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.ts'
@@ -25,15 +24,16 @@ const config: CliCommandConfig = {
       description: 'Only add overrides for production dependencies'
     }
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName}
+      $ ${command}
 
     Options
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName}
+      $ ${command}
+      $ ${command} --pin
   `
 }
 
@@ -48,11 +48,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags
+    parentName
   })
 
   const cwd = process.cwd()

--- a/src/commands/organizations/cmd-organizations.ts
+++ b/src/commands/organizations/cmd-organizations.ts
@@ -1,6 +1,5 @@
-import meowOrExit from 'meow'
-
 import { getOrganizations } from './get-organizations.ts'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.ts'
 
@@ -9,9 +8,9 @@ const config: CliCommandConfig = {
   description: 'List organizations associated with the API key used',
   hidden: false,
   flags: {},
-  help: (parentName, config) => `
+  help: (command, _config) => `
     Usage
-      $ ${parentName} ${config.commandName}
+      $ ${command}
   `
 }
 
@@ -26,11 +25,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  meowOrExit(config.help(parentName, config), {
+  meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags
+    parentName
   })
 
   await getOrganizations()

--- a/src/commands/raw-npm/cmd-raw-npm.ts
+++ b/src/commands/raw-npm/cmd-raw-npm.ts
@@ -1,7 +1,6 @@
-import meowOrExit from 'meow'
-
 import { runRawNpm } from './run-raw-npm.ts'
 import constants from '../../constants'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.ts'
@@ -13,15 +12,15 @@ const config: CliCommandConfig = {
   description: `Temporarily disable the Socket ${NPM} wrapper`,
   hidden: false,
   flags: {},
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} <command>
+      $ ${command} <command>
 
     Options
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName} install
+      $ ${command} install
   `
 }
 
@@ -36,11 +35,12 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  meowOrExit(config.help(parentName, config), {
+  meowOrExit({
+    allowUnknownFlags: true,
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags
+    parentName
   })
 
   await runRawNpm(argv)

--- a/src/commands/raw-npx/cmd-raw-npx.ts
+++ b/src/commands/raw-npx/cmd-raw-npx.ts
@@ -1,7 +1,6 @@
-import meowOrExit from 'meow'
-
 import { runRawNpx } from './run-raw-npx.ts'
 import constants from '../../constants'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.ts'
@@ -13,15 +12,15 @@ const config: CliCommandConfig = {
   description: `Temporarily disable the Socket ${NPX} wrapper`,
   hidden: false,
   flags: {},
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} <command>
+      $ ${command} <command>
 
     Options
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName} install
+      $ ${command} install
   `
 }
 
@@ -36,11 +35,12 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  meowOrExit(config.help(parentName, config), {
+  meowOrExit({
+    allowUnknownFlags: true,
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags
+    parentName
   })
 
   await runRawNpx(argv)

--- a/src/commands/report/cmd-report-create.ts
+++ b/src/commands/report/cmd-report-create.ts
@@ -1,13 +1,12 @@
 import path from 'node:path'
 import process from 'node:process'
 
-import meowOrExit from 'meow'
-
 import { createReport } from './create-report.ts'
 import { getSocketConfig } from './get-socket-config.ts'
 import { viewReport } from './view-report.ts'
 import { commonFlags, outputFlags, validationFlags } from '../../flags'
 import { ColorOrMarkdown } from '../../utils/color-or-markdown.ts'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
@@ -32,9 +31,9 @@ const config: CliCommandConfig = {
       description: 'Will wait for and return the created report'
     }
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} <paths-to-package-folders-and-files>
+      $ ${command} <paths-to-package-folders-and-files>
 
     Uploads the specified "package.json" and lock files for JavaScript, Python, and Go dependency manifests.
     If any folder is specified, the ones found in there recursively are uploaded.
@@ -49,10 +48,10 @@ const config: CliCommandConfig = {
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName} .
-      $ ${parentName} ${config.commandName} '**/package.json'
-      $ ${parentName} ${config.commandName} /path/to/a/package.json /path/to/another/package.json
-      $ ${parentName} ${config.commandName} . --view --json
+      $ ${command} .
+      $ ${command} '**/package.json'
+      $ ${command} /path/to/a/package.json /path/to/another/package.json
+      $ ${command} . --view --json
   `
 }
 
@@ -67,12 +66,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags,
-    allowUnknownFlags: false
+    parentName
   })
 
   // TODO: Allow setting a custom cwd and/or configFile path?

--- a/src/commands/report/cmd-report-view.ts
+++ b/src/commands/report/cmd-report-view.ts
@@ -1,8 +1,8 @@
-import meowOrExit from 'meow'
 import colors from 'yoctocolors-cjs'
 
 import { viewReport } from './view-report.ts'
 import { commonFlags, outputFlags, validationFlags } from '../../flags'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
@@ -16,15 +16,15 @@ const config: CliCommandConfig = {
     ...outputFlags,
     ...validationFlags
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} <report-identifier>
+      $ ${command} <report-identifier>
 
     Options
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName} QXU8PmK7LfH608RAwfIKdbcHgwEd_ZeWJ9QEGv05FJUQ
+      $ ${command} QXU8PmK7LfH608RAwfIKdbcHgwEd_ZeWJ9QEGv05FJUQ
   `
 }
 
@@ -39,12 +39,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags,
-    allowUnknownFlags: false
+    parentName
   })
 
   const [reportId, ...extraInput] = cli.input

--- a/src/commands/repos/cmd-repos-create.ts
+++ b/src/commands/repos/cmd-repos-create.ts
@@ -1,9 +1,9 @@
-import meowOrExit from 'meow'
 import colors from 'yoctocolors-cjs'
 
 import { createRepo } from './create-repo.ts'
 import { commonFlags, outputFlags } from '../../flags'
 import { AuthError } from '../../utils/errors'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
 
@@ -47,15 +47,15 @@ const config: CliCommandConfig = {
       description: 'Repository visibility (Default Private)'
     }
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} <org slug>
+      $ ${command} <org slug>
 
     Options
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName} FakeOrg --repoName=test-repo
+      $ ${command} FakeOrg --repoName=test-repo
   `
 }
 
@@ -70,12 +70,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags,
-    allowUnknownFlags: false
+    parentName
   })
 
   const repoName = cli.flags['repoName']

--- a/src/commands/repos/cmd-repos-delete.ts
+++ b/src/commands/repos/cmd-repos-delete.ts
@@ -1,8 +1,8 @@
-import meowOrExit from 'meow'
 import colors from 'yoctocolors-cjs'
 
 import { deleteRepo } from './delete-repo.ts'
 import { AuthError } from '../../utils/errors'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getDefaultToken } from '../../utils/sdk'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
@@ -12,12 +12,12 @@ const config: CliCommandConfig = {
   description: 'Delete a repository in an organization',
   hidden: false,
   flags: {},
-  help: (parentName, config) => `
+  help: (command, _config) => `
     Usage
-      $ ${parentName} ${config.commandName} <org slug> <repo slug>
+      $ ${command} <org slug> <repo slug>
 
     Examples
-      $ ${parentName} ${config.commandName} FakeOrg test-repo
+      $ ${command} FakeOrg test-repo
   `
 }
 
@@ -32,12 +32,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags,
-    allowUnknownFlags: false
+    parentName
   })
 
   const [orgSlug = '', repoName = ''] = cli.input

--- a/src/commands/repos/cmd-repos-list.ts
+++ b/src/commands/repos/cmd-repos-list.ts
@@ -1,9 +1,9 @@
-import meowOrExit from 'meow'
 import colors from 'yoctocolors-cjs'
 
 import { listRepos } from './list-repos.ts'
 import { commonFlags, outputFlags } from '../../flags'
 import { AuthError } from '../../utils/errors'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
 
@@ -40,15 +40,15 @@ const config: CliCommandConfig = {
     },
     ...outputFlags
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} <org slug>
+      $ ${command} <org slug>
 
     Options
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName} FakeOrg
+      $ ${command} FakeOrg
   `
 }
 
@@ -63,12 +63,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags,
-    allowUnknownFlags: false
+    parentName
   })
 
   const [orgSlug = ''] = cli.input

--- a/src/commands/repos/cmd-repos-update.ts
+++ b/src/commands/repos/cmd-repos-update.ts
@@ -1,9 +1,9 @@
-import meowOrExit from 'meow'
 import colors from 'yoctocolors-cjs'
 
 import { updateRepo } from './update-repo.ts'
 import { commonFlags, outputFlags } from '../../flags'
 import { AuthError } from '../../utils/errors'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
 
@@ -47,15 +47,15 @@ const config: CliCommandConfig = {
       description: 'Repository visibility (Default Private)'
     }
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} <org slug>
+      $ ${command} <org slug>
 
     Options
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName} FakeOrg
+      $ ${command} FakeOrg
   `
 }
 
@@ -70,12 +70,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags,
-    allowUnknownFlags: false
+    parentName
   })
 
   const repoName = cli.flags['repoName']

--- a/src/commands/repos/cmd-repos-view.ts
+++ b/src/commands/repos/cmd-repos-view.ts
@@ -1,9 +1,9 @@
-import meowOrExit from 'meow'
 import colors from 'yoctocolors-cjs'
 
 import { viewRepo } from './view-repo.ts'
 import { commonFlags, outputFlags } from '../../flags'
 import { AuthError } from '../../utils/errors'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
 
@@ -17,15 +17,15 @@ const config: CliCommandConfig = {
     ...commonFlags,
     ...outputFlags
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} <org slug>
+      $ ${command} <org slug>
 
     Options
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName} FakeOrg
+      $ ${command} FakeOrg
   `
 }
 
@@ -40,12 +40,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags,
-    allowUnknownFlags: false
+    parentName
   })
 
   const repoName = cli.flags['repoName']

--- a/src/commands/scan/cmd-scan-create.ts
+++ b/src/commands/scan/cmd-scan-create.ts
@@ -1,6 +1,5 @@
 import process from 'node:process'
 
-import meowOrExit from 'meow'
 import colors from 'yoctocolors-cjs'
 
 import { Spinner } from '@socketsecurity/registry/lib/spinner'
@@ -8,6 +7,7 @@ import { Spinner } from '@socketsecurity/registry/lib/spinner'
 import { createFullScan } from './create-full-scan.ts'
 import { handleUnsuccessfulApiResponse } from '../../utils/api'
 import { AuthError } from '../../utils/errors'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getPackageFilesFullScans } from '../../utils/path-resolve'
 import { getDefaultToken, setupSdk } from '../../utils/sdk'
@@ -78,9 +78,9 @@ const config: CliCommandConfig = {
         'Set the visibility (true/false) of the scan in your dashboard'
     }
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} [...options] <org> <TARGET> [TARGET...]
+      $ ${command} [...options] <org> <TARGET> [TARGET...]
 
     Where TARGET is a FILE or DIR that _must_ be inside the CWD.
 
@@ -91,7 +91,7 @@ const config: CliCommandConfig = {
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName} --repo=test-repo --branch=main FakeOrg ./package.json
+      $ ${command} --repo=test-repo --branch=main FakeOrg ./package.json
   `
 }
 
@@ -106,11 +106,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags
+    parentName
   })
 
   const [orgSlug = '', ...targets] = cli.input

--- a/src/commands/scan/cmd-scan-delete.ts
+++ b/src/commands/scan/cmd-scan-delete.ts
@@ -17,15 +17,15 @@ const config: CliCommandConfig = {
     ...commonFlags,
     ...outputFlags
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} <org slug> <scan ID>
+      $ ${command} <org slug> <scan ID>
 
     Options
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName} FakeOrg 000aaaa1-0000-0a0a-00a0-00a0000000a0
+      $ ${command} FakeOrg 000aaaa1-0000-0a0a-00a0-00a0000000a0
   `
 }
 

--- a/src/commands/scan/cmd-scan-list.ts
+++ b/src/commands/scan/cmd-scan-list.ts
@@ -57,15 +57,15 @@ const config: CliCommandConfig = {
       description: 'Until time - as a unix timestamp'
     }
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} <org slug>
+      $ ${command} <org slug>
 
     Options
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName} FakeOrg
+      $ ${command} FakeOrg
   `
 }
 

--- a/src/commands/scan/cmd-scan-metadata.ts
+++ b/src/commands/scan/cmd-scan-metadata.ts
@@ -20,15 +20,15 @@ const config: CliCommandConfig = {
     ...commonFlags,
     ...outputFlags
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} <org slug> <scan id>
+      $ ${command} <org slug> <scan id>
 
     Options
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName} FakeOrg 000aaaa1-0000-0a0a-00a0-00a0000000a0
+      $ ${command} FakeOrg 000aaaa1-0000-0a0a-00a0-00a0000000a0
   `
 }
 

--- a/src/commands/scan/cmd-scan-stream.ts
+++ b/src/commands/scan/cmd-scan-stream.ts
@@ -20,9 +20,9 @@ const config: CliCommandConfig = {
     ...commonFlags,
     ...outputFlags
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} <org slug> <scan ID> [path to output file]
+      $ ${command} <org slug> <scan ID> [path to output file]
 
     When no output path is given the contents is sent to stdout.
 
@@ -30,7 +30,7 @@ const config: CliCommandConfig = {
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName} FakeOrg 000aaaa1-0000-0a0a-00a0-00a0000000a0 ./stream.txt
+      $ ${command} FakeOrg 000aaaa1-0000-0a0a-00a0-00a0000000a0 ./stream.txt
   `
 }
 

--- a/src/commands/threat-feed/cmd-threat-feed.ts
+++ b/src/commands/threat-feed/cmd-threat-feed.ts
@@ -1,8 +1,7 @@
-import meowOrExit from 'meow'
-
 import { getThreatFeed } from './get-threat-feed.ts'
 import { commonFlags, outputFlags } from '../../flags'
 import { AuthError } from '../../utils/errors'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
 
@@ -40,16 +39,16 @@ const config: CliCommandConfig = {
       description: 'Filter what type of threats to return'
     }
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName}
+      $ ${command}
 
     Options
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName}
-      $ ${parentName} ${config.commandName} --perPage=5 --page=2 --direction=asc --filter=joke
+      $ ${command}
+      $ ${command} --perPage=5 --page=2 --direction=asc --filter=joke
   `
 }
 
@@ -64,11 +63,11 @@ async function run(
   importMeta: ImportMeta,
   { parentName }: { parentName: string }
 ): Promise<void> {
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags
+    parentName
   })
 
   const apiToken = getDefaultToken()

--- a/src/commands/wrapper/cmd-wrapper.ts
+++ b/src/commands/wrapper/cmd-wrapper.ts
@@ -1,12 +1,11 @@
 import fs from 'node:fs'
 import os from 'node:os'
 
-import meowOrExit from 'meow'
-
 import { addSocketWrapper } from './add-socket-wrapper.ts'
 import { checkSocketWrapperSetup } from './check-socket-wrapper-setup.ts'
 import { postinstallWrapper } from './postinstall-wrapper.ts'
 import { removeSocketWrapper } from './remove-socket-wrapper.ts'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
@@ -31,16 +30,16 @@ const config: CliCommandConfig = {
       description: 'Disables the Socket npm/npx wrapper'
     }
   },
-  help: (parentName, config) => `
+  help: (command, config) => `
     Usage
-      $ ${parentName} ${config.commandName} <flag>
+      $ ${command} <flag>
 
     Options
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${parentName} ${config.commandName} --enable
-      $ ${parentName} ${config.commandName} --disable
+      $ ${command} --enable
+      $ ${command} --disable
   `
 }
 
@@ -61,11 +60,11 @@ async function run(
     return
   }
 
-  const cli = meowOrExit(config.help(parentName, config), {
+  const cli = meowOrExit({
     argv,
-    description: config.description,
+    config,
     importMeta,
-    flags: config.flags
+    parentName
   })
 
   const { disable, enable } = cli.flags

--- a/src/utils/meow-with-subcommands.ts
+++ b/src/utils/meow-with-subcommands.ts
@@ -140,17 +140,21 @@ export function meowOrExit({
   allowUnknownFlags?: boolean
 }) {
   const command = `${parentName} ${config.commandName}`
+
+  // Be able to bucket by command
+  Sentry.setTag('command', command)
+
+  const help = config.help(command, config)
+
   // This exits if .printHelp() is called either by meow itself or by us.
-  const cli = meow(config.help(command, config), {
+  const cli = meow({
     argv,
     description: config.description,
+    help,
     importMeta,
     flags: config.flags,
     allowUnknownFlags: Boolean(allowUnknownFlags)
   })
-
-  // Be able to bucket by command
-  Sentry.setTag('command', command)
 
   return cli
 }

--- a/src/utils/meow-with-subcommands.ts
+++ b/src/utils/meow-with-subcommands.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/node'
 import meow from 'meow'
 
 import { toSortedObject } from '@socketsecurity/registry/lib/objects'
@@ -140,9 +139,6 @@ export function meowOrExit({
   allowUnknownFlags?: boolean
 }) {
   const command = `${parentName} ${config.commandName}`
-
-  // Be able to bucket by command
-  Sentry.setTag('command', command)
 
   const help = config.help(command, config)
 


### PR DESCRIPTION
(This depends on https://github.com/SocketDev/socket-cli/pull/333 because Sentry)

Abstract the `meowOrExit` function. This allows us to have a central place to hook into the meows. Case in point: add a tag to Sentry for which command was called to help debugging.

Next PR will add another reasons :d

This PR also cleans up and simplifies the API around calling meow and help etc.