### PR TITLE
Add suggestion flows to `socket scan create`

### DIFF
--- a/src/commands/scan/suggest-org-slug.ts
+++ b/src/commands/scan/suggest-org-slug.ts
@@ -1,0 +1,38 @@
+import { select } from '@socketsecurity/registry/lib/prompts'
+import { SocketSdk } from '@socketsecurity/sdk'
+
+import { handleApiCall } from '../../utils/api.ts'
+
+export async function suggestOrgSlug(
+  socketSdk: SocketSdk
+): Promise<string | void> {
+  const result = await handleApiCall(
+    socketSdk.getOrganizations(),
+    'looking up organizations'
+  )
+  // Ignore a failed request here. It was not the primary goal of
+  // running this command and reporting it only leads to end-user confusion.
+  if (result.success) {
+    const proceed = await select<string>({
+      message:
+        'Missing org name; do you want to use any of these orgs for this scan?',
+      choices: Array.from(Object.values(result.data.organizations))
+        .map(({ name: slug }) => ({
+          name: 'Yes [' + slug + ']',
+          value: slug,
+          description: `Use "${slug}" as the organization`
+        }))
+        .concat({
+          name: 'No',
+          value: '',
+          description:
+            'Do not use any of these organizations (will end in a no-op)'
+        })
+    })
+    if (proceed) {
+      return proceed
+    }
+  } else {
+    // TODO: in verbose mode, report this error to stderr
+  }
+}

--- a/src/commands/scan/suggest-repo-slug.ts
+++ b/src/commands/scan/suggest-repo-slug.ts
@@ -1,0 +1,109 @@
+import path from 'node:path'
+import process from 'node:process'
+
+import { select } from '@socketsecurity/registry/lib/prompts'
+import { SocketSdk } from '@socketsecurity/sdk'
+
+import { handleApiCall } from '../../utils/api.ts'
+
+export async function suggestRepoSlug(
+  socketSdk: SocketSdk,
+  orgSlug: string
+): Promise<{
+  slug: string
+  defaultBranch: string
+} | void> {
+  // Same as above, but if there's a repo with the same name as cwd then
+  // default the selection to that name.
+  const result = await handleApiCall(
+    socketSdk.getOrgRepoList(orgSlug, {
+      orgSlug,
+      sort: 'name',
+      direction: 'asc',
+      // There's no guarantee that the cwd is part of this page. If it's not
+      // then do an additional request and specific search for it instead.
+      // This way we can offer the tip of "do you want to create [cwd]?".
+      perPage: 10,
+      page: 0
+    }),
+    'looking up known repos'
+  )
+  // Ignore a failed request here. It was not the primary goal of
+  // running this command and reporting it only leads to end-user confusion.
+  if (result.success) {
+    const currentDirName = dirNameToSlug(path.basename(process.cwd()))
+
+    let cwdIsKnown =
+      !!currentDirName &&
+      result.data.results.some(obj => obj.slug === currentDirName)
+    if (!cwdIsKnown && currentDirName) {
+      // Do an explicit request so we can assert that the cwd exists or not
+      const result = await handleApiCall(
+        socketSdk.getOrgRepo(orgSlug, currentDirName),
+        'checking if current cwd is a known repo'
+      )
+      if (result.success) {
+        cwdIsKnown = true
+      }
+    }
+
+    const proceed = await select<string>({
+      message:
+        'Missing repo name; do you want to use any of these known repo names for this scan?',
+      choices:
+        // Put the CWD suggestion at the top, whether it exists or not
+        (currentDirName
+          ? [
+              {
+                name: `Yes, current dir [${cwdIsKnown ? currentDirName : `create repo for ${currentDirName}`}]`,
+                value: currentDirName,
+                description: cwdIsKnown
+                  ? 'Register a new repo name under the given org and use it'
+                  : 'Use current dir as repo'
+              }
+            ]
+          : []
+        ).concat(
+          result.data.results
+            .filter(({ slug }) => !!slug && slug !== currentDirName)
+            .map(({ slug }) => ({
+              name: 'Yes [' + slug + ']',
+              value: slug || '', // Filtered above but TS is like nah.
+              description: `Use "${slug}" as the repo name`
+            })),
+          {
+            name: 'No',
+            value: '',
+            description: 'Do not use any of these repos (will end in a no-op)'
+          }
+        )
+    })
+
+    if (proceed) {
+      const repoName = proceed
+      let repoDefaultBranch = ''
+      // Store the default branch to help with the branch name question next
+      result.data.results.some(obj => {
+        if (obj.slug === proceed && obj.default_branch) {
+          repoDefaultBranch = obj.default_branch
+          return
+        }
+      })
+      return { slug: repoName, defaultBranch: repoDefaultBranch }
+    }
+  } else {
+    // TODO: in verbose mode, report this error to stderr
+  }
+}
+
+function dirNameToSlug(name: string): string {
+  // Uses slug specs asserted by our servers
+  // Note: this can lead to collisions; eg. slug for `x--y` and `x---y` is `x-y`
+  return name
+    .toLowerCase()
+    .replace(/[^[a-zA-Z0-9_.-]/g, '_')
+    .replace(/--+/g, '-')
+    .replace(/__+/g, '_')
+    .replace(/\.\.+/g, '.')
+    .replace(/[._-]+$/, '')
+}

--- a/src/commands/scan/suggest_branch_slug.ts
+++ b/src/commands/scan/suggest_branch_slug.ts
@@ -1,0 +1,41 @@
+import { spawnSync } from 'node:child_process'
+
+import { select } from '@socketsecurity/registry/lib/prompts'
+
+export async function suggestBranchSlug(
+  repoDefaultBranch: string | undefined
+): Promise<string | void> {
+  const spawnResult = spawnSync('git', ['branch', '--show-current'])
+  const currentBranch = spawnResult.stdout.toString('utf8').trim()
+  if (spawnResult.status === 0 && currentBranch) {
+    const proceed = await select<string>({
+      message: 'Use the current git branch as target branch name?',
+      choices: [
+        {
+          name: `Yes [${currentBranch}]`,
+          value: currentBranch,
+          description: 'Use the current git branch for branch name'
+        },
+        ...(repoDefaultBranch && repoDefaultBranch !== currentBranch
+          ? [
+              {
+                name: `No, use the default branch [${repoDefaultBranch}]`,
+                value: repoDefaultBranch,
+                description:
+                  'Use the default branch for target repo as the target branch name'
+              }
+            ]
+          : []),
+        {
+          name: 'No',
+          value: '',
+          description:
+            'Do not use the current git branch as name (will end in a no-op)'
+        }
+      ].filter(Boolean)
+    })
+    if (proceed) {
+      return proceed
+    }
+  }
+}

--- a/src/commands/scan/suggest_target.ts
+++ b/src/commands/scan/suggest_target.ts
@@ -1,0 +1,25 @@
+import { select } from '@socketsecurity/registry/lib/prompts'
+
+export async function suggestTarget(): Promise<Array<string> | void> {
+  // We could prefill this with sub-dirs of the current
+  // dir ... but is that going to be useful?
+  const proceed = await select<boolean>({
+    message: 'No TARGET given. Do you want to use the current directory?',
+    choices: [
+      {
+        name: 'Yes',
+        value: true,
+        description: 'Target the current directory'
+      },
+      {
+        name: 'No',
+        value: false,
+        description:
+          'Do not use the current directory (this will end in a no-op)'
+      }
+    ]
+  })
+  if (proceed) {
+    return ['.']
+  }
+}

--- a/test/dry-run.test.ts
+++ b/test/dry-run.test.ts
@@ -789,13 +789,23 @@ describe('dry-run on all commands', async () => {
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
         |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan create\`, cwd: <redacted>
-
-      [DryRun] Bailing now"
+        |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan create\`, cwd: <redacted>"
     `)
-    expect(stderr).toMatchInlineSnapshot(`""`)
+    expect(stderr).toMatchInlineSnapshot(`
+      "\\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
 
-    expect(code, 'dry-run should exit with code 0 if input is ok').toBe(0)
+            - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m
+
+            - Repository name using --repo \\x1b[31m(missing!)\\x1b[39m
+
+            - Branch name using --branch \\x1b[31m(missing!)\\x1b[39m
+
+            - At least one TARGET (e.g. \`.\` or \`./package.json\`) (missing)
+
+            (Additionally, no API Token was set so we cannot auto-discover these details)"
+    `)
+
+    expect(code).toBe(2)
     expect(stdout, 'header should include command (without params)').toContain(
       cmd.slice(0, cmd.indexOf('--dry-run')).join(' ')
     )


### PR DESCRIPTION
This PR updates the `socket scan create` command in a few ways

- Most importantly it adds a suggestion flow
  - When certain flags or args are missing it will use the Socket API to try and make reasonable suggestions
  - When the target is missing it will ask to confirm the target to be the current working directory
  - It will still fail "early" if any of these values are missing after the suggestion flow
- Adds a `--read-only` flag, which is similar to the `--dry-run` flag except it will make REST API calls that only read (eg. no permanent changes)
- Alphabetically orders the function args/params
- Pushes up the error bailout if no api token is present, allowing to better separate the command file logic from the rest
- Fixes `spinner.success` to call `spinner.successAndStop` instead

Here's an example with just running `socket scan create` on the cli folder itself:

![image](https://github.com/user-attachments/assets/fc66fbe2-58fa-45e1-97fe-6e4eaff701ea)

![image](https://github.com/user-attachments/assets/c7ba92a5-c825-4b63-92ac-eb485b50bcb8)

![image](https://github.com/user-attachments/assets/4934df94-52fa-47ff-ab2a-f69da3a5a97d)

![image](https://github.com/user-attachments/assets/c7043ddc-4ea5-46be-9669-ae7d289307d3)

![image](https://github.com/user-attachments/assets/a0c372eb-877c-4d14-b73d-2435cd4134e5)