### PR TITLE
Make spinner stop after emiting handled api error

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -28,7 +28,7 @@ export function handleUnsuccessfulApiResponse<T extends SocketSdkOperations>(
     spinner.stop()
     throw new AuthError(message)
   }
-  spinner.error(
+  spinner.errorAndStop(
     `${colors.bgRed(colors.white('API returned an error:'))} ${message}`
   )
   process.exit(1)


### PR DESCRIPTION
Calling `.error()` on the spinner does not stop the spinner, which leads to slightly unexpected terminal results in some cases. We should make sure it stops in this case.