### PR TITLE
Cleanup analytics command, support markdown

### DIFF
--- a/src/commands/analytics/cmd-analytics.ts
+++ b/src/commands/analytics/cmd-analytics.ts
@@ -2,13 +2,11 @@ import colors from 'yoctocolors-cjs'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 
-import { displayAnalytics } from './display-analytics'
+import { displayAnalytics } from './display-analytics.ts'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
-import { AuthError } from '../../utils/errors'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
-import { getDefaultToken } from '../../utils/sdk'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -21,6 +19,19 @@ const config: CliCommandConfig = {
   flags: {
     ...commonFlags,
     ...outputFlags,
+    file: {
+      type: 'string',
+      shortFlag: 'f',
+      default: '-',
+      description:
+        'Path to a local file to save the output. Only valid with --json/--markdown. Defaults to stdout.'
+    },
+    repo: {
+      type: 'string',
+      shortFlag: 'r',
+      default: '',
+      description: 'Name of the repository. Only valid when scope=repo'
+    },
     scope: {
       type: 'string',
       shortFlag: 's',
@@ -33,18 +44,6 @@ const config: CliCommandConfig = {
       shortFlag: 't',
       default: 7,
       description: 'Time filter - either 7, 30 or 90, default: 7'
-    },
-    repo: {
-      type: 'string',
-      shortFlag: 'r',
-      default: '',
-      description: 'Name of the repository'
-    },
-    file: {
-      type: 'string',
-      shortFlag: 'f',
-      default: '',
-      description: 'Path to a local file to save the output'
     }
   },
   help: (command, { flags }) => `
@@ -82,21 +81,32 @@ async function run(
     parentName
   })
 
-  const { repo, scope, time } = cli.flags
+  const { file, json, markdown, repo, scope, time } = cli.flags
 
   const badScope = scope !== 'org' && scope !== 'repo'
   const badTime = time !== 7 && time !== 30 && time !== 90
   const badRepo = scope === 'repo' && !repo
+  const badFile = file !== '-' && !json && !markdown
+  const badFlags = json && markdown
 
-  if (badScope || badTime || badRepo) {
+  if (badScope || badTime || badRepo || badFile || badFlags) {
     // Use exit status of 2 to indicate incorrect usage, generally invalid
     // options or missing arguments.
     // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
     process.exitCode = 2
-    logger.error(`${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:\n
+    logger.error(
+      `${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:\n
       - Scope must be "repo" or "org" ${badScope ? colors.red('(bad!)') : colors.green('(ok)')}\n
       - The time filter must either be 7, 30 or 90 ${badTime ? colors.red('(bad!)') : colors.green('(ok)')}\n
-      - Repository name using --repo when scope is "repo" ${badRepo ? colors.red('(bad!)') : colors.green('(ok)')}\n`)
+      ${scope === 'repo' ? `- Repository name using --repo when scope is "repo" ${badRepo ? colors.red('(bad!)') : colors.green('(ok)')}` : ''}\n
+      ${badFlags ? `- The \`--json\` and \`--markdown\` flags can not be used at the same time ${badFlags ? colors.red('(bad!)') : colors.green('(ok)')}` : ''}\n
+      ${badFile ? `- The \`--file\` flag is only valid when using \`--json\` or \`--markdown\` ${badFile ? colors.red('(bad!)') : colors.green('(ok)')}` : ''}\n
+    `
+        .trim()
+        .split('\n')
+        .filter(s => !!s.trim())
+        .join('\n') + '\n'
+    )
     return
   }
 
@@ -105,19 +115,11 @@ async function run(
     return
   }
 
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API token.'
-    )
-  }
-
   return await displayAnalytics({
-    apiToken,
     scope,
     time,
     repo: String(repo || ''),
-    outputJson: Boolean(cli.flags['json']),
-    filePath: String(cli.flags['file'] || '')
+    outputKind: json ? 'json' : markdown ? 'markdown' : 'print',
+    filePath: String(file || '')
   })
 }

--- a/src/commands/analytics/cmd-analytics.ts
+++ b/src/commands/analytics/cmd-analytics.ts
@@ -2,7 +2,7 @@ import colors from 'yoctocolors-cjs'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 
-import { displayAnalytics } from './display-analytics.ts'
+import { displayAnalytics } from './display-analytics'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { meowOrExit } from '../../utils/meow-with-subcommands'

--- a/src/commands/analytics/display-analytics.ts
+++ b/src/commands/analytics/display-analytics.ts
@@ -148,7 +148,7 @@ async function outputAnalyticsWithToken({
     if (outputKind === 'markdown') {
       const serialized = renderMarkdown(fdata, time, repo)
 
-      if (filePath) {
+      if (filePath && filePath !== '-') {
         try {
           await fs.writeFile(filePath, serialized, 'utf8')
           logger.log(`Data successfully written to ${filePath}`)
@@ -191,32 +191,35 @@ These are the Socket.dev stats are analytics for the ${repoSlug ? `${repoSlug} r
     [
       [
         'Total critical alerts',
-        mdTableStringNumber(data['total_critical_alerts'])
+        mdTableStringNumber('Date', 'Counts', data['total_critical_alerts'])
       ],
-      ['Total high alerts', mdTableStringNumber(data['total_high_alerts'])],
+      [
+        'Total high alerts',
+        mdTableStringNumber('Date', 'Counts', data['total_high_alerts'])
+      ],
       [
         'Total critical alerts added to the main branch',
-        mdTableStringNumber(data['total_critical_added'])
+        mdTableStringNumber('Date', 'Counts', data['total_critical_added'])
       ],
       [
         'Total high alerts added to the main branch',
-        mdTableStringNumber(data['total_high_added'])
+        mdTableStringNumber('Date', 'Counts', data['total_high_added'])
       ],
       [
         'Total critical alerts prevented from the main branch',
-        mdTableStringNumber(data['total_critical_prevented'])
+        mdTableStringNumber('Date', 'Counts', data['total_critical_prevented'])
       ],
       [
         'Total high alerts prevented from the main branch',
-        mdTableStringNumber(data['total_high_prevented'])
+        mdTableStringNumber('Date', 'Counts', data['total_high_prevented'])
       ],
       [
         'Total medium alerts prevented from the main branch',
-        mdTableStringNumber(data['total_medium_prevented'])
+        mdTableStringNumber('Date', 'Counts', data['total_medium_prevented'])
       ],
       [
         'Total low alerts prevented from the main branch',
-        mdTableStringNumber(data['total_low_prevented'])
+        mdTableStringNumber('Date', 'Counts', data['total_low_prevented'])
       ]
     ]
       .map(([title, table]) => {
@@ -228,7 +231,7 @@ ${table}
       })
       .join('\n\n') +
     '\n\n## Top 5 alert types\n\n' +
-    mdTableStringNumber(data['top_five_alert_types']) +
+    mdTableStringNumber('Name', 'Counts', data['top_five_alert_types']) +
     '\n'
   )
 }

--- a/src/commands/analytics/display-analytics.ts
+++ b/src/commands/analytics/display-analytics.ts
@@ -6,15 +6,15 @@ import contrib from 'blessed-contrib'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 
-import { fetchOrgAnalyticsData } from './fetch-org-analytics.ts'
-import { fetchRepoAnalyticsData } from './fetch-repo-analytics.ts' // Note: Widgets does not seem to actually work as code :'(
+import { fetchOrgAnalyticsData } from './fetch-org-analytics'
+import { fetchRepoAnalyticsData } from './fetch-repo-analytics'
 import constants from '../../constants'
-import { AuthError } from '../../utils/errors.ts'
-import { mdTableStringNumber } from '../../utils/markdown.ts'
+import { AuthError } from '../../utils/errors'
+import { mdTableStringNumber } from '../../utils/markdown'
 import { getDefaultToken } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
-import type { Widgets } from 'blessed'
+import type { Widgets } from 'blessed' // Note: Widgets does not seem to actually work as code :'(
 
 interface FormattedData {
   top_five_alert_types: Record<string, number>

--- a/src/commands/analytics/fetch-org-analytics.ts
+++ b/src/commands/analytics/fetch-org-analytics.ts
@@ -1,0 +1,36 @@
+import { logger } from '@socketsecurity/registry/lib/logger'
+
+import {
+  handleApiCall,
+  handleUnsuccessfulApiResponse
+} from '../../utils/api.ts'
+import { setupSdk } from '../../utils/sdk.ts'
+
+import type { Spinner } from '@socketsecurity/registry/lib/spinner'
+import type { SocketSdkReturnType } from '@socketsecurity/sdk'
+
+export async function fetchOrgAnalyticsData(
+  time: number,
+  spinner: Spinner,
+  apiToken: string
+): Promise<SocketSdkReturnType<'getOrgAnalytics'>['data'] | undefined> {
+  const socketSdk = await setupSdk(apiToken)
+  const result = await handleApiCall(
+    socketSdk.getOrgAnalytics(time.toString()),
+    'fetching analytics data'
+  )
+
+  if (result.success === false) {
+    handleUnsuccessfulApiResponse('getOrgAnalytics', result, spinner)
+    return undefined
+  }
+
+  spinner.stop()
+
+  if (!result.data.length) {
+    logger.log('No analytics data is available for this organization yet.')
+    return undefined
+  }
+
+  return result.data
+}

--- a/src/commands/analytics/fetch-org-analytics.ts
+++ b/src/commands/analytics/fetch-org-analytics.ts
@@ -1,10 +1,7 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 
-import {
-  handleApiCall,
-  handleUnsuccessfulApiResponse
-} from '../../utils/api.ts'
-import { setupSdk } from '../../utils/sdk.ts'
+import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
+import { setupSdk } from '../../utils/sdk'
 
 import type { Spinner } from '@socketsecurity/registry/lib/spinner'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'

--- a/src/commands/analytics/fetch-repo-analytics.ts
+++ b/src/commands/analytics/fetch-repo-analytics.ts
@@ -1,0 +1,37 @@
+import { logger } from '@socketsecurity/registry/lib/logger'
+
+import {
+  handleApiCall,
+  handleUnsuccessfulApiResponse
+} from '../../utils/api.ts'
+import { setupSdk } from '../../utils/sdk.ts'
+
+import type { Spinner } from '@socketsecurity/registry/lib/spinner'
+import type { SocketSdkReturnType } from '@socketsecurity/sdk'
+
+export async function fetchRepoAnalyticsData(
+  repo: string,
+  time: number,
+  spinner: Spinner,
+  apiToken: string
+): Promise<SocketSdkReturnType<'getRepoAnalytics'>['data'] | undefined> {
+  const socketSdk = await setupSdk(apiToken)
+  const result = await handleApiCall(
+    socketSdk.getRepoAnalytics(repo, time.toString()),
+    'fetching analytics data'
+  )
+
+  if (result.success === false) {
+    handleUnsuccessfulApiResponse('getRepoAnalytics', result, spinner)
+    return undefined
+  }
+
+  spinner.stop()
+
+  if (!result.data.length) {
+    logger.log('No analytics data is available for this organization yet.')
+    return undefined
+  }
+
+  return result.data
+}

--- a/src/commands/analytics/fetch-repo-analytics.ts
+++ b/src/commands/analytics/fetch-repo-analytics.ts
@@ -1,10 +1,7 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 
-import {
-  handleApiCall,
-  handleUnsuccessfulApiResponse
-} from '../../utils/api.ts'
-import { setupSdk } from '../../utils/sdk.ts'
+import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
+import { setupSdk } from '../../utils/sdk'
 
 import type { Spinner } from '@socketsecurity/registry/lib/spinner'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,19 +1,21 @@
 export function mdTableStringNumber(
+  title1: string,
+  title2: string,
   obj: Record<string, number | string>
 ): string {
   // | Date        | Counts |
   // | ----------- | ------ |
   // | Header      | 201464 |
   // | Paragraph   |     18 |
-  let mw1 = 4
-  let mw2 = 6
+  let mw1 = title1.length
+  let mw2 = title2.length
   for (const [key, value] of Object.entries(obj)) {
     mw1 = Math.max(mw1, key.length)
     mw2 = Math.max(mw2, String(value ?? '').length)
   }
 
   const lines = []
-  lines.push(`| Date${' '.repeat(mw1 - 4)} | Count${' '.repeat(mw2 - 6)} |`)
+  lines.push(`| ${title1.padEnd(mw1, ' ')} | ${title2.padEnd(mw2)} |`)
   lines.push(`| ${'-'.repeat(mw1)} | ${'-'.repeat(mw2)} |`)
   for (const [key, value] of Object.entries(obj)) {
     lines.push(

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,26 @@
+export function mdTableStringNumber(
+  obj: Record<string, number | string>
+): string {
+  // | Date        | Counts |
+  // | ----------- | ------ |
+  // | Header      | 201464 |
+  // | Paragraph   |     18 |
+  let mw1 = 4
+  let mw2 = 6
+  for (const [key, value] of Object.entries(obj)) {
+    mw1 = Math.max(mw1, key.length)
+    mw2 = Math.max(mw2, String(value ?? '').length)
+  }
+
+  const lines = []
+  lines.push(`| Date${' '.repeat(mw1 - 4)} | Count${' '.repeat(mw2 - 6)} |`)
+  lines.push(`| ${'-'.repeat(mw1)} | ${'-'.repeat(mw2)} |`)
+  for (const [key, value] of Object.entries(obj)) {
+    lines.push(
+      `| ${key.padEnd(mw1, ' ')} | ${String(value ?? '').padStart(mw2, ' ')} |`
+    )
+  }
+  lines.push(`| ${'-'.repeat(mw1)} | ${'-'.repeat(mw2)} |`)
+
+  return lines.join('\n')
+}


### PR DESCRIPTION
This is about the `socket analytics` command:

- Supports the `--markdown` flag, which was previously advertised but completely ignored
  - Including the `--file` flag for it, just like `--json`
- JSON to file will be formatted
- JSON to stdout will be same as the one written to file
  - No more relying on `console.log` to do the formatting, or to hit depth limits
- JSON serialization separately trapped
  - A bit redundant but it's possible for .stringify to hit cicular refs and fail hard
- Fixed up the typing such that the SDK types are properly reflected
- Added some input error conditions which are hidden by default