### PR TITLE
Implement --json and --markdown for audit-log

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
     "test": "run-s check test:*",
     "test:prepare": "cross-env VITEST=1 npm run build",
     "test:unit": "vitest --run",
-    "test:unit:update": "vitest --update",
+    "test:unit:update": "vitest --run --update",
     "test:unit:coverage": "vitest run --coverage",
     "test-ci": "run-s test:*",
-    "testu": "cross-env SOCKET_CLI_NO_API_TOKEN=1 run-s test:prepare test:unit:update",
+    "testu": "cross-env SOCKET_CLI_NO_API_TOKEN=1 run-s test:prepare; npm run test:unit:update --",
     "update": "run-p --aggregate-output update:**",
     "update:deps": "npx --yes npm-check-updates"
   },

--- a/src/commands/audit-log/get-audit-log.ts
+++ b/src/commands/audit-log/get-audit-log.ts
@@ -1,9 +1,11 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 import { Separator, select } from '@socketsecurity/registry/lib/prompts'
+import { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { setupSdk } from '../../utils/sdk'
+import { AuthError } from '../../utils/errors'
+import { getDefaultToken, setupSdk } from '../../utils/sdk'
 
 import type { Choice } from '@socketsecurity/registry/lib/prompts'
 
@@ -12,22 +14,221 @@ type AuditChoice = Choice<string>
 type AuditChoices = (Separator | AuditChoice)[]
 
 export async function getAuditLog({
-  apiToken,
+  logType,
   orgSlug,
-  outputJson,
-  outputMarkdown,
+  outputKind,
   page,
-  perPage,
-  type
+  perPage
 }: {
-  apiToken: string
-  outputJson: boolean
-  outputMarkdown: boolean
+  outputKind: 'json' | 'markdown' | 'print'
   orgSlug: string
   page: number
   perPage: number
-  type: string
+  logType: string
 }): Promise<void> {
+  const apiToken = getDefaultToken()
+  if (!apiToken) {
+    throw new AuthError(
+      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
+    )
+  }
+
+  const auditLogs = await getAuditLogWithToken({
+    apiToken,
+    orgSlug,
+    outputKind,
+    page,
+    perPage,
+    logType
+  })
+  if (!auditLogs) return
+
+  if (outputKind === 'json')
+    await outputAsJson(auditLogs.results, orgSlug, logType, page, perPage)
+  else if (outputKind === 'markdown')
+    await outputAsMarkdown(auditLogs.results, orgSlug, logType, page, perPage)
+  else await outputAsPrint(auditLogs.results, orgSlug, logType)
+}
+
+async function outputAsJson(
+  auditLogs: SocketSdkReturnType<'getAuditLogEvents'>['data']['results'],
+  orgSlug: string,
+  logType: string,
+  page: number,
+  perPage: number
+): Promise<void> {
+  let json
+  try {
+    json = JSON.stringify(
+      {
+        desc: 'Audit logs for given query',
+        generated: new Date().toISOString(),
+        org: orgSlug,
+        logType,
+        page,
+        perPage,
+        logs: auditLogs.map(log => {
+          // Note: The subset is pretty arbitrary
+          const {
+            created_at,
+            event_id,
+            ip_address,
+            type,
+            user_agent,
+            user_email
+          } = log
+          return {
+            event_id,
+            created_at,
+            ip_address,
+            type,
+            user_agent,
+            user_email
+          }
+        })
+      },
+      null,
+      2
+    )
+  } catch (e) {
+    logger.error(
+      'There was a problem converting the logs to JSON, please try without the `--json` flag'
+    )
+    process.exitCode = 1
+    return
+  }
+
+  logger.log(json)
+}
+
+async function outputAsMarkdown(
+  auditLogs: SocketSdkReturnType<'getAuditLogEvents'>['data']['results'],
+  orgSlug: string,
+  logType: string,
+  page: number,
+  perPage: number
+): Promise<void> {
+  let md
+  try {
+    const table = mdTable(auditLogs, [
+      'event_id',
+      'created_at',
+      'type',
+      'user_email',
+      'ip_address',
+      'user_agent'
+    ])
+
+    md =
+      `
+# Socket Audit Logs
+
+These are the Socket.dev audit logs as per requested query.
+- org: ${orgSlug}
+- type filter: ${logType || '(none)'}
+- page: ${page}
+- per page: ${perPage}
+- generated: ${new Date().toISOString()}
+
+${table}
+      `.trim() + '\n'
+  } catch (e) {
+    logger.error(
+      'There was a problem converting the logs to JSON, please try without the `--json` flag'
+    )
+    logger.error(e)
+    process.exitCode = 1
+    return
+  }
+
+  logger.log(md)
+}
+
+function mdTable<
+  T extends SocketSdkReturnType<'getAuditLogEvents'>['data']['results']
+>(
+  logs: T,
+  // This is saying "an array of strings and the strings are a valid key of elements of T"
+  // In turn, T is defined above as the audit log event type from our OpenAPI docs.
+  cols: Array<string & keyof T[number]>
+): string {
+  // Max col width required to fit all data in that column
+  const cws = cols.map(col => col.length)
+
+  for (const log of logs) {
+    for (let i = 0; i < cols.length; ++i) {
+      // @ts-ignore
+      const val: unknown = log[cols[i] ?? ''] ?? ''
+      cws[i] = Math.max(cws[i] ?? 0, String(val).length)
+    }
+  }
+
+  let div = '|'
+  for (const cw of cws) div += ' ' + '-'.repeat(cw) + ' |'
+
+  let header = '|'
+  for (let i = 0; i < cols.length; ++i)
+    header += ' ' + String(cols[i]).padEnd(cws[i] ?? 0, ' ') + ' |'
+
+  let body = ''
+  for (const log of logs) {
+    body += '|'
+    for (let i = 0; i < cols.length; ++i) {
+      // @ts-ignore
+      const val: unknown = log[cols[i] ?? ''] ?? ''
+      body += ' ' + String(val).padEnd(cws[i] ?? 0, ' ') + ' |'
+    }
+    body += '\n'
+  }
+
+  return [div, header, div, body.trim(), div].filter(s => !!s.trim()).join('\n')
+}
+
+async function outputAsPrint(
+  auditLogs: SocketSdkReturnType<'getAuditLogEvents'>['data']['results'],
+  orgSlug: string,
+  logType: string
+): Promise<void> {
+  const data: AuditChoices = []
+  const logDetails: { [key: string]: string } = {}
+
+  for (const d of auditLogs) {
+    const { created_at } = d
+    if (created_at) {
+      const name = `${new Date(created_at).toLocaleDateString('en-us', { year: 'numeric', month: 'numeric', day: 'numeric' })} - ${d.user_email} - ${d.type} - ${d.ip_address} - ${d.user_agent}`
+      data.push(<AuditChoice>{ name }, new Separator())
+      logDetails[name] = JSON.stringify(d.payload)
+    }
+  }
+
+  logger.log(
+    logDetails[
+      (await select({
+        message: logType
+          ? `\n Audit log for: ${orgSlug} with type: ${logType}\n`
+          : `\n Audit log for: ${orgSlug}\n`,
+        choices: data,
+        pageSize: 30
+      })) as any
+    ]
+  )
+}
+
+async function getAuditLogWithToken({
+  apiToken,
+  logType,
+  orgSlug,
+  outputKind,
+  page,
+  perPage
+}: {
+  apiToken: string
+  outputKind: 'json' | 'markdown' | 'print'
+  orgSlug: string
+  page: number
+  perPage: number
+  logType: string
+}): Promise<SocketSdkReturnType<'getAuditLogEvents'>['data'] | void> {
   // Lazily access constants.spinner.
   const { spinner } = constants
 
@@ -36,10 +237,10 @@ export async function getAuditLog({
   const socketSdk = await setupSdk(apiToken)
   const result = await handleApiCall(
     socketSdk.getAuditLogEvents(orgSlug, {
-      outputJson,
-      outputMarkdown,
+      outputJson: outputKind === 'json', // I'm not sure this is used at all
+      outputMarkdown: outputKind === 'markdown', // I'm not sure this is used at all
       orgSlug,
-      type,
+      type: logType,
       page,
       per_page: perPage
     }),
@@ -53,27 +254,5 @@ export async function getAuditLog({
 
   spinner.stop()
 
-  const data: AuditChoices = []
-  const logDetails: { [key: string]: string } = {}
-
-  for (const d of result.data.results) {
-    const { created_at } = d
-    if (created_at) {
-      const name = `${new Date(created_at).toLocaleDateString('en-us', { year: 'numeric', month: 'numeric', day: 'numeric' })} - ${d.user_email} - ${d.type} - ${d.ip_address} - ${d.user_agent}`
-      data.push(<AuditChoice>{ name }, new Separator())
-      logDetails[name] = JSON.stringify(d.payload)
-    }
-  }
-
-  logger.log(
-    logDetails[
-      (await select({
-        message: type
-          ? `\n Audit log for: ${orgSlug} with type: ${type}\n`
-          : `\n Audit log for: ${orgSlug}\n`,
-        choices: data,
-        pageSize: 30
-      })) as any
-    ]
-  )
+  return result.data
 }

--- a/test/dry-run.test.ts
+++ b/test/dry-run.test.ts
@@ -161,7 +161,7 @@ describe('dry-run on all commands', async () => {
     expect(stderr).toMatchInlineSnapshot(`
       "\\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
 
-          - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m"
+            - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m"
     `)
 
     expect(code).toBe(2)


### PR DESCRIPTION
The `socket audit-log` claimed to support the `--json` and `--markdown` flags, but actually ignored them. Now they work.
The default will still do the interactive log cycle thing. I find it a bit confusing since it appears to be a picker of sorts but it doesn't really do anything, other than scroll. But that's a next step problem.