### PR TITLE
Cleanup output for info command

### DIFF
--- a/src/commands/info/cmd-info.ts
+++ b/src/commands/info/cmd-info.ts
@@ -52,6 +52,7 @@ async function run(
     parentName
   })
 
+  const { all, json, markdown, strict } = cli.flags
   const [rawPkgName = ''] = cli.input
 
   if (!rawPkgName || cli.input.length > 1) {
@@ -78,11 +79,10 @@ async function run(
 
   await getPackageInfo({
     commandName: `${parentName} ${config.commandName}`,
-    includeAllIssues: Boolean(cli.flags['all']),
-    outputJson: Boolean(cli.flags['json']),
-    outputMarkdown: Boolean(cli.flags['markdown']),
+    includeAllIssues: Boolean(all),
+    outputKind: json ? 'json' : markdown ? 'markdown' : 'print',
     pkgName,
     pkgVersion,
-    strict: Boolean(cli.flags['strict'])
+    strict: Boolean(strict)
   })
 }

--- a/src/commands/info/fetch-package-info.ts
+++ b/src/commands/info/fetch-package-info.ts
@@ -1,6 +1,5 @@
-import { Spinner } from '@socketsecurity/registry/lib/spinner'
-
 import { PackageData } from './get-package-info'
+import constants from '../../constants'
 import { getSeverityCount } from '../../utils/alert/severity'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
 import { getPublicToken, setupSdk } from '../../utils/sdk'
@@ -8,9 +7,17 @@ import { getPublicToken, setupSdk } from '../../utils/sdk'
 export async function fetchPackageInfo(
   pkgName: string,
   pkgVersion: string,
-  includeAllIssues: boolean,
-  spinner: Spinner
+  includeAllIssues: boolean
 ): Promise<void | PackageData> {
+  // Lazily access constants.spinner.
+  const { spinner } = constants
+
+  spinner.start(
+    pkgVersion === 'latest'
+      ? `Looking up data for the latest version of ${pkgName}`
+      : `Looking up data for version ${pkgVersion} of ${pkgName}`
+  )
+
   const socketSdk = await setupSdk(getPublicToken())
   const result = await handleApiCall(
     socketSdk.getIssuesByNPMPackage(pkgName, pkgVersion),
@@ -41,6 +48,8 @@ export async function fetchPackageInfo(
     result.data,
     includeAllIssues ? undefined : 'high'
   )
+
+  spinner?.successAndStop('Data fetched')
 
   return {
     data: result.data,


### PR DESCRIPTION
Fixes output for the `fix` command;

- A call to `spinner.success() and `.error()` meant the spinner did not stop and as such it's swallowing output and leading to infinite spinner loop.
- Consolidated the outputs into a single param like with the others
- Cleaned up markdown and made it more markdown-y

Before;
![image](https://github.com/user-attachments/assets/8aabea35-0d77-4c08-a7d6-191f3a65fb93)

![image](https://github.com/user-attachments/assets/44eebabe-e14b-4981-9a1b-cae1f7590587)

After;

![image](https://github.com/user-attachments/assets/e883da1a-7254-4b92-8521-d023d09d60a4)

![image](https://github.com/user-attachments/assets/864e4d7e-15d1-41df-a88a-8ddc17ed7c5d)
