### PR TITLE
Be explicit with logger in login

### DIFF
--- a/src/commands/login/attempt-login.ts
+++ b/src/commands/login/attempt-login.ts
@@ -41,7 +41,7 @@ export async function attemptLogin(
       throw new AuthError()
     }
     orgs = result.data
-    spinner.success('API key verified')
+    spinner.successAndStop('API key verified')
   } catch {
     spinner.errorAndStop('Invalid API key')
     return
@@ -94,8 +94,10 @@ export async function attemptLogin(
   const oldToken = getSetting('apiToken')
   try {
     applyLogin(apiToken, enforcedOrgs, apiBaseUrl, apiProxy)
+    spinner.start()
     spinner.successAndStop(`API credentials ${oldToken ? 'updated' : 'set'}`)
   } catch {
+    spinner.start()
     spinner.errorAndStop(`API login failed`)
   }
 }


### PR DESCRIPTION
Minor tweak but let's just be explicit in stopping the spinner for now. We'll revisit this later when we undoubtedly add some kind of "logOk" and "logErr" method to the spinner to abstract this "start-if-not-running" state.

(I think we'll want to have some kind of consistent "OK" and "ERROR" prompt in the CLI, down the road. The spinner is key here right now.)