### PR TITLE
Cleanup scan, merge report stuff, hide report command

### DIFF
--- a/src/commands/audit-log/get-audit-log.ts
+++ b/src/commands/audit-log/get-audit-log.ts
@@ -7,6 +7,7 @@ import { SocketSdkReturnType } from '@socketsecurity/sdk'
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
 import { AuthError } from '../../utils/errors'
+import { mdTable } from '../../utils/markdown'
 import { getDefaultToken, setupSdk } from '../../utils/sdk'
 
 import type { Choice } from '@socketsecurity/registry/lib/prompts'
@@ -111,7 +112,7 @@ async function outputAsMarkdown(
   perPage: number
 ): Promise<void> {
   try {
-    const table = mdTable(auditLogs, [
+    const table = mdTable<any>(auditLogs, [
       'event_id',
       'created_at',
       'type',
@@ -142,46 +143,6 @@ ${table}
     process.exitCode = 1
     return
   }
-}
-
-function mdTable<
-  T extends SocketSdkReturnType<'getAuditLogEvents'>['data']['results']
->(
-  logs: T,
-  // This is saying "an array of strings and the strings are a valid key of elements of T"
-  // In turn, T is defined above as the audit log event type from our OpenAPI docs.
-  cols: Array<string & keyof T[number]>
-): string {
-  // Max col width required to fit all data in that column
-  const cws = cols.map(col => col.length)
-
-  for (const log of logs) {
-    for (let i = 0; i < cols.length; ++i) {
-      // @ts-ignore
-      const val: unknown = log[cols[i] ?? ''] ?? ''
-      cws[i] = Math.max(cws[i] ?? 0, String(val).length)
-    }
-  }
-
-  let div = '|'
-  for (const cw of cws) div += ' ' + '-'.repeat(cw) + ' |'
-
-  let header = '|'
-  for (let i = 0; i < cols.length; ++i)
-    header += ' ' + String(cols[i]).padEnd(cws[i] ?? 0, ' ') + ' |'
-
-  let body = ''
-  for (const log of logs) {
-    body += '|'
-    for (let i = 0; i < cols.length; ++i) {
-      // @ts-ignore
-      const val: unknown = log[cols[i] ?? ''] ?? ''
-      body += ' ' + String(val).padEnd(cws[i] ?? 0, ' ') + ' |'
-    }
-    body += '\n'
-  }
-
-  return [div, header, div, body.trim(), div].filter(s => !!s.trim()).join('\n')
 }
 
 async function outputAsPrint(

--- a/src/commands/raw-npm/cmd-raw-npm.ts
+++ b/src/commands/raw-npm/cmd-raw-npm.ts
@@ -3,7 +3,6 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { runRawNpm } from './run-raw-npm'
 import constants from '../../constants'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
-import { getFlagListOutput } from '../../utils/output-formatting'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -14,12 +13,9 @@ const config: CliCommandConfig = {
   description: `Temporarily disable the Socket ${NPM} wrapper`,
   hidden: false,
   flags: {},
-  help: (command, config) => `
+  help: command => `
     Usage
       $ ${command} <command>
-
-    Options
-      ${getFlagListOutput(config.flags, 6)}
 
     Examples
       $ ${command} install

--- a/src/commands/raw-npx/cmd-raw-npx.ts
+++ b/src/commands/raw-npx/cmd-raw-npx.ts
@@ -3,7 +3,6 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { runRawNpx } from './run-raw-npx'
 import constants from '../../constants'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
-import { getFlagListOutput } from '../../utils/output-formatting'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -14,12 +13,9 @@ const config: CliCommandConfig = {
   description: `Temporarily disable the Socket ${NPX} wrapper`,
   hidden: false,
   flags: {},
-  help: (command, config) => `
+  help: command => `
     Usage
       $ ${command} <command>
-
-    Options
-      ${getFlagListOutput(config.flags, 6)}
 
     Examples
       $ ${command} install

--- a/src/commands/report/cmd-report-create.ts
+++ b/src/commands/report/cmd-report-create.ts
@@ -10,7 +10,6 @@ import constants from '../../constants'
 import { commonFlags, outputFlags, validationFlags } from '../../flags'
 import { ColorOrMarkdown } from '../../utils/color-or-markdown'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
-import { getFlagListOutput } from '../../utils/output-formatting'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -18,7 +17,7 @@ const { DRY_RUN_BAIL_TEXT } = constants
 
 const config: CliCommandConfig = {
   commandName: 'create',
-  description: 'Create a project report',
+  description: '[Deprecated] Create a project report',
   hidden: false,
   flags: {
     ...commonFlags,
@@ -36,27 +35,9 @@ const config: CliCommandConfig = {
       description: 'Will wait for and return the created report'
     }
   },
-  help: (command, config) => `
-    Usage
-      $ ${command} <paths-to-package-folders-and-files>
-
-    Uploads the specified "package.json" and lock files for JavaScript, Python, and Go dependency manifests.
-    If any folder is specified, the ones found in there recursively are uploaded.
-
-    Supports globbing such as "**/package.json", "**/requirements.txt", "**/pyproject.toml", and "**/go.mod".
-
-    Ignores any file specified in your project's ".gitignore", your project's
-    "socket.yml" file's "projectIgnorePaths" and also has a sensible set of
-    default ignores from the "ignore-by-default" module.
-
-    Options
-      ${getFlagListOutput(config.flags, 6)}
-
-    Examples
-      $ ${command} .
-      $ ${command} '**/package.json'
-      $ ${command} /path/to/a/package.json /path/to/another/package.json
-      $ ${command} . --view --json
+  help: () => `
+    This command is deprecated in favor of \`socket scan create\`.
+    It will be removed in the next major release of the CLI.
   `
 }
 

--- a/src/commands/report/cmd-report-view.ts
+++ b/src/commands/report/cmd-report-view.ts
@@ -7,7 +7,6 @@ import { viewReport } from './view-report'
 import constants from '../../constants'
 import { commonFlags, outputFlags, validationFlags } from '../../flags'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
-import { getFlagListOutput } from '../../utils/output-formatting'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -15,22 +14,16 @@ const { DRY_RUN_BAIL_TEXT } = constants
 
 const config: CliCommandConfig = {
   commandName: 'view',
-  description: 'View a project report',
+  description: '[Deprecated] View a project report',
   hidden: false,
   flags: {
     ...commonFlags,
     ...outputFlags,
     ...validationFlags
   },
-  help: (command, config) => `
-    Usage
-      $ ${command} <report-identifier>
-
-    Options
-      ${getFlagListOutput(config.flags, 6)}
-
-    Examples
-      $ ${command} QXU8PmK7LfH608RAwfIKdbcHgwEd_ZeWJ9QEGv05FJUQ
+  help: () => `
+    This command is deprecated in favor of \`socket scan view\`.
+    It will be removed in the next major release of the CLI.
   `
 }
 

--- a/src/commands/report/cmd-report.ts
+++ b/src/commands/report/cmd-report.ts
@@ -8,6 +8,7 @@ const description = '[Deprecated] Project report related commands'
 
 export const cmdReport: CliSubcommand = {
   description,
+  hidden: true, // Deprecated in favor of `scan`
   async run(argv, importMeta, { parentName }) {
     await meowWithSubcommands(
       {

--- a/src/commands/report/create-report.ts
+++ b/src/commands/report/create-report.ts
@@ -3,7 +3,7 @@ import { pluralize } from '@socketsecurity/registry/lib/words'
 
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { getPackageFiles } from '../../utils/path-resolve'
+import { getPackageFilesFullScans } from '../../utils/path-resolve'
 import { setupSdk } from '../../utils/sdk'
 
 import type { SocketYml } from '@socketsecurity/config'
@@ -40,13 +40,13 @@ export async function createReport(
         cause
       })
     })
-  const packagePaths = await getPackageFiles(
+  const packagePaths = await getPackageFilesFullScans(
     cwd,
     inputPaths,
-    socketConfig,
-    supportedFiles
+    supportedFiles,
+    socketConfig
   )
-  const { length: packagePathsCount } = packagePaths
+  const packagePathsCount = packagePaths.length
   if (packagePathsCount && isDebug()) {
     for (const pkgPath of packagePaths) {
       debugLog(`Uploading: ${pkgPath}`)

--- a/src/commands/scan/cmd-scan-create.ts
+++ b/src/commands/scan/cmd-scan-create.ts
@@ -88,13 +88,30 @@ const config: CliCommandConfig = {
       default: false,
       description:
         'Set the visibility (true/false) of the scan in your dashboard'
+    },
+    view: {
+      type: 'boolean',
+      shortFlag: 'v',
+      default: true,
+      description:
+        'Will wait for and return the created report. Use --no-view to disable.'
     }
   },
+  // TODO: your project's "socket.yml" file's "projectIgnorePaths"
   help: (command, config) => `
     Usage
       $ ${command} [...options] <org> <TARGET> [TARGET...]
 
-    Where TARGET is a FILE or DIR that _must_ be inside the CWD.
+    Uploads the specified "package.json" and lock files for JavaScript, Python,
+    Go, Scala, Gradle, and Kotlin dependency manifests.
+    If any folder is specified, the ones found in there recursively are uploaded.
+
+    Supports globbing such as "**/package.json", "**/requirements.txt", etc.
+
+    Ignores any file specified in your project's ".gitignore" and also has a
+    sensible set of default ignores from the "ignore-by-default" module.
+
+    TARGET should be a FILE or DIR that _must_ be inside the CWD.
 
     When a FILE is given only that FILE is targeted. Otherwise any eligible
     files in the given DIR will be considered.
@@ -134,7 +151,7 @@ async function run(
 
   let { branch: branchName, repo: repoName } = cli.flags
 
-  const apiToken = getDefaultToken()
+  const apiToken = getDefaultToken() // This checks if we _can_ suggest anything
 
   if (!apiToken && (!orgSlug || !repoName || !branchName || !targets.length)) {
     // Without api token we cannot recover because we can't request more info

--- a/src/commands/scan/cmd-scan-del.ts
+++ b/src/commands/scan/cmd-scan-del.ts
@@ -6,10 +6,8 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { deleteOrgFullScan } from './delete-full-scan'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
-import { AuthError } from '../../utils/errors'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
-import { getDefaultToken } from '../../utils/sdk'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -75,12 +73,5 @@ async function run(
     return
   }
 
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
-
-  await deleteOrgFullScan(orgSlug, fullScanId, apiToken)
+  await deleteOrgFullScan(orgSlug, fullScanId)
 }

--- a/src/commands/scan/cmd-scan-list.ts
+++ b/src/commands/scan/cmd-scan-list.ts
@@ -6,10 +6,8 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { listFullScans } from './list-full-scans'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
-import { AuthError } from '../../utils/errors'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
-import { getDefaultToken } from '../../utils/sdk'
 
 import type {
   CliCommandConfig,
@@ -113,37 +111,17 @@ async function run(
     return
   }
 
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
-
-  await listFullScans(
+  await listFullScans({
+    direction: String(cli.flags['direction'] || ''),
+    from_time: String(cli.flags['fromTime'] || ''),
     orgSlug,
-    // TODO: refine this object to what we need
-    {
-      outputJson: cli.flags['json'],
-      outputMarkdown: cli.flags['markdown'],
-      orgSlug,
-      sort: cli.flags['sort'],
-      direction: cli.flags['direction'],
-      per_page: cli.flags['perPage'],
-      page: cli.flags['page'],
-      from_time: cli.flags['fromTime'],
-      until_time: cli.flags['untilTime']
-    } as {
-      outputJson: boolean
-      outputMarkdown: boolean
-      orgSlug: string
-      sort: string
-      direction: string
-      per_page: number
-      page: number
-      from_time: string
-      until_time: string
-    },
-    apiToken
-  )
+    outputKind: cli.flags['json']
+      ? 'json'
+      : cli.flags['markdown']
+        ? 'markdown'
+        : 'print',
+    page: Number(cli.flags['page'] || 1),
+    per_page: Number(cli.flags['perPage'] || 30),
+    sort: String(cli.flags['sort'] || '')
+  })
 }

--- a/src/commands/scan/cmd-scan-metadata.ts
+++ b/src/commands/scan/cmd-scan-metadata.ts
@@ -6,10 +6,8 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { getOrgScanMetadata } from './get-full-scan-metadata'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
-import { AuthError } from '../../utils/errors'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
-import { getDefaultToken } from '../../utils/sdk'
 
 import type {
   CliCommandConfig,
@@ -78,12 +76,9 @@ async function run(
     return
   }
 
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
-
-  await getOrgScanMetadata(orgSlug, fullScanId, apiToken)
+  await getOrgScanMetadata(
+    orgSlug,
+    fullScanId,
+    cli.flags['json'] ? 'json' : cli.flags['markdown'] ? 'markdown' : 'print'
+  )
 }

--- a/src/commands/scan/cmd-scan-view.ts
+++ b/src/commands/scan/cmd-scan-view.ts
@@ -3,13 +3,12 @@ import colors from 'yoctocolors-cjs'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 
-import { getFullScan } from './get-full-scan'
+import { streamFullScan } from './stream-full-scan'
+import { viewFullScan } from './view-full-scan'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
-import { AuthError } from '../../utils/errors'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
-import { getDefaultToken } from '../../utils/sdk'
 
 import type {
   CliCommandConfig,
@@ -19,8 +18,8 @@ import type {
 const { DRY_RUN_BAIL_TEXT } = constants
 
 const config: CliCommandConfig = {
-  commandName: 'stream',
-  description: 'Stream the output of a scan',
+  commandName: 'view',
+  description: 'View the raw results of a scan',
   hidden: false,
   flags: {
     ...commonFlags,
@@ -40,7 +39,7 @@ const config: CliCommandConfig = {
   `
 }
 
-export const cmdScanStream: CliSubcommand = {
+export const cmdScanView: CliSubcommand = {
   description: config.description,
   hidden: config.hidden,
   run
@@ -82,12 +81,9 @@ async function run(
     return
   }
 
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
+  if (cli.flags['json']) {
+    await streamFullScan(orgSlug, fullScanId, file)
+  } else {
+    await viewFullScan(orgSlug, fullScanId, file)
   }
-
-  await getFullScan(orgSlug, fullScanId, file, apiToken)
 }

--- a/src/commands/scan/cmd-scan.ts
+++ b/src/commands/scan/cmd-scan.ts
@@ -2,12 +2,12 @@ import { cmdScanCreate } from './cmd-scan-create'
 import { cmdScanDel } from './cmd-scan-del'
 import { cmdScanList } from './cmd-scan-list'
 import { cmdScanMetadata } from './cmd-scan-metadata'
-import { cmdScanStream } from './cmd-scan-stream'
+import { cmdScanView } from './cmd-scan-view'
 import { meowWithSubcommands } from '../../utils/meow-with-subcommands'
 
 import type { CliSubcommand } from '../../utils/meow-with-subcommands'
 
-const description = 'Scans related commands'
+const description = 'Full Scan related commands'
 
 export const cmdScan: CliSubcommand = {
   description,
@@ -15,12 +15,20 @@ export const cmdScan: CliSubcommand = {
     await meowWithSubcommands(
       {
         create: cmdScanCreate,
-        stream: cmdScanStream,
         list: cmdScanList,
         del: cmdScanDel,
-        metadata: cmdScanMetadata
+        metadata: cmdScanMetadata,
+        view: cmdScanView
       },
       {
+        aliases: {
+          // Backwards compat. TODO: Drop next major bump
+          stream: {
+            description: cmdScanView.description,
+            hidden: true,
+            argv: ['view'] // Original args will be appended (!)
+          }
+        },
         argv,
         description,
         importMeta,

--- a/src/commands/scan/delete-full-scan.ts
+++ b/src/commands/scan/delete-full-scan.ts
@@ -1,8 +1,22 @@
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { setupSdk } from '../../utils/sdk'
+import { AuthError } from '../../utils/errors'
+import { getDefaultToken, setupSdk } from '../../utils/sdk'
 
 export async function deleteOrgFullScan(
+  orgSlug: string,
+  fullScanId: string
+): Promise<void> {
+  const apiToken = getDefaultToken()
+  if (!apiToken) {
+    throw new AuthError(
+      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
+    )
+  }
+
+  await deleteOrgFullScanWithToken(orgSlug, fullScanId, apiToken)
+}
+export async function deleteOrgFullScanWithToken(
   orgSlug: string,
   fullScanId: string,
   apiToken: string
@@ -22,5 +36,6 @@ export async function deleteOrgFullScan(
     handleUnsuccessfulApiResponse('deleteOrgFullScan', result, spinner)
     return
   }
+
   spinner.successAndStop('Scan deleted successfully')
 }

--- a/src/commands/scan/get-full-scan-metadata.ts
+++ b/src/commands/scan/get-full-scan-metadata.ts
@@ -2,17 +2,33 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { setupSdk } from '../../utils/sdk'
+import { AuthError } from '../../utils/errors'
+import { getDefaultToken, setupSdk } from '../../utils/sdk'
 
 export async function getOrgScanMetadata(
   orgSlug: string,
   scanId: string,
-  apiToken: string
+  outputKind: 'json' | 'markdown' | 'print'
+): Promise<void> {
+  const apiToken = getDefaultToken()
+  if (!apiToken) {
+    throw new AuthError(
+      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
+    )
+  }
+
+  await getOrgScanMetadataWithToken(orgSlug, scanId, apiToken, outputKind)
+}
+export async function getOrgScanMetadataWithToken(
+  orgSlug: string,
+  scanId: string,
+  apiToken: string,
+  outputKind: 'json' | 'markdown' | 'print'
 ): Promise<void> {
   // Lazily access constants.spinner.
   const { spinner } = constants
 
-  spinner.start("Getting scan's metadata...")
+  spinner.start('Fetching meta data for a full scan...')
 
   const socketSdk = await setupSdk(apiToken)
   const result = await handleApiCall(
@@ -25,6 +41,38 @@ export async function getOrgScanMetadata(
     return
   }
 
-  spinner.stop('Scan metadata:')
-  logger.log(result.data)
+  spinner?.successAndStop('Fetched the meta data\n')
+
+  if (outputKind === 'json') {
+    logger.log(result.data)
+  } else {
+    // Markdown = print
+    if (outputKind === 'markdown') {
+      logger.log('# Scan meta data\n')
+    }
+    logger.log(`Scan ID: ${scanId}\n`)
+    for (const [key, value] of Object.entries(result.data)) {
+      if (
+        [
+          'id',
+          'updated_at',
+          'organization_id',
+          'repository_id',
+          'commit_hash',
+          'html_report_url'
+        ].includes(key)
+      )
+        continue
+      logger.log(`- ${key}:`, value)
+    }
+    if (outputKind === 'markdown') {
+      logger.log(
+        `\nYou can view this report at: [${result.data.html_report_url}](${result.data.html_report_url})\n`
+      )
+    } else {
+      logger.log(
+        `\nYou can view this report at: ${result.data.html_report_url}]\n`
+      )
+    }
+  }
 }

--- a/src/commands/scan/get-full-scan.ts
+++ b/src/commands/scan/get-full-scan.ts
@@ -1,34 +1,57 @@
-import constants from '../../constants'
-import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { setupSdk } from '../../utils/sdk'
+import colors from 'yoctocolors-cjs'
 
-import type { SocketSdkResultType } from '@socketsecurity/sdk'
+import { logger } from '@socketsecurity/registry/lib/logger'
+import { components } from '@socketsecurity/sdk/types/api'
+
+import constants from '../../constants'
+import { handleAPIError, queryAPI } from '../../utils/api'
+import { AuthError } from '../../utils/errors'
+import { getDefaultToken } from '../../utils/sdk'
 
 export async function getFullScan(
   orgSlug: string,
-  fullScanId: string,
-  file: string | undefined,
-  apiToken: string
-): Promise<SocketSdkResultType<'getOrgFullScan'>> {
+  fullScanId: string
+): Promise<Array<components['schemas']['SocketArtifact']> | undefined> {
   // Lazily access constants.spinner.
   const { spinner } = constants
 
-  spinner.start('Streaming scan...')
+  const apiToken = getDefaultToken()
+  if (!apiToken) {
+    throw new AuthError(
+      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
+    )
+  }
 
-  const socketSdk = await setupSdk(apiToken)
-  const data = await handleApiCall(
-    socketSdk.getOrgFullScan(
-      orgSlug,
-      fullScanId,
-      file === '-' ? undefined : file
-    ),
-    'Streaming a scan'
+  spinner.start('Fetching full-scan...')
+
+  const response = await queryAPI(
+    `orgs/${orgSlug}/full-scans/${encodeURIComponent(fullScanId)}`,
+    apiToken
   )
 
-  if (data?.success) {
-    spinner.stop(file ? `Full scan details written to ${file}` : '')
-  } else {
-    handleUnsuccessfulApiResponse('getOrgFullScan', data, spinner)
+  spinner.stop('Fetch complete.')
+
+  if (!response.ok) {
+    const err = await handleAPIError(response.status)
+    logger.error(
+      `${colors.bgRed(colors.white(response.statusText))}: Fetch error: ${err}`
+    )
+    return
   }
+
+  // This is nd-json; each line is a json object
+  const jsons = await response.text()
+  const lines = jsons.split('\n').filter(Boolean)
+  const data = lines.map(line => {
+    try {
+      return JSON.parse(line)
+    } catch {
+      console.error(
+        'At least one line item was returned that could not be parsed as JSON...'
+      )
+      return {}
+    }
+  }) as unknown as Array<components['schemas']['SocketArtifact']>
+
   return data
 }

--- a/src/commands/scan/stream-full-scan.ts
+++ b/src/commands/scan/stream-full-scan.ts
@@ -1,0 +1,45 @@
+import constants from '../../constants'
+import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
+import { AuthError } from '../../utils/errors'
+import { getDefaultToken, setupSdk } from '../../utils/sdk'
+
+import type { SocketSdkResultType } from '@socketsecurity/sdk'
+
+export async function streamFullScan(
+  orgSlug: string,
+  fullScanId: string,
+  file: string | undefined
+): Promise<SocketSdkResultType<'getOrgFullScan'> | undefined> {
+  // Lazily access constants.spinner.
+  const { spinner } = constants
+
+  const apiToken = getDefaultToken()
+  if (!apiToken) {
+    throw new AuthError(
+      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
+    )
+  }
+
+  spinner.start('Fetching scan...')
+
+  const socketSdk = await setupSdk(apiToken)
+  const data = await handleApiCall(
+    socketSdk.getOrgFullScan(
+      orgSlug,
+      fullScanId,
+      file === '-' ? undefined : file
+    ),
+    'Fetching a scan'
+  )
+
+  if (!data?.success) {
+    handleUnsuccessfulApiResponse('getOrgFullScan', data, spinner)
+    return
+  }
+
+  spinner?.successAndStop(
+    file ? `Full scan details written to ${file}` : 'stdout'
+  )
+
+  return data
+}

--- a/src/commands/scan/view-full-scan.ts
+++ b/src/commands/scan/view-full-scan.ts
@@ -1,0 +1,64 @@
+import fs from 'node:fs/promises'
+
+import { logger } from '@socketsecurity/registry/lib/logger'
+import { components } from '@socketsecurity/sdk/types/api'
+
+import { getFullScan } from './get-full-scan'
+import { mdTable } from '../../utils/markdown'
+
+export async function viewFullScan(
+  orgSlug: string,
+  fullScanId: string,
+  filePath: string
+): Promise<void> {
+  const artifacts: Array<components['schemas']['SocketArtifact']> | undefined =
+    await getFullScan(orgSlug, fullScanId)
+  if (!artifacts) return
+
+  const display = artifacts.map(art => {
+    const author = Array.isArray(art.author)
+      ? `${art.author[0]}${art.author.length > 1 ? ' et.al.' : ''}`
+      : art.author
+    return {
+      type: art.type,
+      name: art.name,
+      version: art.version,
+      author,
+      score: JSON.stringify(art.score)
+    }
+  })
+
+  const md = mdTable<any>(display, [
+    'type',
+    'version',
+    'name',
+    'author',
+    'score'
+  ])
+
+  const report =
+    `
+# Scan Details
+
+These are the artifacts and their scores found.
+
+Sscan ID: ${fullScanId}
+
+${md}
+
+View this report at: https://socket.dev/dashboard/org/${orgSlug}/sbom/${fullScanId}
+  `.trim() + '\n'
+
+  if (filePath && filePath !== '-') {
+    try {
+      await fs.writeFile(filePath, report, 'utf8')
+      logger.log(`Data successfully written to ${filePath}`)
+    } catch (e) {
+      logger.error('There was an error trying to write the json to disk')
+      logger.error(e)
+      process.exitCode = 1
+    }
+  } else {
+    logger.log(report)
+  }
+}

--- a/src/utils/path-resolve.ts
+++ b/src/utils/path-resolve.ts
@@ -236,46 +236,17 @@ export function findNpmPathSync(npmBinPath: string): string | undefined {
   }
 }
 
-export async function getPackageFiles(
+export async function getPackageFilesFullScans(
   cwd: string,
   inputPaths: string[],
-  config: SocketYml | undefined,
-  supportedFiles: SocketSdkReturnType<'getReportSupportedFiles'>['data']
+  supportedFiles: SocketSdkReturnType<'getReportSupportedFiles'>['data'],
+  config?: SocketYml | undefined
 ): Promise<string[]> {
   debugLog(`Globbed resolving ${inputPaths.length} paths:`, inputPaths)
 
   const entries = await globWithGitIgnore(pathsToPatterns(inputPaths), {
     cwd,
     socketConfig: config
-  })
-
-  debugLog(
-    `Globbed resolved ${inputPaths.length} paths to ${entries.length} paths:`,
-    entries
-  )
-
-  const packageFiles = await filterGlobResultToSupportedFiles(
-    entries,
-    supportedFiles
-  )
-
-  debugLog(
-    `Mapped ${entries.length} entries to ${packageFiles.length} files:`,
-    packageFiles
-  )
-
-  return packageFiles
-}
-
-export async function getPackageFilesFullScans(
-  cwd: string,
-  inputPaths: string[],
-  supportedFiles: SocketSdkReturnType<'getReportSupportedFiles'>['data']
-): Promise<string[]> {
-  debugLog(`Globbed resolving ${inputPaths.length} paths:`, inputPaths)
-
-  const entries = await globWithGitIgnore(pathsToPatterns(inputPaths), {
-    cwd
   })
 
   debugLog(

--- a/test/dry-run.test.ts
+++ b/test/dry-run.test.ts
@@ -900,14 +900,14 @@ describe('dry-run on all commands', async () => {
     )
   })
 
-  cmdit(['scan', 'stream', '--dry-run'], 'should support', async cmd => {
+  cmdit(['scan', 'view', '--dry-run'], 'should support', async cmd => {
     const { code, stderr, stdout } = await invoke(entryPath, cmd)
     expect(`\n   ${stdout}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
         |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan stream\`, cwd: <redacted>"
+        |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan view\`, cwd: <redacted>"
     `)
     expect(stderr).toMatchInlineSnapshot(`
       "\\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:

--- a/test/path-resolve.test.ts
+++ b/test/path-resolve.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { normalizePath } from '@socketsecurity/registry/lib/path'
 
-import { getPackageFiles } from './dist/path-resolve'
+import { getPackageFilesFullScans } from './dist/path-resolve'
 
 const testPath = __dirname
 const mockPath = normalizePath(path.join(testPath, 'mock'))
@@ -68,7 +68,7 @@ const sortedPromise =
     const result = await fn(...args)
     return result.sort()
   }
-const sortedGetPackageFiles = sortedPromise(getPackageFiles)
+const sortedGetPackageFiles = sortedPromise(getPackageFilesFullScans)
 
 describe('Path Resolve', () => {
   beforeEach(() => {
@@ -92,8 +92,8 @@ describe('Path Resolve', () => {
       const actual = await sortedGetPackageFiles(
         mockPath,
         ['.'],
-        undefined,
-        globPatterns
+        globPatterns,
+        undefined
       )
       expect(actual.map(normalizePath)).toEqual([`${mockPath}/package.json`])
     })
@@ -109,13 +109,13 @@ describe('Path Resolve', () => {
       const actual = await sortedGetPackageFiles(
         mockPath,
         ['**/*'],
+        globPatterns,
         {
           version: 2,
           projectIgnorePaths: ['bar/*', '!bar/package.json'],
           issueRules: {},
           githubApp: {}
-        },
-        globPatterns
+        }
       )
       expect(actual.map(normalizePath)).toEqual([
         `${mockPath}/bar/package.json`,
@@ -136,8 +136,8 @@ describe('Path Resolve', () => {
       const actual = await sortedGetPackageFiles(
         mockPath,
         ['**/*'],
-        undefined,
-        globPatterns
+        globPatterns,
+        undefined
       )
       expect(actual.map(normalizePath)).toEqual([
         `${mockPath}/bar/package.json`,
@@ -165,8 +165,8 @@ describe('Path Resolve', () => {
       const actual = await sortedGetPackageFiles(
         mockPath,
         ['**/*'],
-        undefined,
-        globPatterns
+        globPatterns,
+        undefined
       )
       expect(actual.map(normalizePath)).toEqual([
         `${mockPath}/foo/package-lock.json`,
@@ -185,8 +185,8 @@ describe('Path Resolve', () => {
       const actual = await sortedGetPackageFiles(
         mockPath,
         ['**/*'],
-        undefined,
-        globPatterns
+        globPatterns,
+        undefined
       )
       expect(actual.map(normalizePath)).toEqual([
         `${mockPath}/foo/package-lock.json`,
@@ -204,8 +204,8 @@ describe('Path Resolve', () => {
       const actual = await sortedGetPackageFiles(
         mockPath,
         ['**/*'],
-        undefined,
-        globPatterns
+        globPatterns,
+        undefined
       )
       expect(actual.map(normalizePath)).toEqual([])
     })
@@ -219,8 +219,8 @@ describe('Path Resolve', () => {
       const actual = await sortedGetPackageFiles(
         mockPath,
         ['**/*'],
-        undefined,
-        globPatterns
+        globPatterns,
+        undefined
       )
       expect(actual.map(normalizePath)).toEqual([
         `${mockPath}/package-lock.json`,
@@ -236,8 +236,8 @@ describe('Path Resolve', () => {
       const actual = await sortedGetPackageFiles(
         mockPath,
         ['**/*'],
-        undefined,
-        globPatterns
+        globPatterns,
+        undefined
       )
       expect(actual.map(normalizePath)).toEqual([`${mockPath}/package.json`])
     })
@@ -251,8 +251,8 @@ describe('Path Resolve', () => {
       const actual = await sortedGetPackageFiles(
         mockPath,
         ['**/*'],
-        undefined,
-        globPatterns
+        globPatterns,
+        undefined
       )
       expect(actual.map(normalizePath)).toEqual([
         `${mockPath}/package.json`,
@@ -274,8 +274,8 @@ describe('Path Resolve', () => {
       const actual = await sortedGetPackageFiles(
         mockPath,
         ['**/*'],
-        undefined,
-        globPatterns
+        globPatterns,
+        undefined
       )
       expect(actual.map(normalizePath)).toEqual([
         `${mockPath}/abc/package.json`,


### PR DESCRIPTION
Deprecates and hides the `socket report` command, updates the `socket scan` command with a `socket scan view` command (supplementing the `socket scan stream`), updated some markdown/json flows.

- The `socket report` commands are now hidden and marked as deprecated explicitly
- The `socket report view` command idea is added to the `scan` suite
- There's one feature that `socket report create` had that `scan` does not yet; using a file based config. We'll have to think about this a bit more before we codify that forever, but before the next version bump. Other than that they were equal already.
- Added a `socket scan view` command, which kind of replaces the `socket scan stream`
  - `stream` does not convey the same message as `view`
  - The thing `stream` did is kept though; it'll stream the report to a file
  - Supports --markdown now
- Support --json and --markdown in `socket scan metadata`
- Support --json and --markdown in `socket scan list`