### PR TITLE
Fix threat-feed, improve ui, add eco filter

### DIFF
--- a/src/commands/audit-log/cmd-audit-log.ts
+++ b/src/commands/audit-log/cmd-audit-log.ts
@@ -43,6 +43,9 @@ const config: CliCommandConfig = {
     Usage
       $ ${command} <org slug>
 
+    This feature requires an Enterprise Plan. To learn more about getting access
+    to this feature and many more, please visit https://socket.dev/pricing
+
     Options
       ${getFlagListOutput(config.flags, 6)}
 

--- a/src/commands/threat-feed/cmd-threat-feed.ts
+++ b/src/commands/threat-feed/cmd-threat-feed.ts
@@ -3,10 +3,8 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { getThreatFeed } from './get-threat-feed'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
-import { AuthError } from '../../utils/errors'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
-import { getDefaultToken } from '../../utils/sdk'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -14,7 +12,7 @@ const { DRY_RUN_BAIL_TEXT } = constants
 
 const config: CliCommandConfig = {
   commandName: 'threat-feed',
-  description: 'Look up the threat feed',
+  description: '[beta] Look at the threat feed',
   hidden: false,
   flags: {
     ...commonFlags,
@@ -37,6 +35,12 @@ const config: CliCommandConfig = {
       default: 'desc',
       description: 'Order asc or desc by the createdAt attribute.'
     },
+    ecoSystem: {
+      type: 'string',
+      shortFlag: 'e',
+      default: '',
+      description: 'Only show threats for a particular eco system'
+    },
     filter: {
       type: 'string',
       shortFlag: 'f',
@@ -50,6 +54,32 @@ const config: CliCommandConfig = {
 
     Options
       ${getFlagListOutput(config.flags, 6)}
+
+    This feature requires an Enterprise Plan with Threat Feed add-on. Please
+    contact sales@socket.dev if you would like access to this feature.
+
+    Valid filters:
+
+      - c       Do not filter
+      - u       Unreviewed
+      - fp      False Positives
+      - tp      False Positives and Unreviewed
+      - mal     Malware and Possible Malware [default]
+      - vuln    Vulnerability
+      - anom    Anomaly
+      - secret  Secret
+      - joke    Joke / Fake
+      - spy     Telemetry
+      - typo    Typo-squat
+
+    Valid eco systems:
+
+      - gem
+      - golang
+      - maven
+      - npm
+      - nuget
+      - pypi
 
     Examples
       $ ${command}
@@ -80,19 +110,16 @@ async function run(
     return
   }
 
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
-
   await getThreatFeed({
-    apiToken,
     direction: String(cli.flags['direction'] || 'desc'),
+    ecoSystem: String(cli.flags['ecoSystem'] || ''),
     filter: String(cli.flags['filter'] || 'mal'),
-    outputJson: Boolean(cli.flags['json']),
-    page: String(cli.flags['filter'] || '1'),
-    perPage: Number(cli.flags['per_page'] || 0)
+    outputKind: cli.flags['json']
+      ? 'json'
+      : cli.flags['markdown']
+        ? 'markdown'
+        : 'print',
+    page: String(cli.flags['page'] || '1'),
+    perPage: Number(cli.flags['perPage']) || 30
   })
 }

--- a/src/commands/threat-feed/cmd-threat-feed.ts
+++ b/src/commands/threat-feed/cmd-threat-feed.ts
@@ -12,7 +12,7 @@ const { DRY_RUN_BAIL_TEXT } = constants
 
 const config: CliCommandConfig = {
   commandName: 'threat-feed',
-  description: '[beta] Look at the threat feed',
+  description: '[beta] View the threat feed',
   hidden: false,
   flags: {
     ...commonFlags,
@@ -35,11 +35,11 @@ const config: CliCommandConfig = {
       default: 'desc',
       description: 'Order asc or desc by the createdAt attribute.'
     },
-    ecoSystem: {
+    eco: {
       type: 'string',
       shortFlag: 'e',
       default: '',
-      description: 'Only show threats for a particular eco system'
+      description: 'Only show threats for a particular ecosystem'
     },
     filter: {
       type: 'string',
@@ -52,27 +52,27 @@ const config: CliCommandConfig = {
     Usage
       $ ${command}
 
+    This feature requires a Threat Feed license. Please contact
+    sales@socket.dev if you are interested in purchasing this access.
+
     Options
       ${getFlagListOutput(config.flags, 6)}
 
-    This feature requires an Enterprise Plan with Threat Feed add-on. Please
-    contact sales@socket.dev if you would like access to this feature.
-
     Valid filters:
 
-      - c       Do not filter
-      - u       Unreviewed
-      - fp      False Positives
-      - tp      False Positives and Unreviewed
-      - mal     Malware and Possible Malware [default]
-      - vuln    Vulnerability
       - anom    Anomaly
-      - secret  Secret
+      - c       Do not filter
+      - fp      False Positives
+      - mal     Malware and Possible Malware [default]
       - joke    Joke / Fake
+      - secret  Secrets
       - spy     Telemetry
+      - tp      False Positives and Unreviewed
       - typo    Typo-squat
+      - u       Unreviewed
+      - vuln    Vulnerability
 
-    Valid eco systems:
+    Valid ecosystems:
 
       - gem
       - golang
@@ -112,7 +112,7 @@ async function run(
 
   await getThreatFeed({
     direction: String(cli.flags['direction'] || 'desc'),
-    ecoSystem: String(cli.flags['ecoSystem'] || ''),
+    ecosystem: String(cli.flags['eco'] || ''),
     filter: String(cli.flags['filter'] || 'mal'),
     outputKind: cli.flags['json']
       ? 'json'

--- a/src/commands/threat-feed/get-threat-feed.ts
+++ b/src/commands/threat-feed/get-threat-feed.ts
@@ -29,14 +29,14 @@ type ThreatResult = {
 
 export async function getThreatFeed({
   direction,
-  ecoSystem,
+  ecosystem,
   filter,
   outputKind,
   page,
   perPage
 }: {
   direction: string
-  ecoSystem: string
+  ecosystem: string
   filter: string
   outputKind: 'json' | 'markdown' | 'print'
   page: string
@@ -52,7 +52,7 @@ export async function getThreatFeed({
   await getThreatFeedWithToken({
     apiToken,
     direction,
-    ecoSystem,
+    ecosystem,
     filter,
     outputKind,
     page,
@@ -63,7 +63,7 @@ export async function getThreatFeed({
 async function getThreatFeedWithToken({
   apiToken,
   direction,
-  ecoSystem,
+  ecosystem,
   filter,
   outputKind,
   page,
@@ -71,7 +71,7 @@ async function getThreatFeedWithToken({
 }: {
   apiToken: string
   direction: string
-  ecoSystem: string
+  ecosystem: string
   filter: string
   outputKind: 'json' | 'markdown' | 'print'
   page: string
@@ -82,7 +82,7 @@ async function getThreatFeedWithToken({
 
   const queryParams = new URLSearchParams([
     ['direction', direction],
-    ['ecosystem', ecoSystem],
+    ['ecosystem', ecosystem],
     ['filter', filter],
     ['page', page],
     ['per_page', String(perPage)]
@@ -168,6 +168,7 @@ async function getThreatFeedWithToken({
     if (selectedIndex !== undefined && selectedIndex >= 0) {
       const selectedRow = formattedOutput[selectedIndex]
       if (selectedRow) {
+        // Note: the spacing works around issues with the table; it refuses to pad!
         detailsBox.setContent(
           `Ecosystem: ${selectedRow[0]}\n` +
             `Name: ${selectedRow[1]}\n` +
@@ -205,26 +206,34 @@ function formatResults(data: ThreatResult[]) {
     return [
       ecosystem,
       decodeURIComponent(name),
-      ' ' + version,
-      ' ' + d.threatType,
-      ' ' + timeDiff,
+      ` ${version}`,
+      ` ${d.threatType}`,
+      ` ${timeDiff}`,
       d.locationHtmlUrl
     ]
   })
 }
 
 function msAtHome(isoTimeStamp: string): string {
-  const timeStart = new Date(isoTimeStamp).getTime()
+  const timeStart = Date.parse(isoTimeStamp)
   const timeEnd = Date.now()
+
+  const rtf = new Intl.RelativeTimeFormat('en', {
+    numeric: 'always',
+    style: 'short'
+  })
 
   const delta = timeEnd - timeStart
   if (delta < 60 * 60 * 1000) {
-    return Math.round(delta / (60 * 1000)) + ' min ago'
+    return rtf.format(-Math.round(delta / (60 * 1000)), 'minute')
+    // return Math.round(delta / (60 * 1000)) + ' min ago'
   } else if (delta < 24 * 60 * 60 * 1000) {
-    return (delta / (60 * 60 * 1000)).toFixed(1) + ' hr ago'
+    return rtf.format(-(delta / (60 * 60 * 1000)).toFixed(1), 'hour')
+    // return (delta / (60 * 60 * 1000)).toFixed(1) + ' hr ago'
   } else if (delta < 7 * 24 * 60 * 60 * 1000) {
-    return (delta / (24 * 60 * 60 * 1000)).toFixed(1) + ' day ago'
+    return rtf.format(-(delta / (24 * 60 * 60 * 1000)).toFixed(1), 'day')
+    // return (delta / (24 * 60 * 60 * 1000)).toFixed(1) + ' day ago'
   } else {
-    return isoTimeStamp.slice(0, 8)
+    return isoTimeStamp.slice(0, 10)
   }
 }

--- a/src/commands/threat-feed/get-threat-feed.ts
+++ b/src/commands/threat-feed/get-threat-feed.ts
@@ -1,6 +1,8 @@
 import process from 'node:process'
 
 // @ts-ignore
+import BoxWidget from 'blessed/lib/widgets/box'
+// @ts-ignore
 import ScreenWidget from 'blessed/lib/widgets/screen'
 // @ts-ignore
 import TableWidget from 'blessed-contrib/lib/widget/table'
@@ -9,6 +11,10 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 
 import constants from '../../constants'
 import { queryAPI } from '../../utils/api'
+import { AuthError } from '../../utils/errors'
+import { getDefaultToken } from '../../utils/sdk'
+
+import type { Widgets } from 'blessed' // Note: Widgets does not seem to actually work as code :'(
 
 type ThreatResult = {
   createdAt: string
@@ -22,49 +28,83 @@ type ThreatResult = {
 }
 
 export async function getThreatFeed({
+  direction,
+  ecoSystem,
+  filter,
+  outputKind,
+  page,
+  perPage
+}: {
+  direction: string
+  ecoSystem: string
+  filter: string
+  outputKind: 'json' | 'markdown' | 'print'
+  page: string
+  perPage: number
+}): Promise<void> {
+  const apiToken = getDefaultToken()
+  if (!apiToken) {
+    throw new AuthError(
+      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
+    )
+  }
+
+  await getThreatFeedWithToken({
+    apiToken,
+    direction,
+    ecoSystem,
+    filter,
+    outputKind,
+    page,
+    perPage
+  })
+}
+
+async function getThreatFeedWithToken({
   apiToken,
   direction,
+  ecoSystem,
   filter,
-  outputJson,
+  outputKind,
   page,
   perPage
 }: {
   apiToken: string
-  outputJson: boolean
-  perPage: number
-  page: string
   direction: string
+  ecoSystem: string
   filter: string
+  outputKind: 'json' | 'markdown' | 'print'
+  page: string
+  perPage: number
 }): Promise<void> {
   // Lazily access constants.spinner.
   const { spinner } = constants
 
-  spinner.start('Looking up the threat feed')
+  const queryParams = new URLSearchParams([
+    ['direction', direction],
+    ['ecosystem', ecoSystem],
+    ['filter', filter],
+    ['page', page],
+    ['per_page', String(perPage)]
+  ])
 
-  const formattedQueryParams = formatQueryParams({
-    per_page: perPage,
-    page,
-    direction,
-    filter
-  }).join('&')
-  const response = await queryAPI(
-    `threat-feed?${formattedQueryParams}`,
-    apiToken
-  )
+  spinner.start('Fetching Threat Feed data...')
+
+  const response = await queryAPI(`threat-feed?${queryParams}`, apiToken)
   const data = <{ results: ThreatResult[]; nextPage: string }>(
     await response.json()
   )
 
-  spinner.stop()
+  spinner.stop('Threat feed data fetched')
 
-  if (outputJson) {
+  if (outputKind === 'json') {
     logger.log(data)
     return
   }
 
-  const screen = new ScreenWidget()
+  const screen: Widgets.Screen = new ScreenWidget()
 
-  const table = new TableWidget({
+  const table: any = new TableWidget({
     keys: 'true',
     fg: 'white',
     selectedFg: 'white',
@@ -72,37 +112,85 @@ export async function getThreatFeed({
     interactive: 'true',
     label: 'Threat feed',
     width: '100%',
-    height: '100%',
+    height: '70%', // Changed from 100% to 70%
     border: {
       type: 'line',
       fg: 'cyan'
     },
-    columnSpacing: 3, //in chars
-    columnWidth: [9, 30, 10, 17, 13, 100] /*in chars*/
+    columnWidth: [10, 30, 20, 18, 15, 200],
+    // TODO: the truncation doesn't seem to work too well yet but when we add
+    //       `pad` alignment fails, when we extend columnSpacing alignment fails
+    columnSpacing: 1,
+    truncate: '_'
+  })
+
+  // Create details box at the bottom
+  const detailsBox: Widgets.BoxElement = new BoxWidget({
+    bottom: 0,
+    height: '30%',
+    width: '100%',
+    border: {
+      type: 'line',
+      fg: 'cyan'
+    },
+    label: 'Details',
+    content:
+      'Use arrow keys to navigate. Press Enter to select a threat. Press q to exit.',
+    style: {
+      fg: 'white'
+    }
   })
 
   // allow control the table with the keyboard
   table.focus()
 
   screen.append(table)
+  screen.append(detailsBox)
 
   const formattedOutput = formatResults(data.results)
+  const descriptions = data.results.map(d => d.description)
 
   table.setData({
     headers: [
-      'Ecosystem',
-      'Name',
-      'Version',
-      'Threat type',
-      'Detected at',
-      'Details'
+      ' Ecosystem',
+      ' Name',
+      ' Version',
+      '  Threat type',
+      '  Detected at',
+      ' Details'
     ],
     data: formattedOutput
+  })
+
+  // Update details box when selection changes
+  table.rows.on('select item', () => {
+    const selectedIndex = table.rows.selected
+    if (selectedIndex !== undefined && selectedIndex >= 0) {
+      const selectedRow = formattedOutput[selectedIndex]
+      if (selectedRow) {
+        detailsBox.setContent(
+          `Ecosystem: ${selectedRow[0]}\n` +
+            `Name: ${selectedRow[1]}\n` +
+            `Version:${selectedRow[2]}\n` +
+            `Threat type:${selectedRow[3]}\n` +
+            `Detected at:${selectedRow[4]}\n` +
+            `Details: ${selectedRow[5]}\n` +
+            `Description: ${descriptions[selectedIndex]}`
+        )
+        screen.render()
+      }
+    }
   })
 
   screen.render()
 
   screen.key(['escape', 'q', 'C-c'], () => process.exit(0))
+  screen.key(['return'], () => {
+    const selectedIndex = table.rows.selected
+    screen.destroy()
+    const selectedRow = formattedOutput[selectedIndex]
+    console.log(selectedRow)
+  })
 }
 
 function formatResults(data: ThreatResult[]) {
@@ -111,34 +199,32 @@ function formatResults(data: ThreatResult[]) {
     const name = d.purl.split('/')[1]!.split('@')[0]!
     const version = d.purl.split('@')[1]!
 
-    const timeStart = new Date(d.createdAt).getMilliseconds()
-    const timeEnd = Date.now()
+    const timeDiff = msAtHome(d.createdAt)
 
-    const diff = getHourDiff(timeStart, timeEnd)
-    const hourDiff =
-      diff > 0
-        ? `${diff} hours ago`
-        : `${getMinDiff(timeStart, timeEnd)} minutes ago`
-
+    // Note: the spacing works around issues with the table; it refuses to pad!
     return [
       ecosystem,
       decodeURIComponent(name),
-      version,
-      d.threatType,
-      hourDiff,
+      ' ' + version,
+      ' ' + d.threatType,
+      ' ' + timeDiff,
       d.locationHtmlUrl
     ]
   })
 }
 
-function formatQueryParams(params: object) {
-  return Object.entries(params).map(entry => `${entry[0]}=${entry[1]}`)
-}
+function msAtHome(isoTimeStamp: string): string {
+  const timeStart = new Date(isoTimeStamp).getTime()
+  const timeEnd = Date.now()
 
-function getHourDiff(start: number, end: number) {
-  return Math.floor((end - start) / 3600000)
-}
-
-function getMinDiff(start: number, end: number) {
-  return Math.floor((end - start) / 60000)
+  const delta = timeEnd - timeStart
+  if (delta < 60 * 60 * 1000) {
+    return Math.round(delta / (60 * 1000)) + ' min ago'
+  } else if (delta < 24 * 60 * 60 * 1000) {
+    return (delta / (60 * 60 * 1000)).toFixed(1) + ' hr ago'
+  } else if (delta < 7 * 24 * 60 * 60 * 1000) {
+    return (delta / (24 * 60 * 60 * 1000)).toFixed(1) + ' day ago'
+  } else {
+    return isoTimeStamp.slice(0, 8)
+  }
 }

--- a/src/commands/threat-feed/get-threat-feed.ts
+++ b/src/commands/threat-feed/get-threat-feed.ts
@@ -154,7 +154,7 @@ async function getThreatFeedWithToken({
     headers: [
       ' Ecosystem',
       ' Name',
-      ' Version',
+      '  Version',
       '  Threat type',
       '  Detected at',
       ' Details'


### PR DESCRIPTION
This fixes the threat feed and improves the CLI side of things a bit;

- Fixes the queries (right now it defaulted to fetching zero entries...)
- Added an `ecoSystem` filter to only fetch reports for maven or npm or whatever
- Updated the help to explain the different filter options and what they mean
- Added a description box for the interactive table view; it will show the details for the highlighted row as well as the "description" verdict which explains why a package was flagged.
- Fixed date "ago" strings
- Tried to fix some UI glitches with column positioning. Mostly hacked around the table not properly calculating column widths for some cases, leading to a wrangled table view. In its current form it works and stuff is aligned, at least. We'll revisit this later.

Sample:
![image](https://github.com/user-attachments/assets/7edd5e27-80e7-40a0-b061-fa611f16cae1)

