### PR TITLE
Add note to Scala command

### DIFF
--- a/src/commands/manifest/cmd-manifest-scala.ts
+++ b/src/commands/manifest/cmd-manifest-scala.ts
@@ -78,6 +78,9 @@ const config: CliCommandConfig = {
 
     Support is beta. Please report issues or give us feedback on what's missing.
 
+    This is only for SBT. If your Scala setup uses gradle, please see the help
+    sections for \`socket manifest gradle\` or \`socket cdxgen\`.
+
     Examples
 
       $ ${command} ./build.sbt


### PR DESCRIPTION
The help section for `socket manifest scala` needs to have a note about the difference between `sbt` and `gradle`.

In the future the command should just try to detect either build systems. For now the note will have to suffice.