### PR TITLE
Enable ruby and .net ecosystems for scan

### DIFF
--- a/src/utils/path-resolve.ts
+++ b/src/utils/path-resolve.ts
@@ -27,7 +27,7 @@ async function filterGlobResultToSupportedFiles(
   entries: string[],
   supportedFiles: SocketSdkReturnType<'getReportSupportedFiles'>['data']
 ): Promise<string[]> {
-  const patterns = ['golang', NPM, 'maven', 'pypi'].reduce(
+  const patterns = ['golang', NPM, 'maven', 'pypi', 'gem', 'nuget'].reduce(
     (r: string[], n: string) => {
       const supported = supportedFiles[n]
       r.push(


### PR DESCRIPTION
This enables the glob for including ruby and dotnet files when doing a scan.

Closes ENG-3172