### PR TITLE
[scan report] Support markdown, cleanup, add tests

### DIFF
--- a/src/commands/scan/cmd-scan-report.ts
+++ b/src/commands/scan/cmd-scan-report.ts
@@ -134,7 +134,7 @@ async function run(
     orgSlug,
     fullScanId,
     includeLicensePolicy: false, // !!license,
-    includeSecurityPolicy: !!security,
+    includeSecurityPolicy: typeof security === 'boolean' ? security : true,
     outputKind: json ? 'json' : markdown ? 'markdown' : 'text',
     filePath: file,
     fold: fold as 'none' | 'file' | 'pkg' | 'version',

--- a/src/commands/scan/generate-report.test.ts
+++ b/src/commands/scan/generate-report.test.ts
@@ -8,6 +8,8 @@ import type { components } from '@socketsecurity/sdk/types/api'
 describe('generate-report', () => {
   it('should accept empty args', () => {
     const result = generateReport([], undefined, undefined, {
+      orgSlug: 'fakeorg',
+      scanId: 'scan-ai-dee',
       fold: 'none',
       reportLevel: 'warn'
     })
@@ -16,6 +18,12 @@ describe('generate-report', () => {
       {
         "alerts": Map {},
         "healthy": true,
+        "options": {
+          "fold": "none",
+          "reportLevel": "warn",
+        },
+        "orgSlug": "fakeorg",
+        "scanId": "scan-ai-dee",
       }
     `)
   })
@@ -38,17 +46,25 @@ describe('generate-report', () => {
             }
           } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
           {
+            orgSlug: 'fakeorg',
+            scanId: 'scan-ai-dee',
             fold: 'none',
             reportLevel: 'warn'
           }
         )
 
         expect(result).toMatchInlineSnapshot(`
-      {
-        "alerts": Map {},
-        "healthy": true,
-      }
-    `)
+          {
+            "alerts": Map {},
+            "healthy": true,
+            "options": {
+              "fold": "none",
+              "reportLevel": "warn",
+            },
+            "orgSlug": "fakeorg",
+            "scanId": "scan-ai-dee",
+          }
+        `)
         expect(result.healthy).toBe(true)
         expect(result.alerts.size).toBe(0)
       })
@@ -69,6 +85,8 @@ describe('generate-report', () => {
             }
           } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
           {
+            orgSlug: 'fakeorg',
+            scanId: 'scan-ai-dee',
             fold: 'none',
             reportLevel: 'warn'
           }
@@ -81,14 +99,34 @@ describe('generate-report', () => {
                 "tslib" => Map {
                   "1.14.1" => Map {
                     "package/which.js" => Map {
-                      "envVars at 54:72" => "error",
-                      "envVars at 200:250" => "error",
+                      "envVars at 54:72" => {
+                        "manifest": [
+                          "package-lock.json",
+                        ],
+                        "policy": "error",
+                        "type": "envVars",
+                        "url": "https://socket.dev/npm/package/tslib/1.14.1",
+                      },
+                      "envVars at 200:250" => {
+                        "manifest": [
+                          "package-lock.json",
+                        ],
+                        "policy": "error",
+                        "type": "envVars",
+                        "url": "https://socket.dev/npm/package/tslib/1.14.1",
+                      },
                     },
                   },
                 },
               },
             },
             "healthy": false,
+            "options": {
+              "fold": "none",
+              "reportLevel": "warn",
+            },
+            "orgSlug": "fakeorg",
+            "scanId": "scan-ai-dee",
           }
         `)
         expect(result.healthy).toBe(false)
@@ -111,6 +149,8 @@ describe('generate-report', () => {
             }
           } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
           {
+            orgSlug: 'fakeorg',
+            scanId: 'scan-ai-dee',
             fold: 'none',
             reportLevel: 'warn'
           }
@@ -123,14 +163,34 @@ describe('generate-report', () => {
                 "tslib" => Map {
                   "1.14.1" => Map {
                     "package/which.js" => Map {
-                      "envVars at 54:72" => "warn",
-                      "envVars at 200:250" => "warn",
+                      "envVars at 54:72" => {
+                        "manifest": [
+                          "package-lock.json",
+                        ],
+                        "policy": "warn",
+                        "type": "envVars",
+                        "url": "https://socket.dev/npm/package/tslib/1.14.1",
+                      },
+                      "envVars at 200:250" => {
+                        "manifest": [
+                          "package-lock.json",
+                        ],
+                        "policy": "warn",
+                        "type": "envVars",
+                        "url": "https://socket.dev/npm/package/tslib/1.14.1",
+                      },
                     },
                   },
                 },
               },
             },
             "healthy": true,
+            "options": {
+              "fold": "none",
+              "reportLevel": "warn",
+            },
+            "orgSlug": "fakeorg",
+            "scanId": "scan-ai-dee",
           }
         `)
         expect(result.healthy).toBe(true)
@@ -153,17 +213,25 @@ describe('generate-report', () => {
             }
           } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
           {
+            orgSlug: 'fakeorg',
+            scanId: 'scan-ai-dee',
             fold: 'none',
             reportLevel: 'warn'
           }
         )
 
         expect(result).toMatchInlineSnapshot(`
-      {
-        "alerts": Map {},
-        "healthy": true,
-      }
-    `)
+          {
+            "alerts": Map {},
+            "healthy": true,
+            "options": {
+              "fold": "none",
+              "reportLevel": "warn",
+            },
+            "orgSlug": "fakeorg",
+            "scanId": "scan-ai-dee",
+          }
+        `)
         expect(result.healthy).toBe(true)
         expect(result.alerts.size).toBe(0)
       })
@@ -184,17 +252,25 @@ describe('generate-report', () => {
             }
           } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
           {
+            orgSlug: 'fakeorg',
+            scanId: 'scan-ai-dee',
             fold: 'none',
             reportLevel: 'warn'
           }
         )
 
         expect(result).toMatchInlineSnapshot(`
-      {
-        "alerts": Map {},
-        "healthy": true,
-      }
-    `)
+          {
+            "alerts": Map {},
+            "healthy": true,
+            "options": {
+              "fold": "none",
+              "reportLevel": "warn",
+            },
+            "orgSlug": "fakeorg",
+            "scanId": "scan-ai-dee",
+          }
+        `)
         expect(result.healthy).toBe(true)
         expect(result.alerts.size).toBe(0)
       })
@@ -215,17 +291,25 @@ describe('generate-report', () => {
             }
           } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
           {
+            orgSlug: 'fakeorg',
+            scanId: 'scan-ai-dee',
             fold: 'none',
             reportLevel: 'warn'
           }
         )
 
         expect(result).toMatchInlineSnapshot(`
-      {
-        "alerts": Map {},
-        "healthy": true,
-      }
-    `)
+          {
+            "alerts": Map {},
+            "healthy": true,
+            "options": {
+              "fold": "none",
+              "reportLevel": "warn",
+            },
+            "orgSlug": "fakeorg",
+            "scanId": "scan-ai-dee",
+          }
+        `)
         expect(result.healthy).toBe(true)
         expect(result.alerts.size).toBe(0)
       })
@@ -244,17 +328,25 @@ describe('generate-report', () => {
             }
           } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
           {
+            orgSlug: 'fakeorg',
+            scanId: 'scan-ai-dee',
             fold: 'none',
             reportLevel: 'warn'
           }
         )
 
         expect(result).toMatchInlineSnapshot(`
-      {
-        "alerts": Map {},
-        "healthy": true,
-      }
-    `)
+          {
+            "alerts": Map {},
+            "healthy": true,
+            "options": {
+              "fold": "none",
+              "reportLevel": "warn",
+            },
+            "orgSlug": "fakeorg",
+            "scanId": "scan-ai-dee",
+          }
+        `)
         expect(result.healthy).toBe(true)
         expect(result.alerts.size).toBe(0)
       })
@@ -271,17 +363,25 @@ describe('generate-report', () => {
             }
           } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
           {
+            orgSlug: 'fakeorg',
+            scanId: 'scan-ai-dee',
             fold: 'none',
             reportLevel: 'warn'
           }
         )
 
         expect(result).toMatchInlineSnapshot(`
-      {
-        "alerts": Map {},
-        "healthy": true,
-      }
-    `)
+          {
+            "alerts": Map {},
+            "healthy": true,
+            "options": {
+              "fold": "none",
+              "reportLevel": "warn",
+            },
+            "orgSlug": "fakeorg",
+            "scanId": "scan-ai-dee",
+          }
+        `)
         expect(result.healthy).toBe(true)
         expect(result.alerts.size).toBe(0)
       })
@@ -304,17 +404,25 @@ describe('generate-report', () => {
             }
           } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
           {
+            orgSlug: 'fakeorg',
+            scanId: 'scan-ai-dee',
             fold: 'none',
             reportLevel: 'ignore'
           }
         )
 
         expect(result).toMatchInlineSnapshot(`
-      {
-        "alerts": Map {},
-        "healthy": true,
-      }
-    `)
+          {
+            "alerts": Map {},
+            "healthy": true,
+            "options": {
+              "fold": "none",
+              "reportLevel": "ignore",
+            },
+            "orgSlug": "fakeorg",
+            "scanId": "scan-ai-dee",
+          }
+        `)
         expect(result.healthy).toBe(true)
         expect(result.alerts.size).toBe(0)
       })
@@ -335,6 +443,8 @@ describe('generate-report', () => {
             }
           } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
           {
+            orgSlug: 'fakeorg',
+            scanId: 'scan-ai-dee',
             fold: 'none',
             reportLevel: 'ignore'
           }
@@ -347,14 +457,34 @@ describe('generate-report', () => {
                 "tslib" => Map {
                   "1.14.1" => Map {
                     "package/which.js" => Map {
-                      "envVars at 54:72" => "error",
-                      "envVars at 200:250" => "error",
+                      "envVars at 54:72" => {
+                        "manifest": [
+                          "package-lock.json",
+                        ],
+                        "policy": "error",
+                        "type": "envVars",
+                        "url": "https://socket.dev/npm/package/tslib/1.14.1",
+                      },
+                      "envVars at 200:250" => {
+                        "manifest": [
+                          "package-lock.json",
+                        ],
+                        "policy": "error",
+                        "type": "envVars",
+                        "url": "https://socket.dev/npm/package/tslib/1.14.1",
+                      },
                     },
                   },
                 },
               },
             },
             "healthy": false,
+            "options": {
+              "fold": "none",
+              "reportLevel": "ignore",
+            },
+            "orgSlug": "fakeorg",
+            "scanId": "scan-ai-dee",
           }
         `)
         expect(result.healthy).toBe(false)
@@ -377,6 +507,8 @@ describe('generate-report', () => {
             }
           } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
           {
+            orgSlug: 'fakeorg',
+            scanId: 'scan-ai-dee',
             fold: 'none',
             reportLevel: 'ignore'
           }
@@ -389,14 +521,34 @@ describe('generate-report', () => {
                 "tslib" => Map {
                   "1.14.1" => Map {
                     "package/which.js" => Map {
-                      "envVars at 54:72" => "warn",
-                      "envVars at 200:250" => "warn",
+                      "envVars at 54:72" => {
+                        "manifest": [
+                          "package-lock.json",
+                        ],
+                        "policy": "warn",
+                        "type": "envVars",
+                        "url": "https://socket.dev/npm/package/tslib/1.14.1",
+                      },
+                      "envVars at 200:250" => {
+                        "manifest": [
+                          "package-lock.json",
+                        ],
+                        "policy": "warn",
+                        "type": "envVars",
+                        "url": "https://socket.dev/npm/package/tslib/1.14.1",
+                      },
                     },
                   },
                 },
               },
             },
             "healthy": true,
+            "options": {
+              "fold": "none",
+              "reportLevel": "ignore",
+            },
+            "orgSlug": "fakeorg",
+            "scanId": "scan-ai-dee",
           }
         `)
         expect(result.healthy).toBe(true)
@@ -419,6 +571,8 @@ describe('generate-report', () => {
             }
           } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
           {
+            orgSlug: 'fakeorg',
+            scanId: 'scan-ai-dee',
             fold: 'none',
             reportLevel: 'ignore'
           }
@@ -431,14 +585,34 @@ describe('generate-report', () => {
                 "tslib" => Map {
                   "1.14.1" => Map {
                     "package/which.js" => Map {
-                      "envVars at 54:72" => "monitor",
-                      "envVars at 200:250" => "monitor",
+                      "envVars at 54:72" => {
+                        "manifest": [
+                          "package-lock.json",
+                        ],
+                        "policy": "monitor",
+                        "type": "envVars",
+                        "url": "https://socket.dev/npm/package/tslib/1.14.1",
+                      },
+                      "envVars at 200:250" => {
+                        "manifest": [
+                          "package-lock.json",
+                        ],
+                        "policy": "monitor",
+                        "type": "envVars",
+                        "url": "https://socket.dev/npm/package/tslib/1.14.1",
+                      },
                     },
                   },
                 },
               },
             },
             "healthy": true,
+            "options": {
+              "fold": "none",
+              "reportLevel": "ignore",
+            },
+            "orgSlug": "fakeorg",
+            "scanId": "scan-ai-dee",
           }
         `)
         expect(result.healthy).toBe(true)
@@ -461,6 +635,8 @@ describe('generate-report', () => {
             }
           } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
           {
+            orgSlug: 'fakeorg',
+            scanId: 'scan-ai-dee',
             fold: 'none',
             reportLevel: 'ignore'
           }
@@ -473,14 +649,34 @@ describe('generate-report', () => {
                 "tslib" => Map {
                   "1.14.1" => Map {
                     "package/which.js" => Map {
-                      "envVars at 54:72" => "ignore",
-                      "envVars at 200:250" => "ignore",
+                      "envVars at 54:72" => {
+                        "manifest": [
+                          "package-lock.json",
+                        ],
+                        "policy": "ignore",
+                        "type": "envVars",
+                        "url": "https://socket.dev/npm/package/tslib/1.14.1",
+                      },
+                      "envVars at 200:250" => {
+                        "manifest": [
+                          "package-lock.json",
+                        ],
+                        "policy": "ignore",
+                        "type": "envVars",
+                        "url": "https://socket.dev/npm/package/tslib/1.14.1",
+                      },
                     },
                   },
                 },
               },
             },
             "healthy": true,
+            "options": {
+              "fold": "none",
+              "reportLevel": "ignore",
+            },
+            "orgSlug": "fakeorg",
+            "scanId": "scan-ai-dee",
           }
         `)
         expect(result.healthy).toBe(true)
@@ -503,17 +699,25 @@ describe('generate-report', () => {
             }
           } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
           {
+            orgSlug: 'fakeorg',
+            scanId: 'scan-ai-dee',
             fold: 'none',
             reportLevel: 'ignore'
           }
         )
 
         expect(result).toMatchInlineSnapshot(`
-      {
-        "alerts": Map {},
-        "healthy": true,
-      }
-    `)
+          {
+            "alerts": Map {},
+            "healthy": true,
+            "options": {
+              "fold": "none",
+              "reportLevel": "ignore",
+            },
+            "orgSlug": "fakeorg",
+            "scanId": "scan-ai-dee",
+          }
+        `)
         expect(result.healthy).toBe(true)
         expect(result.alerts.size).toBe(0)
       })
@@ -532,17 +736,25 @@ describe('generate-report', () => {
             }
           } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
           {
+            orgSlug: 'fakeorg',
+            scanId: 'scan-ai-dee',
             fold: 'none',
             reportLevel: 'ignore'
           }
         )
 
         expect(result).toMatchInlineSnapshot(`
-      {
-        "alerts": Map {},
-        "healthy": true,
-      }
-    `)
+          {
+            "alerts": Map {},
+            "healthy": true,
+            "options": {
+              "fold": "none",
+              "reportLevel": "ignore",
+            },
+            "orgSlug": "fakeorg",
+            "scanId": "scan-ai-dee",
+          }
+        `)
         expect(result.healthy).toBe(true)
         expect(result.alerts.size).toBe(0)
       })
@@ -559,17 +771,25 @@ describe('generate-report', () => {
             }
           } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
           {
+            orgSlug: 'fakeorg',
+            scanId: 'scan-ai-dee',
             fold: 'none',
             reportLevel: 'ignore'
           }
         )
 
         expect(result).toMatchInlineSnapshot(`
-      {
-        "alerts": Map {},
-        "healthy": true,
-      }
-    `)
+          {
+            "alerts": Map {},
+            "healthy": true,
+            "options": {
+              "fold": "none",
+              "reportLevel": "ignore",
+            },
+            "orgSlug": "fakeorg",
+            "scanId": "scan-ai-dee",
+          }
+        `)
         expect(result.healthy).toBe(true)
         expect(result.alerts.size).toBe(0)
       })
@@ -593,6 +813,8 @@ describe('generate-report', () => {
           }
         } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
         {
+          orgSlug: 'fakeorg',
+          scanId: 'scan-ai-dee',
           fold: 'none',
           reportLevel: 'warn'
         }
@@ -605,14 +827,34 @@ describe('generate-report', () => {
               "tslib" => Map {
                 "1.14.1" => Map {
                   "package/which.js" => Map {
-                    "envVars at 54:72" => "error",
-                    "envVars at 200:250" => "error",
+                    "envVars at 54:72" => {
+                      "manifest": [
+                        "package-lock.json",
+                      ],
+                      "policy": "error",
+                      "type": "envVars",
+                      "url": "https://socket.dev/npm/package/tslib/1.14.1",
+                    },
+                    "envVars at 200:250" => {
+                      "manifest": [
+                        "package-lock.json",
+                      ],
+                      "policy": "error",
+                      "type": "envVars",
+                      "url": "https://socket.dev/npm/package/tslib/1.14.1",
+                    },
                   },
                 },
               },
             },
           },
           "healthy": false,
+          "options": {
+            "fold": "none",
+            "reportLevel": "warn",
+          },
+          "orgSlug": "fakeorg",
+          "scanId": "scan-ai-dee",
         }
       `)
     })
@@ -633,6 +875,8 @@ describe('generate-report', () => {
           }
         } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
         {
+          orgSlug: 'fakeorg',
+          scanId: 'scan-ai-dee',
           fold: 'file',
           reportLevel: 'warn'
         }
@@ -644,12 +888,25 @@ describe('generate-report', () => {
             "npm" => Map {
               "tslib" => Map {
                 "1.14.1" => Map {
-                  "package/which.js" => "error",
+                  "package/which.js" => {
+                    "manifest": [
+                      "package-lock.json",
+                    ],
+                    "policy": "error",
+                    "type": "envVars",
+                    "url": "https://socket.dev/npm/package/tslib/1.14.1",
+                  },
                 },
               },
             },
           },
           "healthy": false,
+          "options": {
+            "fold": "file",
+            "reportLevel": "warn",
+          },
+          "orgSlug": "fakeorg",
+          "scanId": "scan-ai-dee",
         }
       `)
     })
@@ -670,6 +927,8 @@ describe('generate-report', () => {
           }
         } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
         {
+          orgSlug: 'fakeorg',
+          scanId: 'scan-ai-dee',
           fold: 'version',
           reportLevel: 'warn'
         }
@@ -680,11 +939,24 @@ describe('generate-report', () => {
           "alerts": Map {
             "npm" => Map {
               "tslib" => Map {
-                "1.14.1" => "error",
+                "1.14.1" => {
+                  "manifest": [
+                    "package-lock.json",
+                  ],
+                  "policy": "error",
+                  "type": "envVars",
+                  "url": "https://socket.dev/npm/package/tslib/1.14.1",
+                },
               },
             },
           },
           "healthy": false,
+          "options": {
+            "fold": "version",
+            "reportLevel": "warn",
+          },
+          "orgSlug": "fakeorg",
+          "scanId": "scan-ai-dee",
         }
       `)
     })
@@ -705,6 +977,8 @@ describe('generate-report', () => {
           }
         } as SocketSdkReturnType<'getOrgSecurityPolicy'>,
         {
+          orgSlug: 'fakeorg',
+          scanId: 'scan-ai-dee',
           fold: 'pkg',
           reportLevel: 'warn'
         }
@@ -714,10 +988,23 @@ describe('generate-report', () => {
         {
           "alerts": Map {
             "npm" => Map {
-              "tslib" => "error",
+              "tslib" => {
+                "manifest": [
+                  "package-lock.json",
+                ],
+                "policy": "error",
+                "type": "envVars",
+                "url": "https://socket.dev/npm/package/tslib/1.14.1",
+              },
             },
           },
           "healthy": false,
+          "options": {
+            "fold": "pkg",
+            "reportLevel": "warn",
+          },
+          "orgSlug": "fakeorg",
+          "scanId": "scan-ai-dee",
         }
       `)
     })

--- a/src/commands/scan/report-full-scan.test.ts
+++ b/src/commands/scan/report-full-scan.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest'
+
+import { toJsonReport, toMarkdownReport } from './report-full-scan'
+
+import type { ScanReport } from './generate-report'
+
+describe('report-full-scan', () => {
+  describe('toJsonReport', () => {
+    it('should be able to generate a healthy json report', () => {
+      expect(toJsonReport(getHealthyReport())).toMatchInlineSnapshot(`
+        "{
+          "alerts": {},
+          "healthy": true,
+          "options": {
+            "fold": "none",
+            "reportLevel": "warn"
+          },
+          "orgSlug": "fakeorg",
+          "scanId": "scan-ai-dee"
+        }"
+      `)
+    })
+
+    it('should be able to generate an unhealthy json report', () => {
+      expect(toJsonReport(getUnhealthyReport())).toMatchInlineSnapshot(`
+        "{
+          "alerts": {
+            "npm": {
+              "tslib": {
+                "1.14.1": {
+                  "package/which.js": {
+                    "envVars at 54:72": {
+                      "manifest": [
+                        "package-lock.json"
+                      ],
+                      "policy": "error",
+                      "type": "envVars",
+                      "url": "https://socket.dev/npm/package/tslib/1.14.1"
+                    },
+                    "envVars at 200:250": {
+                      "manifest": [
+                        "package-lock.json"
+                      ],
+                      "policy": "error",
+                      "type": "envVars",
+                      "url": "https://socket.dev/npm/package/tslib/1.14.1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "healthy": false,
+          "options": {
+            "fold": "none",
+            "reportLevel": "warn"
+          },
+          "orgSlug": "fakeorg",
+          "scanId": "scan-ai-dee"
+        }"
+      `)
+    })
+  })
+
+  describe('toJsonReport', () => {
+    it('should be able to generate a healthy md report', () => {
+      expect(toMarkdownReport(getHealthyReport())).toMatchInlineSnapshot(`
+        "# Scan Policy Report
+
+        This report tells you whether the results of a Socket scan results violate the
+        security or license policy set by your organization.
+
+        ## Health status
+
+        The scan *PASSES* all requirements set by your security and license policy.
+
+        ## Settings
+
+        Configuration used to generate this report:
+
+        - Organization: fakeorg
+        - Scan ID: scan-ai-dee
+        - Alert folding: none
+        - Minimal policy level for alert to be included in report: warn
+
+        ## Alerts
+
+        The scan contained no alerts for with a policy set to at least "warn".
+        "
+      `)
+    })
+
+    it('should be able to generate an unhealthy md report', () => {
+      expect(toMarkdownReport(getUnhealthyReport())).toMatchInlineSnapshot(`
+        "# Scan Policy Report
+
+        This report tells you whether the results of a Socket scan results violate the
+        security or license policy set by your organization.
+
+        ## Health status
+
+        The scan *VIOLATES* one or more policies set to the "error" level.
+
+        ## Settings
+
+        Configuration used to generate this report:
+
+        - Organization: fakeorg
+        - Scan ID: scan-ai-dee
+        - Alert folding: none
+        - Minimal policy level for alert to be included in report: warn
+
+        ## Alerts
+
+        All the alerts from the scan with a policy set to at least "warn"}.
+
+        | ------ | ---------- | ------- | ------------- | ------------------------------------------- | ----------------- |
+        | Policy | Alert Type | Package | Introduced by | url                                         | Manifest file     |
+        | ------ | ---------- | ------- | ------------- | ------------------------------------------- | ----------------- |
+        | error  | envVars    | tslib   | 1.14.1        | https://socket.dev/npm/package/tslib/1.14.1 | package-lock.json |
+        | error  | envVars    | tslib   | 1.14.1        | https://socket.dev/npm/package/tslib/1.14.1 | package-lock.json |
+        | ------ | ---------- | ------- | ------------- | ------------------------------------------- | ----------------- |
+        "
+      `)
+    })
+  })
+})
+
+function getHealthyReport(): ScanReport {
+  return {
+    alerts: new Map(),
+    healthy: true,
+    options: {
+      fold: 'none',
+      reportLevel: 'warn'
+    },
+    orgSlug: 'fakeorg',
+    scanId: 'scan-ai-dee'
+  }
+}
+
+function getUnhealthyReport(): ScanReport {
+  return {
+    alerts: new Map([
+      [
+        'npm',
+        new Map([
+          [
+            'tslib',
+            new Map([
+              [
+                '1.14.1',
+                new Map([
+                  [
+                    'package/which.js',
+                    new Map([
+                      [
+                        'envVars at 54:72',
+                        {
+                          manifest: ['package-lock.json'],
+                          policy: 'error' as const,
+                          type: 'envVars',
+                          url: 'https://socket.dev/npm/package/tslib/1.14.1'
+                        }
+                      ],
+                      [
+                        'envVars at 200:250',
+                        {
+                          manifest: ['package-lock.json'],
+                          policy: 'error' as const,
+                          type: 'envVars',
+                          url: 'https://socket.dev/npm/package/tslib/1.14.1'
+                        }
+                      ]
+                    ])
+                  ]
+                ])
+              ]
+            ])
+          ]
+        ])
+      ]
+    ]),
+    healthy: false,
+    options: {
+      fold: 'none',
+      reportLevel: 'warn'
+    },
+    orgSlug: 'fakeorg',
+    scanId: 'scan-ai-dee'
+  }
+}

--- a/src/commands/scan/report-full-scan.ts
+++ b/src/commands/scan/report-full-scan.ts
@@ -5,6 +5,10 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { fetchReportData } from './fetch-report-data'
 import { generateReport } from './generate-report'
 import { mapToObject } from '../../utils/map-to-object'
+import { mdTable } from '../../utils/markdown'
+import { walkNestedMap } from '../../utils/walk-nested-map'
+
+import type { ReportLeafNode, ScanReport } from './generate-report'
 
 export async function reportFullScan({
   filePath,
@@ -47,30 +51,34 @@ export async function reportFullScan({
   } = await fetchReportData(
     orgSlug,
     fullScanId,
-    includeLicensePolicy
-    // includeSecurityPolicy
+    // includeLicensePolicy
+    includeSecurityPolicy
   )
 
   if (!ok) {
     return
   }
 
-  const report = generateReport(
+  const scanReport = generateReport(
     scan,
     undefined, // licensePolicy,
     securityPolicy,
     {
+      orgSlug,
+      scanId: fullScanId,
       fold,
       reportLevel
     }
   )
 
-  if (outputKind === 'json') {
-    const obj = mapToObject(report.alerts)
-
-    const json = JSON.stringify(obj, null, 2)
+  if (
+    outputKind === 'json' ||
+    (outputKind === 'text' && filePath && filePath.endsWith('.json'))
+  ) {
+    const json = toJsonReport(scanReport)
 
     if (filePath && filePath !== '-') {
+      logger.log('Writing json report to', filePath)
       return await fs.writeFile(filePath, json)
     }
 
@@ -78,5 +86,96 @@ export async function reportFullScan({
     return
   }
 
-  logger.dir(report, { depth: null })
+  if (outputKind === 'markdown' || (filePath && filePath.endsWith('.md'))) {
+    const md = toMarkdownReport(scanReport)
+
+    if (filePath && filePath !== '-') {
+      logger.log('Writing markdown report to', filePath)
+      return await fs.writeFile(filePath, md)
+    }
+
+    logger.log(md)
+    return
+  }
+
+  logger.dir(scanReport, { depth: null })
+}
+
+export function toJsonReport(report: ScanReport): string {
+  const obj = mapToObject(report.alerts)
+
+  const json = JSON.stringify(
+    {
+      ...report,
+      alerts: obj
+    },
+    null,
+    2
+  )
+
+  return json
+}
+
+export function toMarkdownReport(report: ScanReport): string {
+  const flatData = Array.from(walkNestedMap(report.alerts)).map(
+    ({ keys, value }: { keys: string[]; value: ReportLeafNode }) => {
+      const { manifest, policy, type, url } = value
+      return {
+        'Alert Type': type,
+        Package: keys[1] || '<unknown>',
+        'Introduced by': keys[2] || '<unknown>',
+        url,
+        'Manifest file': manifest.join(', '),
+        Policy: policy
+      }
+    }
+  )
+
+  const md =
+    `
+# Scan Policy Report
+
+This report tells you whether the results of a Socket scan results violate the
+security or license policy set by your organization.
+
+## Health status
+
+${
+  report.healthy
+    ? 'The scan *PASSES* all requirements set by your security and license policy.'
+    : 'The scan *VIOLATES* one or more policies set to the "error" level.'
+}
+
+## Settings
+
+Configuration used to generate this report:
+
+- Organization: ${report.orgSlug}
+- Scan ID: ${report.scanId}
+- Alert folding: ${report.options.fold === 'none' ? 'none' : `up to ${report.options.fold}`}
+- Minimal policy level for alert to be included in report: ${report.options.reportLevel === 'defer' ? 'everything' : report.options.reportLevel}
+
+## Alerts
+
+${
+  report.alerts.size
+    ? `All the alerts from the scan with a policy set to at least "${report.options.reportLevel}"}.`
+    : `The scan contained no alerts for with a policy set to at least "${report.options.reportLevel}".`
+}
+
+${
+  !report.alerts.size
+    ? ''
+    : mdTable(flatData, [
+        'Policy',
+        'Alert Type',
+        'Package',
+        'Introduced by',
+        'url',
+        'Manifest file'
+      ])
+}
+  `.trim() + '\n'
+
+  return md
 }

--- a/src/utils/walk-nested-map.test.ts
+++ b/src/utils/walk-nested-map.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest'
+
+import { walkNestedMap } from './walk-nested-map'
+
+describe('walkNestedMap', () => {
+  it('should walk a flat map', () => {
+    expect(
+      Array.from(
+        walkNestedMap(
+          new Map([
+            ['x', 1],
+            ['y', 2],
+            ['z', 3]
+          ])
+        )
+      )
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "keys": [
+            "x",
+          ],
+          "value": 1,
+        },
+        {
+          "keys": [
+            "y",
+          ],
+          "value": 2,
+        },
+        {
+          "keys": [
+            "z",
+          ],
+          "value": 3,
+        },
+      ]
+    `)
+  })
+
+  it('should walk a 2d map', () => {
+    expect(
+      Array.from(
+        walkNestedMap(
+          new Map([
+            [
+              'x',
+              new Map([
+                ['x2', 1],
+                ['y2', 2],
+                ['z2', 3]
+              ])
+            ],
+            [
+              'y',
+              new Map([
+                ['x3', 1],
+                ['y3', 2],
+                ['z3', 3]
+              ])
+            ]
+          ])
+        )
+      )
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "keys": [
+            "x",
+            "x2",
+          ],
+          "value": 1,
+        },
+        {
+          "keys": [
+            "x",
+            "y2",
+          ],
+          "value": 2,
+        },
+        {
+          "keys": [
+            "x",
+            "z2",
+          ],
+          "value": 3,
+        },
+        {
+          "keys": [
+            "y",
+            "x3",
+          ],
+          "value": 1,
+        },
+        {
+          "keys": [
+            "y",
+            "y3",
+          ],
+          "value": 2,
+        },
+        {
+          "keys": [
+            "y",
+            "z3",
+          ],
+          "value": 3,
+        },
+      ]
+    `)
+  })
+
+  it('should walk a 3d map', () => {
+    expect(
+      Array.from(
+        walkNestedMap(
+          new Map([
+            [
+              'a',
+              new Map([
+                [
+                  'x',
+                  new Map([
+                    ['x2', 1],
+                    ['y2', 2],
+                    ['z2', 3]
+                  ])
+                ],
+                [
+                  'y',
+                  new Map([
+                    ['x3', 1],
+                    ['y3', 2],
+                    ['z3', 3]
+                  ])
+                ]
+              ])
+            ],
+            [
+              'b',
+              new Map([
+                [
+                  'x',
+                  new Map([
+                    ['x2', 1],
+                    ['y2', 2],
+                    ['z2', 3]
+                  ])
+                ],
+                [
+                  'y',
+                  new Map([
+                    ['x3', 1],
+                    ['y3', 2],
+                    ['z3', 3]
+                  ])
+                ]
+              ])
+            ]
+          ])
+        )
+      )
+        // Makes test easier to read...
+        .map(obj => JSON.stringify(obj))
+    ).toMatchInlineSnapshot(`
+      [
+        "{"keys":["a","x","x2"],"value":1}",
+        "{"keys":["a","x","y2"],"value":2}",
+        "{"keys":["a","x","z2"],"value":3}",
+        "{"keys":["a","y","x3"],"value":1}",
+        "{"keys":["a","y","y3"],"value":2}",
+        "{"keys":["a","y","z3"],"value":3}",
+        "{"keys":["b","x","x2"],"value":1}",
+        "{"keys":["b","x","y2"],"value":2}",
+        "{"keys":["b","x","z2"],"value":3}",
+        "{"keys":["b","y","x3"],"value":1}",
+        "{"keys":["b","y","y3"],"value":2}",
+        "{"keys":["b","y","z3"],"value":3}",
+      ]
+    `)
+  })
+})

--- a/src/utils/walk-nested-map.ts
+++ b/src/utils/walk-nested-map.ts
@@ -1,0 +1,14 @@
+type NestedMap<T> = Map<string, T | NestedMap<T>>
+
+export function* walkNestedMap<T>(
+  map: NestedMap<T>,
+  keys: string[] = []
+): Generator<{ keys: string[]; value: T }> {
+  for (const [_key, value] of map.entries()) {
+    if (value instanceof Map) {
+      yield* walkNestedMap(value as NestedMap<T>, keys.concat(_key))
+    } else {
+      yield { keys, value: value }
+    }
+  }
+}

--- a/src/utils/walk-nested-map.ts
+++ b/src/utils/walk-nested-map.ts
@@ -4,11 +4,11 @@ export function* walkNestedMap<T>(
   map: NestedMap<T>,
   keys: string[] = []
 ): Generator<{ keys: string[]; value: T }> {
-  for (const [_key, value] of map.entries()) {
+  for (const [key, value] of map.entries()) {
     if (value instanceof Map) {
-      yield* walkNestedMap(value as NestedMap<T>, keys.concat(_key))
+      yield* walkNestedMap(value as NestedMap<T>, keys.concat(key))
     } else {
-      yield { keys, value: value }
+      yield { keys: keys.concat(key), value: value }
     }
   }
 }


### PR DESCRIPTION
Main purpose of this PR is to add `--markdown` support to `socket scan report`. See tests for example what that looks like.

Stuff was abstracted and cleaned up, too. Tests were added.

The json report now includes the org slug, the scan id, and the fold/reportlevel settings used to generate the report.