### PR TITLE
Increase test timeout to 30s to please the CI flakiness

### DIFF
--- a/test/utils.ts
+++ b/test/utils.ts
@@ -24,7 +24,7 @@ export function cmdit(
   it(
     `${title}: \`${cmd.join(' ')}\``,
     {
-      timeout: 10_000,
+      timeout: 30_000,
       ...options
     },
     cb.bind(null, cmd)


### PR DESCRIPTION
Sometimes 10s just isn't enough to sip your coffee and eat your lunch and finish tests that should take 2s and read the newspaper.