### PR TITLE
[scan report] Add --short flag for CI type of use cases

### DIFF
--- a/src/commands/scan/cmd-scan-report.test.ts
+++ b/src/commands/scan/cmd-scan-report.test.ts
@@ -28,6 +28,7 @@ describe('socket scan report', async () => {
           --markdown        Output result as markdown
           --reportLevel     Which policy level alerts should be reported
           --security        Report the security policy status. Default: true
+          --short           Report only the healthy status
 
         This consumes 1 quota unit plus 1 for each of the requested policy types.
 
@@ -42,6 +43,8 @@ describe('socket scan report', async () => {
 
         By default only the warn and error policy level alerts are reported. You can
         override this and request more ('defer' < 'ignore' < 'monitor' < 'warn' < 'error')
+
+        Short responses: JSON: \`{healthy:bool}\`, markdown: \`healthy = bool\`, text: \`OK/ERR\`
 
         Examples
           $ socket scan report FakeOrg 000aaaa1-0000-0a0a-00a0-00a0000000a0 --json --fold=version"

--- a/src/commands/scan/cmd-scan-report.ts
+++ b/src/commands/scan/cmd-scan-report.ts
@@ -34,6 +34,11 @@ const config: CliCommandConfig = {
       default: 'warn',
       description: 'Which policy level alerts should be reported'
     },
+    short: {
+      type: 'boolean',
+      default: false,
+      description: 'Report only the healthy status'
+    },
     // license: {
     //   type: 'boolean',
     //   default: true,
@@ -65,6 +70,8 @@ const config: CliCommandConfig = {
 
     By default only the warn and error policy level alerts are reported. You can
     override this and request more ('defer' < 'ignore' < 'monitor' < 'warn' < 'error')
+
+    Short responses: JSON: \`{healthy:bool}\`, markdown: \`healthy = bool\`, text: \`OK/ERR\`
 
     Examples
       $ ${command} FakeOrg 000aaaa1-0000-0a0a-00a0-00a0000000a0 --json --fold=version
@@ -138,6 +145,7 @@ async function run(
     outputKind: json ? 'json' : markdown ? 'markdown' : 'text',
     filePath: file,
     fold: fold as 'none' | 'file' | 'pkg' | 'version',
+    short: !!cli.flags['short'],
     reportLevel: reportLevel as
       | 'warn'
       | 'error'


### PR DESCRIPTION
Adds a --short flag to `socket scan report` to have brief outputs intended for CI/automated usages. Will report OK/ERR by default, `{healthy:boolean}` for JSON, and `healthy = boolean` in markdown modes.

Also made exit code reflect `healthy:false` state (regardless of output mode).