### PR TITLE
Refactor package filename to handle-* fetch-* and output-*

### DIFF
--- a/src/commands/package/cmd-package-shallow.ts
+++ b/src/commands/package/cmd-package-shallow.ts
@@ -2,8 +2,8 @@ import colors from 'yoctocolors-cjs'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import { handlePurlsShallowScore } from './handle-purls-shallow-score'
 import { parsePackageSpecifiers } from './parse-package-specifiers'
-import { showPurlInfo } from './show-purl-info'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
@@ -103,7 +103,7 @@ async function run(
     return
   }
 
-  await showPurlInfo({
+  await handlePurlsShallowScore({
     outputKind: json ? 'json' : markdown ? 'markdown' : 'text',
     purls
   })

--- a/src/commands/package/fetch-purls-shallow-score.ts
+++ b/src/commands/package/fetch-purls-shallow-score.ts
@@ -9,7 +9,7 @@ import type {
   SocketSdkReturnType
 } from '@socketsecurity/sdk'
 
-export async function fetchPackageInfo(
+export async function fetchPurlsShallowScore(
   purls: string[]
 ): Promise<SocketSdkReturnType<'batchPackageFetch'>> {
   const socketSdk = await setupSdk(getPublicToken())

--- a/src/commands/package/handle-purls-shallow-score.ts
+++ b/src/commands/package/handle-purls-shallow-score.ts
@@ -1,18 +1,18 @@
-import { fetchPackageInfo } from './fetch-package-info'
-import { logPackageInfo } from './log-package-info'
+import { fetchPurlsShallowScore } from './fetch-purls-shallow-score'
+import { outputPurlsShallowScore } from './output-purls-shallow-score'
 
 import type { components } from '@socketsecurity/sdk/types/api'
 
-export async function showPurlInfo({
+export async function handlePurlsShallowScore({
   outputKind,
   purls
 }: {
   outputKind: 'json' | 'markdown' | 'text'
   purls: string[]
 }) {
-  const packageData = await fetchPackageInfo(purls)
+  const packageData = await fetchPurlsShallowScore(purls)
   if (packageData) {
-    logPackageInfo(
+    outputPurlsShallowScore(
       purls,
       packageData.data as Array<components['schemas']['SocketArtifact']>,
       outputKind

--- a/src/commands/package/output-purls-shallow-score.ts
+++ b/src/commands/package/output-purls-shallow-score.ts
@@ -5,7 +5,7 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 
 import type { components } from '@socketsecurity/sdk/types/api'
 
-export function logPackageInfo(
+export function outputPurlsShallowScore(
   purls: string[],
   packageData: Array<components['schemas']['SocketArtifact']>,
   outputKind: 'json' | 'markdown' | 'text'

--- a/src/utils/sdk.ts
+++ b/src/utils/sdk.ts
@@ -48,7 +48,10 @@ export function getDefaultToken(): string | undefined {
 }
 
 export function getPublicToken(): string {
-  return getDefaultToken() ?? SOCKET_PUBLIC_API_TOKEN
+  return (
+    (process.env['SOCKET_SECURITY_API_TOKEN'] || getDefaultToken()) ??
+    SOCKET_PUBLIC_API_TOKEN
+  )
 }
 
 export async function setupSdk(


### PR DESCRIPTION
Started to realize an emerging pattern;

Command file does initial handling, then usually fetches (or collects) data before displaying (or transmitting) it.

Going to make that more consistent in all commands, here's a sample: use `handle-` for the "bridging" file. Basically this is the command being invoked without the input handling/validation. Or put differently, everything that happens after dry-run exits.

Then there's a `fetch-*` file for collecting the data from the API. This may be different for files that collect data from disk or whatever but at least most of the "get-" should become "fetch-".

And the last file is `output-*` to display the result to the user, or to write it to disk or something.

I suspect that most `fetch-` stuffs can be abstracted pretty decently as part of our sdk interface, but there are some edge cases to take care of so we'll see if that holds.

Also updated some logic to be able to test locally.