### PR TITLE
Allow config override through --config or env.SOCKET_CLI_CONFIG

### DIFF
--- a/src/commands/analytics/cmd-analytics.test.ts
+++ b/src/commands/analytics/cmd-analytics.test.ts
@@ -11,10 +11,13 @@ describe('socket analytics', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['analytics', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['analytics', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Look up analytics data
 
         Usage
@@ -38,8 +41,8 @@ describe('socket analytics', async () => {
           $ socket analytics --scope=org --time=30
           $ socket analytics --scope=repo --repo=test-repo --time=30"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -47,14 +50,15 @@ describe('socket analytics', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket analytics\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket analytics`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket analytics`'
+      )
+    }
+  )
 
   cmdit(
-    ['analytics', '--dry-run'],
+    ['analytics', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/audit-log/cmd-audit-log.test.ts
+++ b/src/commands/audit-log/cmd-audit-log.test.ts
@@ -11,10 +11,13 @@ describe('socket audit-log', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['audit-log', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['audit-log', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Look up the audit log for an organization
 
         Usage
@@ -35,8 +38,8 @@ describe('socket audit-log', async () => {
         Examples
           $ socket audit-log FakeOrg"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -44,14 +47,15 @@ describe('socket audit-log', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket audit-log\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket audit-log`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket audit-log`'
+      )
+    }
+  )
 
   cmdit(
-    ['audit-log', '--dry-run'],
+    ['audit-log', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -73,7 +77,7 @@ describe('socket audit-log', async () => {
   )
 
   cmdit(
-    ['audit-log', 'fakeorg', '--dry-run'],
+    ['audit-log', 'fakeorg', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/cdxgen/cmd-cdxgen.test.ts
+++ b/src/commands/cdxgen/cmd-cdxgen.test.ts
@@ -81,14 +81,12 @@ describe('socket cdxgen', async () => {
 
     // expect(code, 'help should exit with code 2').toBe(2)
     expect(code, 'help should exit with code 2').toBe(0) // cdxgen special case
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket cdxgen`'
-    )
+    expect(stderr, 'banner includes base command').toContain('`socket cdxgen`')
   })
 
   // cdxgen does not support --dry-run
   // cmdit(
-  //   ['cdxgen', '--dry-run'],
+  //   ['cdxgen', '--help', '--config', '{}'],
   //   'should require args with just dry-run',
   //   async cmd => {
   //     const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/cdxgen/cmd-cdxgen.ts
+++ b/src/commands/cdxgen/cmd-cdxgen.ts
@@ -1,6 +1,4 @@
 // import { meowOrExit } from '../../utils/meow-with-subcommands'
-import process from 'node:process'
-
 import yargsParse from 'yargs-parser'
 
 import { logger } from '@socketsecurity/registry/lib/logger'

--- a/src/commands/config/cmd-config-get.test.ts
+++ b/src/commands/config/cmd-config-get.test.ts
@@ -11,10 +11,13 @@ describe('socket config get', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['config', 'get', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['config', 'get', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Get the value of a local CLI config item
 
         Usage
@@ -36,8 +39,8 @@ describe('socket config get', async () => {
         Examples
           $ socket config get FakeOrg --repoName=test-repo"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -45,14 +48,15 @@ describe('socket config get', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket config get\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket config get`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket config get`'
+      )
+    }
+  )
 
   cmdit(
-    ['config', 'get', '--dry-run'],
+    ['config', 'get', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -74,7 +78,7 @@ describe('socket config get', async () => {
   )
 
   cmdit(
-    ['config', 'get', 'test', '--dry-run'],
+    ['config', 'get', 'test', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/config/cmd-config-list.test.ts
+++ b/src/commands/config/cmd-config-list.test.ts
@@ -11,10 +11,13 @@ describe('socket config get', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['config', 'list', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['config', 'list', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Show all local CLI config items and their values
 
         Usage
@@ -37,8 +40,8 @@ describe('socket config get', async () => {
         Examples
           $ socket config list FakeOrg --repoName=test-repo"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -46,14 +49,15 @@ describe('socket config get', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket config list\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket config list`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket config list`'
+      )
+    }
+  )
 
   cmdit(
-    ['config', 'list', '--dry-run'],
+    ['config', 'list', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/config/cmd-config-set.test.ts
+++ b/src/commands/config/cmd-config-set.test.ts
@@ -11,10 +11,13 @@ describe('socket config get', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['config', 'set', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['config', 'set', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Update the value of a local CLI config item
 
         Usage
@@ -41,8 +44,8 @@ describe('socket config get', async () => {
         Examples
           $ socket config set apiProxy https://example.com"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -50,14 +53,15 @@ describe('socket config get', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket config set\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket config set`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket config set`'
+      )
+    }
+  )
 
   cmdit(
-    ['config', 'set', '--dry-run'],
+    ['config', 'set', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -81,7 +85,7 @@ describe('socket config get', async () => {
   )
 
   cmdit(
-    ['config', 'set', 'test', 'xyz', '--dry-run'],
+    ['config', 'set', 'test', 'xyz', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/config/cmd-config-unset.test.ts
+++ b/src/commands/config/cmd-config-unset.test.ts
@@ -11,10 +11,13 @@ describe('socket config unset', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['config', 'unset', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['config', 'unset', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Clear the value of a local CLI config item
 
         Usage
@@ -36,8 +39,8 @@ describe('socket config unset', async () => {
         Examples
           $ socket config unset FakeOrg --repoName=test-repo"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -45,14 +48,15 @@ describe('socket config unset', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket config unset\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket config unset`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket config unset`'
+      )
+    }
+  )
 
   cmdit(
-    ['config', 'unset', '--dry-run'],
+    ['config', 'unset', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -74,7 +78,7 @@ describe('socket config unset', async () => {
   )
 
   cmdit(
-    ['config', 'unset', 'test', '--dry-run'],
+    ['config', 'unset', 'test', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/config/cmd-config.test.ts
+++ b/src/commands/config/cmd-config.test.ts
@@ -11,10 +11,13 @@ describe('socket config', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['config', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['config', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Commands related to the local CLI configuration
 
         Usage
@@ -33,8 +36,8 @@ describe('socket config', async () => {
         Examples
           $ socket config --help"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -42,14 +45,15 @@ describe('socket config', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket config\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket config`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket config`'
+      )
+    }
+  )
 
   cmdit(
-    ['config', '--dry-run'],
+    ['config', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/dependencies/cmd-dependencies.test.ts
+++ b/src/commands/dependencies/cmd-dependencies.test.ts
@@ -11,10 +11,13 @@ describe('socket dependencies', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['dependencies', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['dependencies', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Search for any dependency that is being used in your organization
 
         Usage
@@ -31,8 +34,8 @@ describe('socket dependencies', async () => {
         Examples
           socket dependencies --limit 20 --offset 10"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -40,14 +43,15 @@ describe('socket dependencies', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket dependencies\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket dependencies`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket dependencies`'
+      )
+    }
+  )
 
   cmdit(
-    ['dependencies', '--dry-run'],
+    ['dependencies', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/diff-scan/cmd-diff-scan.test.ts
+++ b/src/commands/diff-scan/cmd-diff-scan.test.ts
@@ -11,10 +11,13 @@ describe('socket diff-scan', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['diff-scan', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['diff-scan', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Diff scans related commands
 
         Usage
@@ -30,8 +33,8 @@ describe('socket diff-scan', async () => {
         Examples
           $ socket diff-scan --help"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -39,14 +42,15 @@ describe('socket diff-scan', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket diff-scan`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket diff-scan`'
+      )
+    }
+  )
 
   cmdit(
-    ['diff-scan', '--dry-run'],
+    ['diff-scan', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/fix/cmd-fix.test.ts
+++ b/src/commands/fix/cmd-fix.test.ts
@@ -11,10 +11,13 @@ describe('socket fix', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['fix', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['fix', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Fix "fixable" Socket alerts
 
         Usage
@@ -24,8 +27,8 @@ describe('socket fix', async () => {
           --dryRun          Do input validation for a command and exit 0 when input is ok
           --help            Print this help."
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -33,14 +36,13 @@ describe('socket fix', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket fix\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket fix`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain('`socket fix`')
+    }
+  )
 
   cmdit(
-    ['fix', '--dry-run'],
+    ['fix', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/info/cmd-info.test.ts
+++ b/src/commands/info/cmd-info.test.ts
@@ -11,10 +11,13 @@ describe('socket info', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['info', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['info', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Look up info regarding a package
 
         Usage
@@ -32,8 +35,8 @@ describe('socket info', async () => {
           $ socket info webtorrent
           $ socket info webtorrent@1.9.1"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -41,14 +44,13 @@ describe('socket info', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket info\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket info`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain('`socket info`')
+    }
+  )
 
   cmdit(
-    ['info', '--dry-run'],
+    ['info', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -72,7 +74,7 @@ describe('socket info', async () => {
   )
 
   cmdit(
-    ['info', 'mootools', '--dry-run'],
+    ['info', 'mootools', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/login/cmd-login.test.ts
+++ b/src/commands/login/cmd-login.test.ts
@@ -11,10 +11,13 @@ describe('socket login', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['login', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['login', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Socket API login
 
         Usage
@@ -32,8 +35,8 @@ describe('socket login', async () => {
           $ socket login
           $ socket login --api-proxy=http://localhost:1234"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -41,14 +44,13 @@ describe('socket login', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket login\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket login`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain('`socket login`')
+    }
+  )
 
   cmdit(
-    ['login', 'mootools', '--dry-run'],
+    ['login', 'mootools', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/logout/cmd-logout.test.ts
+++ b/src/commands/logout/cmd-logout.test.ts
@@ -11,10 +11,13 @@ describe('socket logout', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['logout', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['logout', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Socket API logout
 
         Usage
@@ -22,8 +25,8 @@ describe('socket logout', async () => {
 
         Logs out of the Socket API and clears all Socket credentials from disk"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -31,14 +34,15 @@ describe('socket logout', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket logout\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket logout`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket logout`'
+      )
+    }
+  )
 
   cmdit(
-    ['logout', 'mootools', '--dry-run'],
+    ['logout', 'mootools', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/manifest/cmd-manifest-auto.test.ts
+++ b/src/commands/manifest/cmd-manifest-auto.test.ts
@@ -11,10 +11,13 @@ describe('socket manifest auto', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['manifest', 'auto', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['manifest', 'auto', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Auto-detect build and attempt to generate manifest file
 
         Usage
@@ -30,8 +33,8 @@ describe('socket manifest auto', async () => {
         supported case then it will try to generate the manifest file for that
         language with the default or detected settings."
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -39,14 +42,15 @@ describe('socket manifest auto', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest auto\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket manifest auto`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket manifest auto`'
+      )
+    }
+  )
 
   cmdit(
-    ['manifest', 'auto', '--dry-run'],
+    ['manifest', 'auto', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/manifest/cmd-manifest-gradle.test.ts
+++ b/src/commands/manifest/cmd-manifest-gradle.test.ts
@@ -12,72 +12,71 @@ describe('socket manifest gradle', async () => {
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
   cmdit(
-    ['manifest', 'gradle', '--help'],
+    ['manifest', 'gradle', '--help', '--config', '{}'],
     'should support --help',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "[beta] Use Gradle to generate a manifest file (\`pom.xml\`) for a Gradle/Java/Kotlin/etc project
+        "[beta] Use Gradle to generate a manifest file (\`pom.xml\`) for a Gradle/Java/Kotlin/etc project
 
-        Usage
-          $ socket manifest gradle [--gradle=path/to/gradle/binary] [--out=path/to/result] DIR
+          Usage
+            $ socket manifest gradle [--gradle=path/to/gradle/binary] [--out=path/to/result] DIR
 
-        Options
-          --bin             Location of gradlew binary to use, default: CWD/gradlew
-          --cwd             Set the cwd, defaults to process.cwd()
-          --dryRun          Do input validation for a command and exit 0 when input is ok
-          --gradleOpts      Additional options to pass on to ./gradlew, see \`./gradlew --help\`
-          --help            Print this help.
-          --out             Path of output file; where to store the resulting manifest, see also --stdout
-          --stdout          Print resulting pom.xml to stdout (supersedes --out)
-          --task            Task to target. By default targets all.
-          --verbose         Print debug messages
+          Options
+            --bin             Location of gradlew binary to use, default: CWD/gradlew
+            --cwd             Set the cwd, defaults to process.cwd()
+            --dryRun          Do input validation for a command and exit 0 when input is ok
+            --gradleOpts      Additional options to pass on to ./gradlew, see \`./gradlew --help\`
+            --help            Print this help.
+            --out             Path of output file; where to store the resulting manifest, see also --stdout
+            --stdout          Print resulting pom.xml to stdout (supersedes --out)
+            --task            Task to target. By default targets all.
+            --verbose         Print debug messages
 
-        Uses gradle, preferably through your local project \`gradlew\`, to generate a
-        \`pom.xml\` file for each task. If you have no \`gradlew\` you can try the
-        global \`gradle\` binary but that may not work (hard to predict).
+          Uses gradle, preferably through your local project \`gradlew\`, to generate a
+          \`pom.xml\` file for each task. If you have no \`gradlew\` you can try the
+          global \`gradle\` binary but that may not work (hard to predict).
 
-        The \`pom.xml\` is a manifest file similar to \`package.json\` for npm or
-        or requirements.txt for PyPi), but specifically for Maven, which is Java's
-        dependency repository. Languages like Kotlin and Scala piggy back on it too.
+          The \`pom.xml\` is a manifest file similar to \`package.json\` for npm or
+          or requirements.txt for PyPi), but specifically for Maven, which is Java's
+          dependency repository. Languages like Kotlin and Scala piggy back on it too.
 
-        There are some caveats with the gradle to \`pom.xml\` conversion:
+          There are some caveats with the gradle to \`pom.xml\` conversion:
 
-        - each task will generate its own xml file and by default it generates one xml
-          for every task.
+          - each task will generate its own xml file and by default it generates one xml
+            for every task.
 
-        - it's possible certain features don't translate well into the xml. If you
-          think something is missing that could be supported please reach out.
+          - it's possible certain features don't translate well into the xml. If you
+            think something is missing that could be supported please reach out.
 
-        - it works with your \`gradlew\` from your repo and local settings and config
+          - it works with your \`gradlew\` from your repo and local settings and config
 
-        Support is beta. Please report issues or give us feedback on what's missing.
+          Support is beta. Please report issues or give us feedback on what's missing.
 
-        Examples
+          Examples
 
-          $ socket manifest gradle .
-          $ socket manifest gradle --gradlew=../gradlew ."
-    `
+            $ socket manifest gradle .
+            $ socket manifest gradle --gradlew=../gradlew ."
+      `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
-      "
-         _____         _       _        /---------------
-        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
-        |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest gradle\`, cwd: <redacted>"
-    `)
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest gradle\`, cwd: <redacted>"
+      `)
 
       expect(code, 'help should exit with code 2').toBe(2)
-      expect(
-        stderr,
-        'header should include command (without params)'
-      ).toContain('`socket manifest gradle`')
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket manifest gradle`'
+      )
     }
   )
 
   cmdit(
-    ['manifest', 'gradle', '--dry-run'],
+    ['manifest', 'gradle', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -101,7 +100,7 @@ describe('socket manifest gradle', async () => {
   )
 
   cmdit(
-    ['manifest', 'gradle', 'mootools', '--dry-run'],
+    ['manifest', 'gradle', 'mootools', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/manifest/cmd-manifest-kotlin.test.ts
+++ b/src/commands/manifest/cmd-manifest-kotlin.test.ts
@@ -12,72 +12,71 @@ describe('socket manifest kotlin', async () => {
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
   cmdit(
-    ['manifest', 'kotlin', '--help'],
+    ['manifest', 'kotlin', '--help', '--config', '{}'],
     'should support --help',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "[beta] Use Gradle to generate a manifest file (\`pom.xml\`) for a Kotlin project
+        "[beta] Use Gradle to generate a manifest file (\`pom.xml\`) for a Kotlin project
 
-        Usage
-          $ socket manifest kotlin [--gradle=path/to/gradle/binary] [--out=path/to/result] DIR
+          Usage
+            $ socket manifest kotlin [--gradle=path/to/gradle/binary] [--out=path/to/result] DIR
 
-        Options
-          --bin             Location of gradlew binary to use, default: CWD/gradlew
-          --cwd             Set the cwd, defaults to process.cwd()
-          --dryRun          Do input validation for a command and exit 0 when input is ok
-          --gradleOpts      Additional options to pass on to ./gradlew, see \`./gradlew --help\`
-          --help            Print this help.
-          --out             Path of output file; where to store the resulting manifest, see also --stdout
-          --stdout          Print resulting pom.xml to stdout (supersedes --out)
-          --task            Task to target. By default targets all.
-          --verbose         Print debug messages
+          Options
+            --bin             Location of gradlew binary to use, default: CWD/gradlew
+            --cwd             Set the cwd, defaults to process.cwd()
+            --dryRun          Do input validation for a command and exit 0 when input is ok
+            --gradleOpts      Additional options to pass on to ./gradlew, see \`./gradlew --help\`
+            --help            Print this help.
+            --out             Path of output file; where to store the resulting manifest, see also --stdout
+            --stdout          Print resulting pom.xml to stdout (supersedes --out)
+            --task            Task to target. By default targets all.
+            --verbose         Print debug messages
 
-        Uses gradle, preferably through your local project \`gradlew\`, to generate a
-        \`pom.xml\` file for each task. If you have no \`gradlew\` you can try the
-        global \`gradle\` binary but that may not work (hard to predict).
+          Uses gradle, preferably through your local project \`gradlew\`, to generate a
+          \`pom.xml\` file for each task. If you have no \`gradlew\` you can try the
+          global \`gradle\` binary but that may not work (hard to predict).
 
-        The \`pom.xml\` is a manifest file similar to \`package.json\` for npm or
-        or requirements.txt for PyPi), but specifically for Maven, which is Java's
-        dependency repository. Languages like Kotlin and Scala piggy back on it too.
+          The \`pom.xml\` is a manifest file similar to \`package.json\` for npm or
+          or requirements.txt for PyPi), but specifically for Maven, which is Java's
+          dependency repository. Languages like Kotlin and Scala piggy back on it too.
 
-        There are some caveats with the gradle to \`pom.xml\` conversion:
+          There are some caveats with the gradle to \`pom.xml\` conversion:
 
-        - each task will generate its own xml file and by default it generates one xml
-          for every task. (This may be a good thing!)
+          - each task will generate its own xml file and by default it generates one xml
+            for every task. (This may be a good thing!)
 
-        - it's possible certain features don't translate well into the xml. If you
-          think something is missing that could be supported please reach out.
+          - it's possible certain features don't translate well into the xml. If you
+            think something is missing that could be supported please reach out.
 
-        - it works with your \`gradlew\` from your repo and local settings and config
+          - it works with your \`gradlew\` from your repo and local settings and config
 
-        Support is beta. Please report issues or give us feedback on what's missing.
+          Support is beta. Please report issues or give us feedback on what's missing.
 
-        Examples
+          Examples
 
-          $ socket manifest kotlin .
-          $ socket manifest kotlin --gradlew=../gradlew ."
-    `
+            $ socket manifest kotlin .
+            $ socket manifest kotlin --gradlew=../gradlew ."
+      `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
-      "
-         _____         _       _        /---------------
-        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
-        |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest kotlin\`, cwd: <redacted>"
-    `)
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest kotlin\`, cwd: <redacted>"
+      `)
 
       expect(code, 'help should exit with code 2').toBe(2)
-      expect(
-        stderr,
-        'header should include command (without params)'
-      ).toContain('`socket manifest kotlin`')
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket manifest kotlin`'
+      )
     }
   )
 
   cmdit(
-    ['manifest', 'kotlin', '--dry-run'],
+    ['manifest', 'kotlin', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -101,7 +100,7 @@ describe('socket manifest kotlin', async () => {
   )
 
   cmdit(
-    ['manifest', 'kotlin', 'mootools', '--dry-run'],
+    ['manifest', 'kotlin', 'mootools', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/manifest/cmd-manifest-scala.test.ts
+++ b/src/commands/manifest/cmd-manifest-scala.test.ts
@@ -11,10 +11,13 @@ describe('socket manifest scala', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['manifest', 'scala', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['manifest', 'scala', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "[beta] Generate a manifest file (\`pom.xml\`) from Scala's \`build.sbt\` file
 
         Usage
@@ -60,8 +63,8 @@ describe('socket manifest scala', async () => {
           $ socket manifest scala ./build.sbt
           $ socket manifest scala --bin=/usr/bin/sbt ./build.sbt"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -69,14 +72,15 @@ describe('socket manifest scala', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest scala\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket manifest scala`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket manifest scala`'
+      )
+    }
+  )
 
   cmdit(
-    ['manifest', 'scala', '--dry-run'],
+    ['manifest', 'scala', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -100,7 +104,7 @@ describe('socket manifest scala', async () => {
   )
 
   cmdit(
-    ['manifest', 'scala', 'mootools', '--dry-run'],
+    ['manifest', 'scala', 'mootools', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/manifest/cmd-manifest.test.ts
+++ b/src/commands/manifest/cmd-manifest.test.ts
@@ -11,10 +11,13 @@ describe('socket manifest', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['manifest', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['manifest', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Generate a dependency manifest for given file or dir
 
         Usage
@@ -33,8 +36,8 @@ describe('socket manifest', async () => {
         Examples
           $ socket manifest --help"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -42,14 +45,15 @@ describe('socket manifest', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket manifest`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket manifest`'
+      )
+    }
+  )
 
   cmdit(
-    ['manifest', 'mootools', '--dry-run'],
+    ['manifest', 'mootools', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/npm/cmd-npm.test.ts
+++ b/src/commands/npm/cmd-npm.test.ts
@@ -11,17 +11,20 @@ describe('socket npm', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['npm', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['npm', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "npm wrapper functionality
 
         Usage
           $ socket npm"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -29,14 +32,13 @@ describe('socket npm', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket npm\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket npm`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain('`socket npm`')
+    }
+  )
 
   cmdit(
-    ['npm', '--dry-run'],
+    ['npm', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/npx/cmd-npx.test.ts
+++ b/src/commands/npx/cmd-npx.test.ts
@@ -11,17 +11,20 @@ describe('socket npx', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['npx', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['npx', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "npx wrapper functionality
 
         Usage
           $ socket npx"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -29,14 +32,13 @@ describe('socket npx', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket npx\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket npx`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain('`socket npx`')
+    }
+  )
 
   cmdit(
-    ['npx', '--dry-run'],
+    ['npx', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/oops/cmd-oops.test.ts
+++ b/src/commands/oops/cmd-oops.test.ts
@@ -11,10 +11,13 @@ describe('socket oops', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['oops', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['oops', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Trigger an intentional error (for development)
 
         Usage
@@ -22,8 +25,8 @@ describe('socket oops', async () => {
 
         Don't run me."
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -31,14 +34,13 @@ describe('socket oops', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket oops\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket oops`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain('`socket oops`')
+    }
+  )
 
   cmdit(
-    ['oops', '--dry-run'],
+    ['oops', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/optimize/cmd-optimize.test.ts
+++ b/src/commands/optimize/cmd-optimize.test.ts
@@ -11,10 +11,13 @@ describe('socket optimize', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['optimize', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['optimize', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Optimize dependencies with @socketregistry overrides
 
         Usage
@@ -30,8 +33,8 @@ describe('socket optimize', async () => {
           $ socket optimize
           $ socket optimize --pin"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -39,14 +42,15 @@ describe('socket optimize', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket optimize\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket optimize`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket optimize`'
+      )
+    }
+  )
 
   cmdit(
-    ['optimize', '--dry-run'],
+    ['optimize', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/optimize/cmd-optimize.ts
+++ b/src/commands/optimize/cmd-optimize.ts
@@ -1,5 +1,3 @@
-import process from 'node:process'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { applyOptimization } from './apply-optimization'

--- a/src/commands/organization/cmd-organization-list.test.ts
+++ b/src/commands/organization/cmd-organization-list.test.ts
@@ -12,53 +12,52 @@ describe('socket organization list', async () => {
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
   cmdit(
-    ['organization', 'list', '--help'],
+    ['organization', 'list', '--help', '--config', '{}'],
     'should support --help',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "List organizations associated with the API key used
+        "List organizations associated with the API key used
 
-        Usage
-          $ socket organization list
+          Usage
+            $ socket organization list
 
-        Options
-          --dryRun          Do input validation for a command and exit 0 when input is ok
-          --help            Print this help.
-          --json            Output result as json
-          --markdown        Output result as markdown"
-    `
+          Options
+            --dryRun          Do input validation for a command and exit 0 when input is ok
+            --help            Print this help.
+            --json            Output result as json
+            --markdown        Output result as markdown"
+      `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
-      "
-         _____         _       _        /---------------
-        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
-        |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization list\`, cwd: <redacted>"
-    `)
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization list\`, cwd: <redacted>"
+      `)
 
       expect(code, 'help should exit with code 2').toBe(2)
-      expect(
-        stderr,
-        'header should include command (without params)'
-      ).toContain('`socket organization list`')
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket organization list`'
+      )
     }
   )
 
   cmdit(
-    ['organization', 'list', '--dry-run'],
+    ['organization', 'list', '--dry-run', '--config', '{}'],
     'should be ok with org name and id',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
-      "
-         _____         _       _        /---------------
-        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
-        |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization list\`, cwd: <redacted>"
-    `)
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization list\`, cwd: <redacted>"
+      `)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
     }

--- a/src/commands/organization/cmd-organization-policy-security.test.ts
+++ b/src/commands/organization/cmd-organization-policy-security.test.ts
@@ -12,49 +12,48 @@ describe('socket organization list', async () => {
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
   cmdit(
-    ['organization', 'policy', 'security', '--help'],
+    ['organization', 'policy', 'security', '--help', '--config', '{}'],
     'should support --help',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "Retrieve the security policy of an organization.
+        "Retrieve the security policy of an organization.
 
-        Usage
-          $ socket organization policy security <org slug>
+          Usage
+            $ socket organization policy security <org slug>
 
-        Options
-          --dryRun          Do input validation for a command and exit 0 when input is ok
-          --help            Print this help.
-          --json            Output result as json
-          --markdown        Output result as markdown
+          Options
+            --dryRun          Do input validation for a command and exit 0 when input is ok
+            --help            Print this help.
+            --json            Output result as json
+            --markdown        Output result as markdown
 
-        Your API token will need the \`security-policy:read\` permission otherwise
-        the request will fail with an authentication error.
+          Your API token will need the \`security-policy:read\` permission otherwise
+          the request will fail with an authentication error.
 
-        Examples
-          $ socket organization policy security mycorp
-          $ socket organization policy security mycorp --json"
-    `
+          Examples
+            $ socket organization policy security mycorp
+            $ socket organization policy security mycorp --json"
+      `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
-      "
-         _____         _       _        /---------------
-        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
-        |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy security\`, cwd: <redacted>"
-    `)
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy security\`, cwd: <redacted>"
+      `)
 
       expect(code, 'help should exit with code 2').toBe(2)
-      expect(
-        stderr,
-        'header should include command (without params)'
-      ).toContain('`socket organization policy security`')
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket organization policy security`'
+      )
     }
   )
 
   cmdit(
-    ['organization', 'policy', 'security', '--dry-run'],
+    ['organization', 'policy', 'security', '--dry-run', '--config', '{}'],
     'should reject dry run without proper args',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -77,18 +76,26 @@ describe('socket organization list', async () => {
   )
 
   cmdit(
-    ['organization', 'policy', 'security', 'fakeorg', '--dry-run'],
+    [
+      'organization',
+      'policy',
+      'security',
+      'fakeorg',
+      '--dry-run',
+      '--config',
+      '{}'
+    ],
     'should be ok with org name and id',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
-      "
-         _____         _       _        /---------------
-        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
-        |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy security\`, cwd: <redacted>"
-    `)
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy security\`, cwd: <redacted>"
+      `)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
     }

--- a/src/commands/organization/cmd-organization-policy.test.ts
+++ b/src/commands/organization/cmd-organization-policy.test.ts
@@ -12,27 +12,27 @@ describe('socket organization list', async () => {
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
   cmdit(
-    ['organization', 'policy', '--help'],
+    ['organization', 'policy', '--help', '--config', '{}'],
     'should support --help',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "Organization policy details
+        "Organization policy details
 
-        Usage
-          $ socket organization policy <command>
+          Usage
+            $ socket organization policy <command>
 
-        Commands
-        
+          Commands
+            (none)
 
-        Options
-          --dryRun          Do input validation for a command and exit 0 when input is ok
-          --help            Print this help.
+          Options
+            --dryRun          Do input validation for a command and exit 0 when input is ok
+            --help            Print this help.
 
-        Examples
-          $ socket organization policy --help"
-    `
+          Examples
+            $ socket organization policy --help"
+      `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
@@ -43,10 +43,29 @@ describe('socket organization list', async () => {
     `)
 
       expect(code, 'help should exit with code 2').toBe(2)
-      expect(
-        stderr,
-        'header should include command (without params)'
-      ).toContain('`socket organization policy`')
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket organization policy`'
+      )
+    }
+  )
+
+  cmdit(
+    ['organization', 'policy', '--dry-run', '--config', '{}'],
+    'should support --dry-run',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `"[DryRun]: No-op, call a sub-command; ok"`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      "
+         _____         _       _        /---------------
+        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+        |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+        |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy\`, cwd: <redacted>"
+    `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
     }
   )
 })

--- a/src/commands/organization/cmd-organization-quota.test.ts
+++ b/src/commands/organization/cmd-organization-quota.test.ts
@@ -12,53 +12,52 @@ describe('socket organization quota', async () => {
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
   cmdit(
-    ['organization', 'quota', '--help'],
+    ['organization', 'quota', '--help', '--config', '{}'],
     'should support --help',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "List organizations associated with the API key used
+        "List organizations associated with the API key used
 
-        Usage
-          $ socket organization quota
+          Usage
+            $ socket organization quota
 
-        Options
-          --dryRun          Do input validation for a command and exit 0 when input is ok
-          --help            Print this help.
-          --json            Output result as json
-          --markdown        Output result as markdown"
-    `
+          Options
+            --dryRun          Do input validation for a command and exit 0 when input is ok
+            --help            Print this help.
+            --json            Output result as json
+            --markdown        Output result as markdown"
+      `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
-      "
-         _____         _       _        /---------------
-        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
-        |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization quota\`, cwd: <redacted>"
-    `)
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization quota\`, cwd: <redacted>"
+      `)
 
       expect(code, 'help should exit with code 2').toBe(2)
-      expect(
-        stderr,
-        'header should include command (without params)'
-      ).toContain('`socket organization quota`')
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket organization quota`'
+      )
     }
   )
 
   cmdit(
-    ['organization', 'quota', '--dry-run'],
+    ['organization', 'quota', '--dry-run', '--config', '{}'],
     'should be ok with org name and id',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
-      "
-         _____         _       _        /---------------
-        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
-        |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization quota\`, cwd: <redacted>"
-    `)
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization quota\`, cwd: <redacted>"
+      `)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
     }

--- a/src/commands/organization/cmd-organization.test.ts
+++ b/src/commands/organization/cmd-organization.test.ts
@@ -11,10 +11,13 @@ describe('socket organization', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['organization', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['organization', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Account details
 
         Usage
@@ -30,8 +33,8 @@ describe('socket organization', async () => {
         Examples
           $ socket organization --help"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -39,14 +42,15 @@ describe('socket organization', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket organization`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket organization`'
+      )
+    }
+  )
 
   cmdit(
-    ['organization', '--dry-run'],
+    ['organization', '--dry-run', '--config', '{}'],
     'should be ok with org name and id',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/package/cmd-package-shallow.test.ts
+++ b/src/commands/package/cmd-package-shallow.test.ts
@@ -12,67 +12,66 @@ describe('socket package shallow', async () => {
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
   cmdit(
-    ['package', 'shallow', '--help'],
+    ['package', 'shallow', '--help', '--config', '{}'],
     'should support --help',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "Look up info regarding one or more packages but not their transitives
+        "Look up info regarding one or more packages but not their transitives
 
-        Usage
-          $ socket package shallow <<ecosystem> <name> [<name> ...] | <purl> [<purl> ...]>
+          Usage
+            $ socket package shallow <<ecosystem> <name> [<name> ...] | <purl> [<purl> ...]>
 
-        Options
-          --dryRun          Do input validation for a command and exit 0 when input is ok
-          --help            Print this help.
-          --json            Output result as json
-          --markdown        Output result as markdown
+          Options
+            --dryRun          Do input validation for a command and exit 0 when input is ok
+            --help            Print this help.
+            --json            Output result as json
+            --markdown        Output result as markdown
 
-        Requirements
-          - quota: 100
-          - scope: \`packages:list\`
+          Requirements
+            - quota: 100
+            - scope: \`packages:list\`
 
-        Show scoring details for one or more packages purely based on their own package.
-        This means that any dependency scores are not reflected by the score. You can
-        use the \`socket package score <pkg>\` command to get its full transitive score.
+          Show scoring details for one or more packages purely based on their own package.
+          This means that any dependency scores are not reflected by the score. You can
+          use the \`socket package score <pkg>\` command to get its full transitive score.
 
-        Only a few ecosystems are supported like npm, golang, and maven.
+          Only a few ecosystems are supported like npm, golang, and maven.
 
-        A "purl" is a standard package name formatting: \`pkg:eco/name@version\`
-        This command will automatically prepend "pkg:" when not present.
+          A "purl" is a standard package name formatting: \`pkg:eco/name@version\`
+          This command will automatically prepend "pkg:" when not present.
 
-        If the first arg is an ecosystem, remaining args that are not a purl are
-        assumed to be scoped to that ecosystem.
+          If the first arg is an ecosystem, remaining args that are not a purl are
+          assumed to be scoped to that ecosystem.
 
-        Examples
-          $ socket package shallow npm webtorrent
-          $ socket package shallow npm webtorrent@1.9.1
-          $ socket package shallow npm/webtorrent@1.9.1
-          $ socket package shallow pkg:npm/webtorrent@1.9.1
-          $ socket package shallow maven webtorrent babel
-          $ socket package shallow npm/webtorrent golang/babel
-          $ socket package shallow npm npm/webtorrent@1.0.1 babel"
-    `
+          Examples
+            $ socket package shallow npm webtorrent
+            $ socket package shallow npm webtorrent@1.9.1
+            $ socket package shallow npm/webtorrent@1.9.1
+            $ socket package shallow pkg:npm/webtorrent@1.9.1
+            $ socket package shallow maven webtorrent babel
+            $ socket package shallow npm/webtorrent golang/babel
+            $ socket package shallow npm npm/webtorrent@1.0.1 babel"
+      `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
-      "
-         _____         _       _        /---------------
-        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
-        |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket package shallow\`, cwd: <redacted>"
-    `)
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket package shallow\`, cwd: <redacted>"
+      `)
 
       expect(code, 'help should exit with code 2').toBe(2)
-      expect(
-        stderr,
-        'header should include command (without params)'
-      ).toContain('`socket package shallow`')
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket package shallow`'
+      )
     }
   )
 
   cmdit(
-    ['package', 'shallow', '--dry-run'],
+    ['package', 'shallow', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -96,7 +95,7 @@ describe('socket package shallow', async () => {
   )
 
   cmdit(
-    ['package', 'shallow', 'npm', 'babel', '--dry-run'],
+    ['package', 'shallow', 'npm', 'babel', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/package/cmd-package.test.ts
+++ b/src/commands/package/cmd-package.test.ts
@@ -11,27 +11,30 @@ describe('socket package', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['package', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
+  cmdit(
+    ['package', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
+        "Commands relating to looking up published packages
+
+          Usage
+            $ socket package <command>
+
+          Commands
+            (none)
+
+          Options
+            --dryRun          Do input validation for a command and exit 0 when input is ok
+            --help            Print this help.
+
+          Examples
+            $ socket package --help"
       `
-      "Commands relating to looking up published packages
-
-        Usage
-          $ socket package <command>
-
-        Commands
-        
-
-        Options
-          --dryRun          Do input validation for a command and exit 0 when input is ok
-          --help            Print this help.
-
-        Examples
-          $ socket package --help"
-    `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -39,9 +42,30 @@ describe('socket package', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket package\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket package`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket package`'
+      )
+    }
+  )
+
+  cmdit(
+    ['package', '--dry-run', '--config', '{}'],
+    'should be ok with org name and id',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `"[DryRun]: No-op, call a sub-command; ok"`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket package\`, cwd: <redacted>"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
 })

--- a/src/commands/raw-npm/cmd-raw-npm.test.ts
+++ b/src/commands/raw-npm/cmd-raw-npm.test.ts
@@ -11,10 +11,13 @@ describe('socket raw-npm', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['raw-npm', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['raw-npm', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Temporarily disable the Socket npm wrapper
 
         Usage
@@ -23,8 +26,8 @@ describe('socket raw-npm', async () => {
         Examples
           $ socket raw-npm install"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -32,14 +35,15 @@ describe('socket raw-npm', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket raw-npm\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket raw-npm`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket raw-npm`'
+      )
+    }
+  )
 
   cmdit(
-    ['raw-npm', '--dry-run'],
+    ['raw-npm', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/report/cmd-report-create.test.ts
+++ b/src/commands/report/cmd-report-create.test.ts
@@ -11,17 +11,20 @@ describe('socket report create', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['report', 'create', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['report', 'create', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "[Deprecated] Create a project report
 
         This command is deprecated in favor of \`socket scan view\`.
         It will be removed in the next major release of the CLI."
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -29,14 +32,15 @@ describe('socket report create', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket report create\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket report create`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket report create`'
+      )
+    }
+  )
 
   cmdit(
-    ['report', 'create', '--dry-run'],
+    ['report', 'create', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/report/cmd-report-create.ts
+++ b/src/commands/report/cmd-report-create.ts
@@ -1,5 +1,4 @@
 import path from 'node:path'
-import process from 'node:process'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 

--- a/src/commands/report/cmd-report-view.test.ts
+++ b/src/commands/report/cmd-report-view.test.ts
@@ -11,17 +11,20 @@ describe('socket report create', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['report', 'create', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['report', 'create', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "[Deprecated] Create a project report
 
         This command is deprecated in favor of \`socket scan view\`.
         It will be removed in the next major release of the CLI."
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -29,14 +32,15 @@ describe('socket report create', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket report create\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket report create`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket report create`'
+      )
+    }
+  )
 
   cmdit(
-    ['report', 'create', '--dry-run'],
+    ['report', 'create', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/report/cmd-report.test.ts
+++ b/src/commands/report/cmd-report.test.ts
@@ -11,10 +11,13 @@ describe('socket report', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['report', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['report', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "[Deprecated] Project report related commands
 
         Usage
@@ -31,8 +34,8 @@ describe('socket report', async () => {
         Examples
           $ socket report --help"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -40,14 +43,15 @@ describe('socket report', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket report\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket report`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket report`'
+      )
+    }
+  )
 
   cmdit(
-    ['report', '--dry-run'],
+    ['report', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/repos/cmd-repos-create.test.ts
+++ b/src/commands/repos/cmd-repos-create.test.ts
@@ -7,37 +7,33 @@ import { cmdit, invokeNpm } from '../../../test/utils'
 
 const { CLI } = constants
 
-describe('socket diff-scan get', async () => {
+describe('socket repos create', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
   cmdit(
-    ['diff-scan', 'get', '--help', '--config', '{}'],
+    ['repos', 'create', '--help', '--config', '{}'],
     'should support --help',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "Get a diff scan for an organization
+      "Create a repository in an organization
 
         Usage
-          $ socket diff-scan get <org slug> --before=<before> --after=<after>
-
-        This command displays the package changes between two scans. The full output
-        can be pretty large depending on the size of your repo and time range. It is
-        best stored to disk to be further analyzed by other tools.
+          $ socket repos create <org slug>
 
         Options
-          --after           The full scan ID of the head scan
-          --before          The full scan ID of the base scan
-          --depth           Max depth of JSON to display before truncating, use zero for no limit (without --json/--file)
+          --defaultBranch   Repository default branch
           --dryRun          Do input validation for a command and exit 0 when input is ok
-          --file            Path to a local file where the output should be saved. Use \`-\` to force stdout.
           --help            Print this help.
-          --json            Output result as json. This can be big. Use --file to store it to disk without truncation.
+          --homepage        Repository url
+          --repoDescription Repository description
+          --repoName        Repository name
+          --visibility      Repository visibility (Default Private)
 
         Examples
-          $ socket diff-scan get FakeCorp --before=aaa0aa0a-aaaa-0000-0a0a-0000000a00a0 --after=aaa1aa1a-aaaa-1111-1a1a-1111111a11a1"
+          $ socket repos create FakeOrg --repoName=test-repo"
     `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
@@ -45,18 +41,18 @@ describe('socket diff-scan get', async () => {
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
         |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>"
+        |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos create\`, cwd: <redacted>"
     `)
 
       expect(code, 'help should exit with code 2').toBe(2)
       expect(stderr, 'banner includes base command').toContain(
-        '`socket diff-scan get`'
+        '`socket repos create`'
       )
     }
   )
 
   cmdit(
-    ['diff-scan', 'get', '--dry-run', '--config', '{}'],
+    ['repos', 'create', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -66,16 +62,13 @@ describe('socket diff-scan get', async () => {
            _____         _       _        /---------------
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-          |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos create\`, cwd: <redacted>
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
 
-              - Specify a before and after full scan ID \\x1b[31m(missing before and after!)\\x1b[39m
+        - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m
 
-                  - To get full scans IDs, you can run the command "socket scan list <your org slug>".
-                    The args are expecting a full \`aaa0aa0a-aaaa-0000-0a0a-0000000a00a0\` ID.
-
-              - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m"
+        - Repository name using --repoName \\x1b[31m(missing!)\\x1b[39m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -83,18 +76,7 @@ describe('socket diff-scan get', async () => {
   )
 
   cmdit(
-    [
-      'diff-scan',
-      'get',
-      'fakeorg',
-      '--dry-run',
-      '--config',
-      '{}',
-      '--before',
-      'x',
-      '--after',
-      'y'
-    ],
+    ['repos', 'create', 'a', '--repoName', 'b', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -104,7 +86,7 @@ describe('socket diff-scan get', async () => {
            _____         _       _        /---------------
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-          |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>"
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos create\`, cwd: <redacted>"
       `)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)

--- a/src/commands/repos/cmd-repos-del.test.ts
+++ b/src/commands/repos/cmd-repos-del.test.ts
@@ -7,37 +7,28 @@ import { cmdit, invokeNpm } from '../../../test/utils'
 
 const { CLI } = constants
 
-describe('socket diff-scan get', async () => {
+describe('socket repos del', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
   cmdit(
-    ['diff-scan', 'get', '--help', '--config', '{}'],
+    ['repos', 'del', '--help', '--config', '{}'],
     'should support --help',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "Get a diff scan for an organization
+      "Delete a repository in an organization
 
         Usage
-          $ socket diff-scan get <org slug> --before=<before> --after=<after>
-
-        This command displays the package changes between two scans. The full output
-        can be pretty large depending on the size of your repo and time range. It is
-        best stored to disk to be further analyzed by other tools.
+          $ socket repos del <org slug> <repo slug>
 
         Options
-          --after           The full scan ID of the head scan
-          --before          The full scan ID of the base scan
-          --depth           Max depth of JSON to display before truncating, use zero for no limit (without --json/--file)
           --dryRun          Do input validation for a command and exit 0 when input is ok
-          --file            Path to a local file where the output should be saved. Use \`-\` to force stdout.
           --help            Print this help.
-          --json            Output result as json. This can be big. Use --file to store it to disk without truncation.
 
         Examples
-          $ socket diff-scan get FakeCorp --before=aaa0aa0a-aaaa-0000-0a0a-0000000a00a0 --after=aaa1aa1a-aaaa-1111-1a1a-1111111a11a1"
+          $ socket repos del FakeOrg test-repo"
     `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
@@ -45,18 +36,18 @@ describe('socket diff-scan get', async () => {
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
         |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>"
+        |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos del\`, cwd: <redacted>"
     `)
 
       expect(code, 'help should exit with code 2').toBe(2)
       expect(stderr, 'banner includes base command').toContain(
-        '`socket diff-scan get`'
+        '`socket repos del`'
       )
     }
   )
 
   cmdit(
-    ['diff-scan', 'get', '--dry-run', '--config', '{}'],
+    ['repos', 'del', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -66,16 +57,15 @@ describe('socket diff-scan get', async () => {
            _____         _       _        /---------------
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-          |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos del\`, cwd: <redacted>
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
 
-              - Specify a before and after full scan ID \\x1b[31m(missing before and after!)\\x1b[39m
+        - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m
 
-                  - To get full scans IDs, you can run the command "socket scan list <your org slug>".
-                    The args are expecting a full \`aaa0aa0a-aaaa-0000-0a0a-0000000a00a0\` ID.
+        - Repository name as the second argument \\x1b[31m(missing!)\\x1b[39m
 
-              - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m"
+        - At least one TARGET (e.g. \`.\` or \`./package.json\`"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -83,18 +73,7 @@ describe('socket diff-scan get', async () => {
   )
 
   cmdit(
-    [
-      'diff-scan',
-      'get',
-      'fakeorg',
-      '--dry-run',
-      '--config',
-      '{}',
-      '--before',
-      'x',
-      '--after',
-      'y'
-    ],
+    ['repos', 'del', 'a', 'b', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -104,7 +83,7 @@ describe('socket diff-scan get', async () => {
            _____         _       _        /---------------
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-          |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>"
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos del\`, cwd: <redacted>"
       `)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)

--- a/src/commands/repos/cmd-repos-list.test.ts
+++ b/src/commands/repos/cmd-repos-list.test.ts
@@ -7,37 +7,34 @@ import { cmdit, invokeNpm } from '../../../test/utils'
 
 const { CLI } = constants
 
-describe('socket diff-scan get', async () => {
+describe('socket repos list', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
   cmdit(
-    ['diff-scan', 'get', '--help', '--config', '{}'],
+    ['repos', 'list', '--help', '--config', '{}'],
     'should support --help',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "Get a diff scan for an organization
+      "List repositories in an organization
 
         Usage
-          $ socket diff-scan get <org slug> --before=<before> --after=<after>
-
-        This command displays the package changes between two scans. The full output
-        can be pretty large depending on the size of your repo and time range. It is
-        best stored to disk to be further analyzed by other tools.
+          $ socket repos list <org slug>
 
         Options
-          --after           The full scan ID of the head scan
-          --before          The full scan ID of the base scan
-          --depth           Max depth of JSON to display before truncating, use zero for no limit (without --json/--file)
+          --direction       Direction option
           --dryRun          Do input validation for a command and exit 0 when input is ok
-          --file            Path to a local file where the output should be saved. Use \`-\` to force stdout.
           --help            Print this help.
-          --json            Output result as json. This can be big. Use --file to store it to disk without truncation.
+          --json            Output result as json
+          --markdown        Output result as markdown
+          --page            Page number
+          --perPage         Number of results per page
+          --sort            Sorting option
 
         Examples
-          $ socket diff-scan get FakeCorp --before=aaa0aa0a-aaaa-0000-0a0a-0000000a00a0 --after=aaa1aa1a-aaaa-1111-1a1a-1111111a11a1"
+          $ socket repos list FakeOrg"
     `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
@@ -45,18 +42,18 @@ describe('socket diff-scan get', async () => {
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
         |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>"
+        |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos list\`, cwd: <redacted>"
     `)
 
       expect(code, 'help should exit with code 2').toBe(2)
       expect(stderr, 'banner includes base command').toContain(
-        '`socket diff-scan get`'
+        '`socket repos list`'
       )
     }
   )
 
   cmdit(
-    ['diff-scan', 'get', '--dry-run', '--config', '{}'],
+    ['repos', 'list', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -66,16 +63,13 @@ describe('socket diff-scan get', async () => {
            _____         _       _        /---------------
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-          |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos list\`, cwd: <redacted>
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
 
-              - Specify a before and after full scan ID \\x1b[31m(missing before and after!)\\x1b[39m
+        - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m
 
-                  - To get full scans IDs, you can run the command "socket scan list <your org slug>".
-                    The args are expecting a full \`aaa0aa0a-aaaa-0000-0a0a-0000000a00a0\` ID.
-
-              - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m"
+        - At least one TARGET (e.g. \`.\` or \`./package.json\`"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -83,18 +77,7 @@ describe('socket diff-scan get', async () => {
   )
 
   cmdit(
-    [
-      'diff-scan',
-      'get',
-      'fakeorg',
-      '--dry-run',
-      '--config',
-      '{}',
-      '--before',
-      'x',
-      '--after',
-      'y'
-    ],
+    ['repos', 'list', 'a', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -104,7 +87,7 @@ describe('socket diff-scan get', async () => {
            _____         _       _        /---------------
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-          |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>"
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos list\`, cwd: <redacted>"
       `)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)

--- a/src/commands/repos/cmd-repos-update.test.ts
+++ b/src/commands/repos/cmd-repos-update.test.ts
@@ -7,37 +7,33 @@ import { cmdit, invokeNpm } from '../../../test/utils'
 
 const { CLI } = constants
 
-describe('socket diff-scan get', async () => {
+describe('socket repos update', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
   cmdit(
-    ['diff-scan', 'get', '--help', '--config', '{}'],
+    ['repos', 'update', '--help', '--config', '{}'],
     'should support --help',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "Get a diff scan for an organization
+      "Update a repository in an organization
 
         Usage
-          $ socket diff-scan get <org slug> --before=<before> --after=<after>
-
-        This command displays the package changes between two scans. The full output
-        can be pretty large depending on the size of your repo and time range. It is
-        best stored to disk to be further analyzed by other tools.
+          $ socket repos update <org slug>
 
         Options
-          --after           The full scan ID of the head scan
-          --before          The full scan ID of the base scan
-          --depth           Max depth of JSON to display before truncating, use zero for no limit (without --json/--file)
+          --defaultBranch   Repository default branch
           --dryRun          Do input validation for a command and exit 0 when input is ok
-          --file            Path to a local file where the output should be saved. Use \`-\` to force stdout.
           --help            Print this help.
-          --json            Output result as json. This can be big. Use --file to store it to disk without truncation.
+          --homepage        Repository url
+          --repoDescription Repository description
+          --repoName        Repository name
+          --visibility      Repository visibility (Default Private)
 
         Examples
-          $ socket diff-scan get FakeCorp --before=aaa0aa0a-aaaa-0000-0a0a-0000000a00a0 --after=aaa1aa1a-aaaa-1111-1a1a-1111111a11a1"
+          $ socket repos update FakeOrg"
     `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
@@ -45,18 +41,18 @@ describe('socket diff-scan get', async () => {
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
         |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>"
+        |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos update\`, cwd: <redacted>"
     `)
 
       expect(code, 'help should exit with code 2').toBe(2)
       expect(stderr, 'banner includes base command').toContain(
-        '`socket diff-scan get`'
+        '`socket repos update`'
       )
     }
   )
 
   cmdit(
-    ['diff-scan', 'get', '--dry-run', '--config', '{}'],
+    ['repos', 'update', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -66,16 +62,15 @@ describe('socket diff-scan get', async () => {
            _____         _       _        /---------------
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-          |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos update\`, cwd: <redacted>
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
 
-              - Specify a before and after full scan ID \\x1b[31m(missing before and after!)\\x1b[39m
+        - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m
 
-                  - To get full scans IDs, you can run the command "socket scan list <your org slug>".
-                    The args are expecting a full \`aaa0aa0a-aaaa-0000-0a0a-0000000a00a0\` ID.
+        - Repository name using --repoName \\x1b[31m(missing!)\\x1b[39m
 
-              - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m"
+        - At least one TARGET (e.g. \`.\` or \`./package.json\`"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -83,18 +78,7 @@ describe('socket diff-scan get', async () => {
   )
 
   cmdit(
-    [
-      'diff-scan',
-      'get',
-      'fakeorg',
-      '--dry-run',
-      '--config',
-      '{}',
-      '--before',
-      'x',
-      '--after',
-      'y'
-    ],
+    ['repos', 'update', 'a', '--repoName', 'b', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -104,7 +88,7 @@ describe('socket diff-scan get', async () => {
            _____         _       _        /---------------
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-          |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>"
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos update\`, cwd: <redacted>"
       `)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)

--- a/src/commands/repos/cmd-repos-view.test.ts
+++ b/src/commands/repos/cmd-repos-view.test.ts
@@ -7,37 +7,31 @@ import { cmdit, invokeNpm } from '../../../test/utils'
 
 const { CLI } = constants
 
-describe('socket diff-scan get', async () => {
+describe('socket repos view', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
   cmdit(
-    ['diff-scan', 'get', '--help', '--config', '{}'],
+    ['repos', 'view', '--help', '--config', '{}'],
     'should support --help',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "Get a diff scan for an organization
+      "View repositories in an organization
 
         Usage
-          $ socket diff-scan get <org slug> --before=<before> --after=<after>
-
-        This command displays the package changes between two scans. The full output
-        can be pretty large depending on the size of your repo and time range. It is
-        best stored to disk to be further analyzed by other tools.
+          $ socket repos view <org slug>
 
         Options
-          --after           The full scan ID of the head scan
-          --before          The full scan ID of the base scan
-          --depth           Max depth of JSON to display before truncating, use zero for no limit (without --json/--file)
           --dryRun          Do input validation for a command and exit 0 when input is ok
-          --file            Path to a local file where the output should be saved. Use \`-\` to force stdout.
           --help            Print this help.
-          --json            Output result as json. This can be big. Use --file to store it to disk without truncation.
+          --json            Output result as json
+          --markdown        Output result as markdown
+          --repoName        The repository to check
 
         Examples
-          $ socket diff-scan get FakeCorp --before=aaa0aa0a-aaaa-0000-0a0a-0000000a00a0 --after=aaa1aa1a-aaaa-1111-1a1a-1111111a11a1"
+          $ socket repos view FakeOrg"
     `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
@@ -45,18 +39,18 @@ describe('socket diff-scan get', async () => {
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
         |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>"
+        |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos view\`, cwd: <redacted>"
     `)
 
       expect(code, 'help should exit with code 2').toBe(2)
       expect(stderr, 'banner includes base command').toContain(
-        '`socket diff-scan get`'
+        '`socket repos view`'
       )
     }
   )
 
   cmdit(
-    ['diff-scan', 'get', '--dry-run', '--config', '{}'],
+    ['repos', 'view', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -66,16 +60,13 @@ describe('socket diff-scan get', async () => {
            _____         _       _        /---------------
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-          |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos view\`, cwd: <redacted>
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
 
-              - Specify a before and after full scan ID \\x1b[31m(missing before and after!)\\x1b[39m
+        - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m
 
-                  - To get full scans IDs, you can run the command "socket scan list <your org slug>".
-                    The args are expecting a full \`aaa0aa0a-aaaa-0000-0a0a-0000000a00a0\` ID.
-
-              - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m"
+        - Repository name using --repoName \\x1b[31m(missing!)\\x1b[39m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -83,18 +74,7 @@ describe('socket diff-scan get', async () => {
   )
 
   cmdit(
-    [
-      'diff-scan',
-      'get',
-      'fakeorg',
-      '--dry-run',
-      '--config',
-      '{}',
-      '--before',
-      'x',
-      '--after',
-      'y'
-    ],
+    ['repos', 'view', 'a', '--repoName', 'b', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -104,7 +84,7 @@ describe('socket diff-scan get', async () => {
            _____         _       _        /---------------
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-          |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>"
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos view\`, cwd: <redacted>"
       `)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)

--- a/src/commands/repos/cmd-repos.test.ts
+++ b/src/commands/repos/cmd-repos.test.ts
@@ -7,24 +7,35 @@ import { cmdit, invokeNpm } from '../../../test/utils'
 
 const { CLI } = constants
 
-describe('socket raw-npx', async () => {
+describe('socket repos', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
   cmdit(
-    ['raw-npx', '--help', '--config', '{}'],
+    ['repos', '--help', '--config', '{}'],
     'should support --help',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "Temporarily disable the Socket npx wrapper
+      "Repositories related commands
 
         Usage
-          $ socket raw-npx <command>
+          $ socket repos <command>
+
+        Commands
+          create            Create a repository in an organization
+          del               Delete a repository in an organization
+          list              List repositories in an organization
+          update            Update a repository in an organization
+          view              View repositories in an organization
+
+        Options
+          --dryRun          Do input validation for a command and exit 0 when input is ok
+          --help            Print this help.
 
         Examples
-          $ socket raw-npx install"
+          $ socket repos --help"
     `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
@@ -32,28 +43,28 @@ describe('socket raw-npx', async () => {
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
         |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket raw-npx\`, cwd: <redacted>"
+        |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos\`, cwd: <redacted>"
     `)
 
       expect(code, 'help should exit with code 2').toBe(2)
-      expect(stderr, 'banner includes base command').toContain(
-        '`socket raw-npx`'
-      )
+      expect(stderr, 'banner includes base command').toContain('`socket repos`')
     }
   )
 
   cmdit(
-    ['raw-npx', '--dry-run', '--config', '{}'],
+    ['repos', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(stdout).toMatchInlineSnapshot(
+        `"[DryRun]: No-op, call a sub-command; ok"`
+      )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-          |_____|___|___|_,_|___|_|.dev   | Command: \`socket raw-npx\`, cwd: <redacted>"
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos\`, cwd: <redacted>"
       `)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)

--- a/src/commands/scan/cmd-scan-create.test.ts
+++ b/src/commands/scan/cmd-scan-create.test.ts
@@ -11,25 +11,64 @@ describe('socket scan create', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['scan', 'create', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(`""`)
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+  cmdit(
+    ['scan', 'create', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`
+      "Create a scan
+
+        Usage
+          $ socket scan create [...options] <org> <TARGET> [TARGET...]
+
+        Uploads the specified "package.json" and lock files for JavaScript, Python,
+        Go, Scala, Gradle, and Kotlin dependency manifests.
+        If any folder is specified, the ones found in there recursively are uploaded.
+
+        Supports globbing such as "**/package.json", "**/requirements.txt", etc.
+
+        Ignores any file specified in your project's ".gitignore" and also has a
+        sensible set of default ignores from the "ignore-by-default" module.
+
+        TARGET should be a FILE or DIR that _must_ be inside the CWD.
+
+        When a FILE is given only that FILE is targeted. Otherwise any eligible
+        files in the given DIR will be considered.
+
+        Options
+          --branch          Branch name
+          --commitHash      Commit hash
+          --commitMessage   Commit message
+          --committers      Committers
+          --cwd             working directory, defaults to process.cwd()
+          --defaultBranch   Make default branch
+          --dryRun          run input validation part of command without any concrete side effects
+          --help            Print this help.
+          --pendingHead     Set as pending head
+          --pullRequest     Commit hash
+          --readOnly        Similar to --dry-run except it can read from remote, stops before it would create an actual report
+          --repo            Repository name
+          --tmp             Set the visibility (true/false) of the scan in your dashboard
+          --view            Will wait for and return the created report. Use --no-view to disable.
+
+        Examples
+          $ socket scan create --repo=test-repo --branch=main FakeOrg ./package.json"
+    `)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
         |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan create\`, cwd: <redacted>
-
-      Unknown flag
-      --help"
+        |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan create\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket scan create`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket scan create`'
+      )
+    }
+  )
 
   cmdit(
     [

--- a/src/commands/scan/cmd-scan-create.ts
+++ b/src/commands/scan/cmd-scan-create.ts
@@ -1,5 +1,3 @@
-import process from 'node:process'
-
 import { stripIndents } from 'common-tags'
 import colors from 'yoctocolors-cjs'
 

--- a/src/commands/scan/cmd-scan-create.ts
+++ b/src/commands/scan/cmd-scan-create.ts
@@ -11,6 +11,7 @@ import { suggestRepoSlug } from './suggest-repo-slug'
 import { suggestBranchSlug } from './suggest_branch_slug'
 import { suggestTarget } from './suggest_target'
 import constants from '../../constants'
+import { commonFlags } from '../../flags'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -24,6 +25,7 @@ const config: CliCommandConfig = {
   description: 'Create a scan',
   hidden: false,
   flags: {
+    ...commonFlags,
     repo: {
       type: 'string',
       shortFlag: 'r',

--- a/src/commands/scan/cmd-scan-del.test.ts
+++ b/src/commands/scan/cmd-scan-del.test.ts
@@ -11,10 +11,13 @@ describe('socket scan del', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['scan', 'del', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['scan', 'del', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Delete a scan
 
         Usage
@@ -29,8 +32,8 @@ describe('socket scan del', async () => {
         Examples
           $ socket scan del FakeOrg 000aaaa1-0000-0a0a-00a0-00a0000000a0"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -38,14 +41,15 @@ describe('socket scan del', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan del\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket scan del`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket scan del`'
+      )
+    }
+  )
 
   cmdit(
-    ['scan', 'del', '--dry-run'],
+    ['scan', 'del', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -69,7 +73,7 @@ describe('socket scan del', async () => {
   )
 
   cmdit(
-    ['scan', 'del', 'fakeorg', 'scanidee', '--dry-run'],
+    ['scan', 'del', 'fakeorg', 'scanidee', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/scan/cmd-scan-list.test.ts
+++ b/src/commands/scan/cmd-scan-list.test.ts
@@ -11,10 +11,13 @@ describe('socket scan list', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['scan', 'list', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['scan', 'list', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "List the scans for an organization
 
         Usage
@@ -35,8 +38,8 @@ describe('socket scan list', async () => {
         Examples
           $ socket scan list FakeOrg"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -44,14 +47,15 @@ describe('socket scan list', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan list\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket scan list`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket scan list`'
+      )
+    }
+  )
 
   cmdit(
-    ['scan', 'list', '--dry-run'],
+    ['scan', 'list', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -73,7 +77,7 @@ describe('socket scan list', async () => {
   )
 
   cmdit(
-    ['scan', 'list', 'fakeorg', '--dry-run'],
+    ['scan', 'list', 'fakeorg', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/scan/cmd-scan-metadata.test.ts
+++ b/src/commands/scan/cmd-scan-metadata.test.ts
@@ -11,10 +11,13 @@ describe('socket scan metadata', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['scan', 'metadata', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['scan', 'metadata', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Get a scan's metadata
 
         Usage
@@ -29,8 +32,8 @@ describe('socket scan metadata', async () => {
         Examples
           $ socket scan metadata FakeOrg 000aaaa1-0000-0a0a-00a0-00a0000000a0"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -38,14 +41,15 @@ describe('socket scan metadata', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan metadata\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket scan metadata`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket scan metadata`'
+      )
+    }
+  )
 
   cmdit(
-    ['scan', 'metadata', '--dry-run'],
+    ['scan', 'metadata', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -69,7 +73,7 @@ describe('socket scan metadata', async () => {
   )
 
   cmdit(
-    ['scan', 'metadata', 'fakeorg', 'scanidee', '--dry-run'],
+    ['scan', 'metadata', 'fakeorg', 'scanidee', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/scan/cmd-scan-report.test.ts
+++ b/src/commands/scan/cmd-scan-report.test.ts
@@ -11,10 +11,13 @@ describe('socket scan report', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['scan', 'report', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['scan', 'report', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Check whether a scan result passes the organizational policies (security, license)
 
         Usage
@@ -49,8 +52,8 @@ describe('socket scan report', async () => {
         Examples
           $ socket scan report FakeOrg 000aaaa1-0000-0a0a-00a0-00a0000000a0 --json --fold=version"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -58,14 +61,15 @@ describe('socket scan report', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan report\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket scan report`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket scan report`'
+      )
+    }
+  )
 
   cmdit(
-    ['scan', 'report', '--dry-run'],
+    ['scan', 'report', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -91,18 +95,18 @@ describe('socket scan report', async () => {
   )
 
   cmdit(
-    ['scan', 'report', 'org', 'report-id', '--dry-run'],
+    ['scan', 'report', 'org', 'report-id', '--dry-run', '--config', '{}'],
     'should be ok with org name and id',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
-      "
-         _____         _       _        /---------------
-        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
-        |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan report\`, cwd: <redacted>"
-    `)
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan report\`, cwd: <redacted>"
+      `)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
     }

--- a/src/commands/scan/cmd-scan-view.test.ts
+++ b/src/commands/scan/cmd-scan-view.test.ts
@@ -11,10 +11,13 @@ describe('socket scan view', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['scan', 'view', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['scan', 'view', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "View the raw results of a scan
 
         Usage
@@ -31,8 +34,8 @@ describe('socket scan view', async () => {
         Examples
           $ socket scan view FakeOrg 000aaaa1-0000-0a0a-00a0-00a0000000a0 ./stream.txt"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -40,14 +43,15 @@ describe('socket scan view', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan view\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket scan view`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket scan view`'
+      )
+    }
+  )
 
   cmdit(
-    ['scan', 'view', '--dry-run'],
+    ['scan', 'view', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -71,7 +75,7 @@ describe('socket scan view', async () => {
   )
 
   cmdit(
-    ['scan', 'view', 'fakeorg', 'scanidee', '--dry-run'],
+    ['scan', 'view', 'fakeorg', 'scanidee', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/scan/cmd-scan.test.ts
+++ b/src/commands/scan/cmd-scan.test.ts
@@ -11,31 +11,34 @@ describe('socket scan', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['scan', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
+  cmdit(
+    ['scan', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
+        "Full Scan related commands
+
+          Usage
+            $ socket scan <command>
+
+          Commands
+            create            Create a scan
+            del               Delete a scan
+            list              List the scans for an organization
+            metadata          Get a scan's metadata
+            view              View the raw results of a scan
+
+          Options
+            --dryRun          Do input validation for a command and exit 0 when input is ok
+            --help            Print this help.
+
+          Examples
+            $ socket scan --help"
       `
-      "Full Scan related commands
-
-        Usage
-          $ socket scan <command>
-
-        Commands
-          create            Create a scan
-          del               Delete a scan
-          list              List the scans for an organization
-          metadata          Get a scan's metadata
-          view              View the raw results of a scan
-
-        Options
-          --dryRun          Do input validation for a command and exit 0 when input is ok
-          --help            Print this help.
-
-        Examples
-          $ socket scan --help"
-    `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -43,14 +46,13 @@ describe('socket scan', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket scan`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain('`socket scan`')
+    }
+  )
 
   cmdit(
-    ['scan', '--dry-run'],
+    ['scan', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/threat-feed/cmd-threat-feed.test.ts
+++ b/src/commands/threat-feed/cmd-threat-feed.test.ts
@@ -11,10 +11,13 @@ describe('socket threat-feed', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['threat-feed', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['threat-feed', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "[beta] View the threat feed
 
         Usage
@@ -61,8 +64,8 @@ describe('socket threat-feed', async () => {
           $ socket threat-feed
           $ socket threat-feed --perPage=5 --page=2 --direction=asc --filter=joke"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -70,14 +73,15 @@ describe('socket threat-feed', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket threat-feed\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket threat-feed`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket threat-feed`'
+      )
+    }
+  )
 
   cmdit(
-    ['threat-feed', '--dry-run'],
+    ['threat-feed', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/wrapper/cmd-wrapper.test.ts
+++ b/src/commands/wrapper/cmd-wrapper.test.ts
@@ -11,10 +11,13 @@ describe('socket wrapper', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['wrapper', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['wrapper', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Enable or disable the Socket npm/npx wrapper
 
         Usage
@@ -30,8 +33,8 @@ describe('socket wrapper', async () => {
           $ socket wrapper --enable
           $ socket wrapper --disable"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -39,14 +42,15 @@ describe('socket wrapper', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket wrapper\`, cwd: <redacted>"
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket wrapper`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket wrapper`'
+      )
+    }
+  )
 
   cmdit(
-    ['wrapper', '--dry-run'],
+    ['wrapper', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -7,9 +7,18 @@ type NumberFlag = Flag<'number', number> | Flag<'number', number[], true>
 type AnyFlag = StringFlag | BooleanFlag | NumberFlag
 
 // Note: we use this description in getFlagListOutput, meow doesn't care
-export type MeowFlags = Record<string, AnyFlag & { description: string }>
+export type MeowFlags = Record<
+  string,
+  AnyFlag & { description: string; hidden?: boolean }
+>
 
 export const commonFlags: MeowFlags = {
+  config: {
+    type: 'string',
+    default: '',
+    hidden: true,
+    description: 'Override the local config with this JSON'
+  },
   help: {
     type: 'boolean',
     default: false,

--- a/src/utils/output-formatting.ts
+++ b/src/utils/output-formatting.ts
@@ -1,12 +1,16 @@
+import type { MeowFlags } from '../flags'
+
 type HelpListOptions = {
   keyPrefix: string
   padName: number
 }
 
-type ListDescription = string | { description: string }
+type ListDescription =
+  | { description: string }
+  | { description: string; hidden: boolean }
 
 export function getFlagListOutput(
-  list: Record<string, ListDescription>,
+  list: MeowFlags,
   indent: number,
   { keyPrefix = '--', padName } = {} as HelpListOptions
 ): string {
@@ -27,16 +31,17 @@ export function getHelpListOutput(
   let result = ''
   const names = Object.keys(list).sort()
   for (const name of names) {
-    const rawDescription = list[name]
+    const entry = list[name]
+    if (entry && 'hidden' in entry && entry?.hidden) {
+      continue
+    }
     const description =
-      (typeof rawDescription === 'object'
-        ? rawDescription.description
-        : rawDescription) || ''
+      (typeof entry === 'object' ? entry.description : entry) || ''
     result +=
       ''.padEnd(indent) +
       (keyPrefix + name).padEnd(padName) +
       description +
       '\n'
   }
-  return result.trim()
+  return result.trim() || '(none)'
 }


### PR DESCRIPTION
This adds an option to override the local config through either an env var (`SOCKET_CLI_CONFIG`) or flag (`--config`).

When an override is used, config changes will not be persisted to disk.

The main goal is to add an easy way for tests to use different configs without having to set up heavy machinery for it. But it's also a common feature seen in other packages so why not.

This will add a hidden flag `--config` to almost all commands.

Drops `process` imports because that's an auto-global in nodejs.

All tests are updated to use `--config {}`, where supported. Lots of churn in the test files as a result. Would ignore that in the review.

This PR also fixes a bunch of the `dry-run` tests :see_no_evil: because they were still using `--help`.

