### PR TITLE
Abstract bad input reporter to make it more consistent

### DIFF
--- a/src/commands/audit-log/cmd-audit-log.test.ts
+++ b/src/commands/audit-log/cmd-audit-log.test.ts
@@ -67,9 +67,9 @@ describe('socket audit-log', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket audit-log\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m"
+          - Org name should be the first arg (\\x1b[31mmissing\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/audit-log/cmd-audit-log.ts
+++ b/src/commands/audit-log/cmd-audit-log.ts
@@ -1,12 +1,10 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleAuditLog } from './handle-audit-log'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { getConfigValue } from '../../utils/config'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -79,19 +77,13 @@ async function run(
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
 
-  if (!orgSlug) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(
-      stripIndents`
-      ${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:\n
-      - Org name as the first argument ${!orgSlug ? colors.red('(missing!)') : colors.green('(ok)')}
-    `
-    )
-    return
-  }
+  const waswasInput = handleBadInput({
+    test: orgSlug,
+    message: 'Org name should be the first arg',
+    pass: 'ok',
+    fail: 'missing'
+  })
+  if (waswasInput) return
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)

--- a/src/commands/config/cmd-config-auto.ts
+++ b/src/commands/config/cmd-config-auto.ts
@@ -1,12 +1,10 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleConfigAuto } from './handle-config-auto'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { supportedConfigKeys } from '../../utils/config'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -67,17 +65,13 @@ async function run(
   const { json, markdown } = cli.flags
   const [key = ''] = cli.input
 
-  if (!supportedConfigKeys.has(key as keyof LocalConfig) && key !== 'test') {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(stripIndents`${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
-
-      - Config key should be the first arg ${!key ? colors.red('(missing!)') : !supportedConfigKeys.has(key as any) ? colors.red('(invalid config key!)') : colors.green('(ok)')}
-    `)
-    return
-  }
+  const wasBadInput = handleBadInput({
+    test: supportedConfigKeys.has(key as keyof LocalConfig) && key !== 'test',
+    message: 'Config key should be the first arg',
+    pass: 'ok',
+    fail: key ? 'invalid config key' : 'missing'
+  })
+  if (wasBadInput) return
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)

--- a/src/commands/config/cmd-config-get.test.ts
+++ b/src/commands/config/cmd-config-get.test.ts
@@ -18,28 +18,28 @@ describe('socket config get', async () => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "Get the value of a local CLI config item
+        "Get the value of a local CLI config item
 
-        Usage
-          $ socket config get <org slug>
+          Usage
+            $ socket config get <org slug>
 
-        Options
-          --dryRun          Do input validation for a command and exit 0 when input is ok
-          --help            Print this help.
-          --json            Output result as json
-          --markdown        Output result as markdown
+          Options
+            --dryRun          Do input validation for a command and exit 0 when input is ok
+            --help            Print this help.
+            --json            Output result as json
+            --markdown        Output result as markdown
 
-        Keys:
+          Keys:
 
-         - apiBaseUrl -- Base URL of the API endpoint
-         - apiProxy -- A proxy through which to access the API
-         - apiToken -- The API token required to access most API endpoints
-         - defaultOrg -- The default org slug to use when appropriate; usually the org your API token has access to. When set, all orgSlug arguments are implied to be this value.
-         - enforcedOrgs -- Orgs in this list have their security policies enforced on this machine
+           - apiBaseUrl -- Base URL of the API endpoint
+           - apiProxy -- A proxy through which to access the API
+           - apiToken -- The API token required to access most API endpoints
+           - defaultOrg -- The default org slug to use when appropriate; usually the org your API token has access to. When set, all orgSlug arguments are implied to be this value.
+           - enforcedOrgs -- Orgs in this list have their security policies enforced on this machine
 
-        Examples
-          $ socket config get FakeOrg --repoName=test-repo"
-    `
+          Examples
+            $ socket config get FakeOrg --repoName=test-repo"
+      `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
@@ -69,9 +69,9 @@ describe('socket config get', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket config get\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - Config key should be the first arg \\x1b[31m(missing!)\\x1b[39m"
+          - Config key should be the first arg (\\x1b[31mmissing\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -79,17 +79,19 @@ describe('socket config get', async () => {
   )
 
   cmdit(
-    ['config', 'get', 'test', '--dry-run', '--config', '{}'],
+    ['config', 'test', 'test', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(stdout).toMatchInlineSnapshot(
+        `"[DryRun]: No-op, call a sub-command; ok"`
+      )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-          |_____|___|___|_,_|___|_|.dev   | Command: \`socket config get\`, cwd: <redacted>"
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket config\`, cwd: <redacted>"
       `)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)

--- a/src/commands/config/cmd-config-get.ts
+++ b/src/commands/config/cmd-config-get.ts
@@ -1,12 +1,10 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleConfigGet } from './handle-config-get'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { supportedConfigKeys } from '../../utils/config'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -62,17 +60,13 @@ async function run(
   const { json, markdown } = cli.flags
   const [key = ''] = cli.input
 
-  if (!supportedConfigKeys.has(key as keyof LocalConfig) && key !== 'test') {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(stripIndents`${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
-
-      - Config key should be the first arg ${!key ? colors.red('(missing!)') : !supportedConfigKeys.has(key as any) ? colors.red('(invalid config key!)') : colors.green('(ok)')}
-    `)
-    return
-  }
+  const wasBadInput = handleBadInput({
+    test: supportedConfigKeys.has(key as keyof LocalConfig) || key === 'test',
+    message: 'Config key should be the first arg',
+    pass: 'ok',
+    fail: key ? 'invalid config key' : 'missing'
+  })
+  if (wasBadInput) return
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)

--- a/src/commands/config/cmd-config-list.test.ts
+++ b/src/commands/config/cmd-config-list.test.ts
@@ -18,29 +18,29 @@ describe('socket config get', async () => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "Show all local CLI config items and their values
+        "Show all local CLI config items and their values
 
-        Usage
-          $ socket config list <org slug>
+          Usage
+            $ socket config list <org slug>
 
-        Options
-          --dryRun          Do input validation for a command and exit 0 when input is ok
-          --full            Show full tokens in plaintext (unsafe)
-          --help            Print this help.
-          --json            Output result as json
-          --markdown        Output result as markdown
+          Options
+            --dryRun          Do input validation for a command and exit 0 when input is ok
+            --full            Show full tokens in plaintext (unsafe)
+            --help            Print this help.
+            --json            Output result as json
+            --markdown        Output result as markdown
 
-        Keys:
+          Keys:
 
-         - apiBaseUrl -- Base URL of the API endpoint
-         - apiProxy -- A proxy through which to access the API
-         - apiToken -- The API token required to access most API endpoints
-         - defaultOrg -- The default org slug to use when appropriate; usually the org your API token has access to. When set, all orgSlug arguments are implied to be this value.
-         - enforcedOrgs -- Orgs in this list have their security policies enforced on this machine
+           - apiBaseUrl -- Base URL of the API endpoint
+           - apiProxy -- A proxy through which to access the API
+           - apiToken -- The API token required to access most API endpoints
+           - defaultOrg -- The default org slug to use when appropriate; usually the org your API token has access to. When set, all orgSlug arguments are implied to be this value.
+           - enforcedOrgs -- Orgs in this list have their security policies enforced on this machine
 
-        Examples
-          $ socket config list FakeOrg --repoName=test-repo"
-    `
+          Examples
+            $ socket config list FakeOrg --repoName=test-repo"
+      `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "

--- a/src/commands/config/cmd-config-set.test.ts
+++ b/src/commands/config/cmd-config-set.test.ts
@@ -18,33 +18,33 @@ describe('socket config get', async () => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "Update the value of a local CLI config item
+        "Update the value of a local CLI config item
 
-        Usage
-          $ socket config set <key> <value>
+          Usage
+            $ socket config set <key> <value>
 
-        Options
-          --dryRun          Do input validation for a command and exit 0 when input is ok
-          --help            Print this help.
-          --json            Output result as json
-          --markdown        Output result as markdown
+          Options
+            --dryRun          Do input validation for a command and exit 0 when input is ok
+            --help            Print this help.
+            --json            Output result as json
+            --markdown        Output result as markdown
 
-        This is a crude way of updating the local configuration for this CLI tool.
+          This is a crude way of updating the local configuration for this CLI tool.
 
-        Note that updating a value here is nothing more than updating a key/value
-        store entry. No validation is happening. The server may reject your config.
+          Note that updating a value here is nothing more than updating a key/value
+          store entry. No validation is happening. The server may reject your config.
 
-        Keys:
+          Keys:
 
-         - apiBaseUrl -- Base URL of the API endpoint
-         - apiProxy -- A proxy through which to access the API
-         - apiToken -- The API token required to access most API endpoints
-         - defaultOrg -- The default org slug to use when appropriate; usually the org your API token has access to. When set, all orgSlug arguments are implied to be this value.
-         - enforcedOrgs -- Orgs in this list have their security policies enforced on this machine
+           - apiBaseUrl -- Base URL of the API endpoint
+           - apiProxy -- A proxy through which to access the API
+           - apiToken -- The API token required to access most API endpoints
+           - defaultOrg -- The default org slug to use when appropriate; usually the org your API token has access to. When set, all orgSlug arguments are implied to be this value.
+           - enforcedOrgs -- Orgs in this list have their security policies enforced on this machine
 
-        Examples
-          $ socket config set apiProxy https://example.com"
-    `
+          Examples
+            $ socket config set apiProxy https://example.com"
+      `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
@@ -74,11 +74,11 @@ describe('socket config get', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket config set\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - Config key should be the first arg \\x1b[31m(missing!)\\x1b[39m
+          - Config key should be the first arg (\\x1b[31mmissing\\x1b[39m)
 
-        - Key value should be the remaining args (use \`del\` to unset a value) \\x1b[31m(missing!)\\x1b[39m"
+          - Key value should be the remaining args (use \`unset\` to unset a value) (\\x1b[31mmissing\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/config/cmd-config-unset.test.ts
+++ b/src/commands/config/cmd-config-unset.test.ts
@@ -18,28 +18,28 @@ describe('socket config unset', async () => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "Clear the value of a local CLI config item
+        "Clear the value of a local CLI config item
 
-        Usage
-          $ socket config unset <org slug>
+          Usage
+            $ socket config unset <org slug>
 
-        Options
-          --dryRun          Do input validation for a command and exit 0 when input is ok
-          --help            Print this help.
-          --json            Output result as json
-          --markdown        Output result as markdown
+          Options
+            --dryRun          Do input validation for a command and exit 0 when input is ok
+            --help            Print this help.
+            --json            Output result as json
+            --markdown        Output result as markdown
 
-        Keys:
+          Keys:
 
-         - apiBaseUrl -- Base URL of the API endpoint
-         - apiProxy -- A proxy through which to access the API
-         - apiToken -- The API token required to access most API endpoints
-         - defaultOrg -- The default org slug to use when appropriate; usually the org your API token has access to. When set, all orgSlug arguments are implied to be this value.
-         - enforcedOrgs -- Orgs in this list have their security policies enforced on this machine
+           - apiBaseUrl -- Base URL of the API endpoint
+           - apiProxy -- A proxy through which to access the API
+           - apiToken -- The API token required to access most API endpoints
+           - defaultOrg -- The default org slug to use when appropriate; usually the org your API token has access to. When set, all orgSlug arguments are implied to be this value.
+           - enforcedOrgs -- Orgs in this list have their security policies enforced on this machine
 
-        Examples
-          $ socket config unset FakeOrg --repoName=test-repo"
-    `
+          Examples
+            $ socket config unset FakeOrg --repoName=test-repo"
+      `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
@@ -69,9 +69,9 @@ describe('socket config unset', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket config unset\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - Config key should be the first arg \\x1b[31m(missing!)\\x1b[39m"
+          - Config key should be the first arg (\\x1b[31mmissing\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/config/cmd-config-unset.ts
+++ b/src/commands/config/cmd-config-unset.ts
@@ -1,12 +1,10 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleConfigUnset } from './handle-config-unset'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { supportedConfigKeys } from '../../utils/config'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -62,17 +60,13 @@ async function run(
   const { json, markdown } = cli.flags
   const [key = ''] = cli.input
 
-  if (!supportedConfigKeys.has(key as keyof LocalConfig) && key !== 'test') {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(stripIndents`${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
-
-      - Config key should be the first arg ${!key ? colors.red('(missing!)') : !supportedConfigKeys.has(key as any) ? colors.red('(invalid config key!)') : colors.green('(ok)')}
-    `)
-    return
-  }
+  const wasBadInput = handleBadInput({
+    test: supportedConfigKeys.has(key as keyof LocalConfig) || key === 'test',
+    message: 'Config key should be the first arg',
+    pass: 'ok',
+    fail: key ? 'invalid config key' : 'missing'
+  })
+  if (wasBadInput) return
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)

--- a/src/commands/diff-scan/cmd-diff-scan-get.test.ts
+++ b/src/commands/diff-scan/cmd-diff-scan-get.test.ts
@@ -68,11 +68,12 @@ describe('socket diff-scan get', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-              - Specify a before and after scan ID \\x1b[31m(missing before and after!)\\x1b[39m
-                  - To get scans IDs, you can run the command "socket scan list <your org slug>".
-                    The args are expecting a full \`aaa0aa0a-aaaa-0000-0a0a-0000000a00a0\` ID."
+          - Specify a before and after scan ID (\\x1b[31mmissing before and after\\x1b[39m)
+            The args are expecting a full \`aaa0aa0a-aaaa-0000-0a0a-0000000a00a0\` scan ID.
+
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/info/cmd-info.test.ts
+++ b/src/commands/info/cmd-info.test.ts
@@ -62,11 +62,11 @@ describe('socket info', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket info\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-              - Expecting a package name \\x1b[31m(missing!)\\x1b[39m
+          - Expecting a package name (\\x1b[31mmissing\\x1b[39m)
 
-              - Can only accept one package at a time \\x1b[32m(ok)\\x1b[39m"
+          - Can only accept one package at a time (\\x1b[31mgot 0\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/info/cmd-info.ts
+++ b/src/commands/info/cmd-info.ts
@@ -1,10 +1,9 @@
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handlePackageInfo } from './handle-package-info'
 import constants from '../../constants'
 import { commonFlags, outputFlags, validationFlags } from '../../flags'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -55,16 +54,22 @@ async function run(
   const { all, json, markdown, strict } = cli.flags
   const [rawPkgName = ''] = cli.input
 
-  if (!rawPkgName || cli.input.length > 1) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(`${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:\n
-      - Expecting a package name ${!rawPkgName ? colors.red('(missing!)') : colors.green('(ok)')}\n
-      - Can only accept one package at a time ${cli.input.length > 1 ? colors.red('(got ' + cli.input.length + '!)') : colors.green('(ok)')}\n`)
-    return
-  }
+  const wasBadInput = handleBadInput(
+    {
+      test: rawPkgName,
+      message: 'Expecting a package name',
+      pass: 'ok',
+      fail: 'missing'
+    },
+    {
+      test: cli.input.length === 1,
+      hide: cli.input.length === 1,
+      message: 'Can only accept one package at a time',
+      pass: 'ok',
+      fail: 'got ' + cli.input.length
+    }
+  )
+  if (wasBadInput) return
 
   const versionSeparator = rawPkgName.lastIndexOf('@')
   const pkgName =

--- a/src/commands/manifest/cmd-manifest-gradle.test.ts
+++ b/src/commands/manifest/cmd-manifest-gradle.test.ts
@@ -88,11 +88,11 @@ describe('socket manifest gradle', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest gradle\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - The DIR arg is required \\x1b[31m(missing!)\\x1b[39m
+          - The DIR arg is required (\\x1b[31mmissing\\x1b[39m)
 
-        - Can only accept one DIR (make sure to escape spaces!) \\x1b[32m(ok)\\x1b[39m"
+          - Can only accept one DIR (make sure to escape spaces!) (\\x1b[31mreceived 0\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/manifest/cmd-manifest-gradle.ts
+++ b/src/commands/manifest/cmd-manifest-gradle.ts
@@ -1,13 +1,11 @@
 import path from 'node:path'
 
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { convertGradleToMaven } from './convert_gradle_to_maven'
 import constants from '../../constants'
 import { commonFlags } from '../../flags'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -118,23 +116,28 @@ async function run(
     logger.groupEnd()
   }
 
-  const target = cli.input[0]
+  const [target = ''] = cli.input
 
   // TODO: I'm not sure it's feasible to parse source file from stdin. We could
-  // try, store contents in a file in some folder, target that folder... what
-  // would the file name be?
-  if (!target || target === '-' || cli.input.length > 1) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(stripIndents`${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
+  //       try, store contents in a file in some folder, target that folder... what
+  //       would the file name be?
 
-      - The DIR arg is required ${!target ? colors.red('(missing!)') : target === '-' ? colors.red('(stdin is not supported)') : colors.green('(ok)')}
-
-      - Can only accept one DIR (make sure to escape spaces!) ${cli.input.length > 1 ? colors.red(`(received ${cli.input.length}!)`) : colors.green('(ok)')}`)
-    return
-  }
+  const wasBadInput = handleBadInput(
+    {
+      test: target && target !== '-',
+      message: 'The DIR arg is required',
+      pass: 'ok',
+      fail: target === '-' ? 'stdin is not supported' : 'missing'
+    },
+    {
+      test: cli.input.length === 1,
+      hide: cli.input.length === 1,
+      message: 'Can only accept one DIR (make sure to escape spaces!)',
+      pass: 'ok',
+      fail: 'received ' + cli.input.length
+    }
+  )
+  if (wasBadInput) return
 
   let bin: string
   if (cli.flags['bin']) {

--- a/src/commands/manifest/cmd-manifest-kotlin.test.ts
+++ b/src/commands/manifest/cmd-manifest-kotlin.test.ts
@@ -88,11 +88,11 @@ describe('socket manifest kotlin', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest kotlin\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - The DIR arg is required \\x1b[31m(missing!)\\x1b[39m
+          - The DIR arg is required (\\x1b[31mmissing\\x1b[39m)
 
-        - Can only accept one DIR (make sure to escape spaces!) \\x1b[32m(ok)\\x1b[39m"
+          - Can only accept one DIR (make sure to escape spaces!) (\\x1b[31mreceived 0\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/manifest/cmd-manifest-kotlin.ts
+++ b/src/commands/manifest/cmd-manifest-kotlin.ts
@@ -1,13 +1,11 @@
 import path from 'node:path'
 
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { convertGradleToMaven } from './convert_gradle_to_maven'
 import constants from '../../constants'
 import { commonFlags } from '../../flags'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -123,25 +121,28 @@ async function run(
     logger.groupEnd()
   }
 
-  const target = cli.input[0]
+  const [target = ''] = cli.input
 
   // TODO: I'm not sure it's feasible to parse source file from stdin. We could
-  // try, store contents in a file in some folder, target that folder... what
-  // would the file name be?
-  if (!target || target === '-' || cli.input.length > 1) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(
-      stripIndents`${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
+  //       try, store contents in a file in some folder, target that folder... what
+  //       would the file name be?
 
-      - The DIR arg is required ${!target ? colors.red('(missing!)') : target === '-' ? colors.red('(stdin is not supported)') : colors.green('(ok)')}
-
-      - Can only accept one DIR (make sure to escape spaces!) ${cli.input.length > 1 ? colors.red(`(received ${cli.input.length}!)`) : colors.green('(ok)')}`
-    )
-    return
-  }
+  const wasBadInput = handleBadInput(
+    {
+      test: target && target !== '-',
+      message: 'The DIR arg is required',
+      pass: 'ok',
+      fail: target === '-' ? 'stdin is not supported' : 'missing'
+    },
+    {
+      test: cli.input.length === 1,
+      hide: cli.input.length === 1,
+      message: 'Can only accept one DIR (make sure to escape spaces!)',
+      pass: 'ok',
+      fail: 'received ' + cli.input.length
+    }
+  )
+  if (wasBadInput) return
 
   let bin: string
   if (cli.flags['bin']) {

--- a/src/commands/manifest/cmd-manifest-scala.test.ts
+++ b/src/commands/manifest/cmd-manifest-scala.test.ts
@@ -92,11 +92,11 @@ describe('socket manifest scala', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest scala\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - The DIR or FILE arg is required \\x1b[31m(missing!)\\x1b[39m
+          - The DIR arg is required (\\x1b[31mmissing\\x1b[39m)
 
-        - Can only accept one DIR or FILE (make sure to escape spaces!) \\x1b[32m(ok)\\x1b[39m"
+          - Can only accept one DIR (make sure to escape spaces!) (\\x1b[31mreceived 0\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/manifest/cmd-manifest-scala.ts
+++ b/src/commands/manifest/cmd-manifest-scala.ts
@@ -1,11 +1,9 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { convertSbtToMaven } from './convert_sbt_to_maven'
 import constants from '../../constants'
 import { commonFlags } from '../../flags'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -116,25 +114,28 @@ async function run(
     logger.groupEnd()
   }
 
-  const target = cli.input[0]
+  const [target = ''] = cli.input
 
   // TODO: I'm not sure it's feasible to parse source file from stdin. We could
-  // try, store contents in a file in some folder, target that folder... what
-  // would the file name be?
-  if (!target || target === '-' || cli.input.length > 1) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(
-      stripIndents`${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
+  //       try, store contents in a file in some folder, target that folder... what
+  //       would the file name be?
 
-      - The DIR or FILE arg is required ${!target ? colors.red('(missing!)') : target === '-' ? colors.red('(stdin is not supported)') : colors.green('(ok)')}
-
-      - Can only accept one DIR or FILE (make sure to escape spaces!) ${cli.input.length > 1 ? colors.red(`(received ${cli.input.length}!)`) : colors.green('(ok)')}`
-    )
-    return
-  }
+  const wasBadInput = handleBadInput(
+    {
+      test: target && target !== '-',
+      message: 'The DIR arg is required',
+      pass: 'ok',
+      fail: target === '-' ? 'stdin is not supported' : 'missing'
+    },
+    {
+      test: cli.input.length === 1,
+      hide: cli.input.length === 1,
+      message: 'Can only accept one DIR (make sure to escape spaces!)',
+      pass: 'ok',
+      fail: 'received ' + cli.input.length
+    }
+  )
+  if (wasBadInput) return
 
   let bin: string = 'sbt'
   if (cli.flags['bin']) {

--- a/src/commands/organization/cmd-organization-list.ts
+++ b/src/commands/organization/cmd-organization-list.ts
@@ -1,11 +1,9 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleOrganizationList } from './handle-organization-list'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -50,18 +48,15 @@ async function run(
 
   const json = Boolean(cli.flags['json'])
   const markdown = Boolean(cli.flags['markdown'])
-  if (json && markdown) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(stripIndents`
-${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
 
-  - The json and markdown flags cannot be both set, pick one
-    `)
-    return
-  }
+  const wasBadInput = handleBadInput({
+    hide: !json || !markdown,
+    test: !json || !markdown,
+    message: 'The json and markdown flags cannot be both set, pick one',
+    pass: 'ok',
+    fail: 'omit one'
+  })
+  if (wasBadInput) return
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)

--- a/src/commands/organization/cmd-organization-policy-security.test.ts
+++ b/src/commands/organization/cmd-organization-policy-security.test.ts
@@ -65,10 +65,9 @@ describe('socket organization list', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy security\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m
-        - The json and markdown flags cannot be both set \\x1b[32m(ok)\\x1b[39m"
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if input bad').toBe(2)

--- a/src/commands/organization/cmd-organization-policy-security.ts
+++ b/src/commands/organization/cmd-organization-policy-security.ts
@@ -1,12 +1,10 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleSecurityPolicy } from './handle-security-policy'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { getConfigValue } from '../../utils/config'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -63,19 +61,23 @@ async function run(
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
 
-  if (!orgSlug || (json && markdown)) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(stripIndents`
-${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
-
-  ${defaultOrgSlug ? '' : `- Org name as the first argument ${!orgSlug ? colors.red('(missing!)') : colors.green('(ok)')}`}
-  - The json and markdown flags cannot be both set ${json && markdown ? colors.red('(pick one!)') : colors.green('(ok)')}
-    `)
-    return
-  }
+  const wasBadInput = handleBadInput(
+    {
+      hide: defaultOrgSlug,
+      test: orgSlug,
+      message: 'Org name as the first argument',
+      pass: 'ok',
+      fail: 'missing'
+    },
+    {
+      hide: !json || !markdown,
+      test: !json || !markdown,
+      message: 'The json and markdown flags cannot be both set, pick one',
+      pass: 'ok',
+      fail: 'omit one'
+    }
+  )
+  if (wasBadInput) return
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)

--- a/src/commands/organization/cmd-organization-quota.ts
+++ b/src/commands/organization/cmd-organization-quota.ts
@@ -1,11 +1,9 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleQuota } from './handle-quota'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -50,18 +48,15 @@ async function run(
 
   const json = Boolean(cli.flags['json'])
   const markdown = Boolean(cli.flags['markdown'])
-  if (json && markdown) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(stripIndents`
-${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
 
-  - The json and markdown flags cannot be both set, pick one
-    `)
-    return
-  }
+  const wasBadInput = handleBadInput({
+    hide: !json || !markdown,
+    test: !json || !markdown,
+    message: 'The json and markdown flags cannot be both set, pick one',
+    pass: 'ok',
+    fail: 'omit one'
+  })
+  if (wasBadInput) return
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)

--- a/src/commands/package/cmd-package-shallow.test.ts
+++ b/src/commands/package/cmd-package-shallow.test.ts
@@ -83,11 +83,11 @@ describe('socket package shallow', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket package shallow\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-              - First parameter should be an ecosystem or all args must be purls \\x1b[31m(bad!)\\x1b[39m
+          - First parameter should be an ecosystem or all args must be purls (\\x1b[31mbad\\x1b[39m)
 
-              - Expecting at least one package \\x1b[31m(missing!)\\x1b[39m"
+          - Expecting at least one package (\\x1b[31mmissing\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/package/cmd-package-shallow.ts
+++ b/src/commands/package/cmd-package-shallow.ts
@@ -1,11 +1,10 @@
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handlePurlsShallowScore } from './handle-purls-shallow-score'
 import { parsePackageSpecifiers } from './parse-package-specifiers'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -86,17 +85,29 @@ async function run(
 
   const { purls, valid } = parsePackageSpecifiers(ecosystem, pkgs)
 
-  if (!valid || !purls.length) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(`${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:\n
-      - First parameter should be an ecosystem or all args must be purls ${!valid ? colors.red('(bad!)') : colors.green('(ok)')}\n
-      - Expecting at least one package ${!purls.length ? colors.red('(missing!)') : colors.green('(ok)')}\n
-    `)
-    return
-  }
+  const wasBadInput = handleBadInput(
+    {
+      test: valid,
+      message:
+        'First parameter should be an ecosystem or all args must be purls',
+      pass: 'ok',
+      fail: 'bad'
+    },
+    {
+      test: purls.length > 0,
+      message: 'Expecting at least one package',
+      pass: 'ok',
+      fail: 'missing'
+    },
+    {
+      hide: !json || !markdown,
+      test: !json || !markdown,
+      message: 'The json and markdown flags cannot be both set, pick one',
+      pass: 'ok',
+      fail: 'omit one'
+    }
+  )
+  if (wasBadInput) return
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)

--- a/src/commands/repos/cmd-repos-create.test.ts
+++ b/src/commands/repos/cmd-repos-create.test.ts
@@ -64,11 +64,11 @@ describe('socket repos create', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos create\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-        - Repository name using --repoName \\x1b[31m(missing!)\\x1b[39m"
+          - Repository name using --repoNam (\\x1b[31minvalid\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/repos/cmd-repos-create.ts
+++ b/src/commands/repos/cmd-repos-create.ts
@@ -1,11 +1,10 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleCreateRepo } from './handle-create-repo'
 import constants from '../../constants'
 import { commonFlags } from '../../flags'
+import { getConfigValue } from '../../utils/config'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -81,20 +80,25 @@ async function run(
   })
 
   const repoName = cli.flags['repoName']
-  const [orgSlug = ''] = cli.input
+  const defaultOrgSlug = getConfigValue('defaultOrg')
+  const orgSlug = defaultOrgSlug || cli.input[0] || ''
 
-  if (!repoName || typeof repoName !== 'string' || !orgSlug) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(stripIndents`${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
-
-      - Org name as the first argument ${!orgSlug ? colors.red('(missing!)') : colors.green('(ok)')}
-
-      - Repository name using --repoName ${!repoName ? colors.red('(missing!)') : typeof repoName !== 'string' ? colors.red('(invalid!)') : colors.green('(ok)')}`)
-    return
-  }
+  const wasBadInput = handleBadInput(
+    {
+      hide: defaultOrgSlug,
+      test: orgSlug,
+      message: 'Org name as the first argument',
+      pass: 'ok',
+      fail: 'missing'
+    },
+    {
+      test: repoName,
+      message: 'Repository name using --repoNam',
+      pass: 'ok',
+      fail: typeof repoName !== 'string' ? 'missing' : 'invalid'
+    }
+  )
+  if (wasBadInput) return
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)
@@ -103,7 +107,7 @@ async function run(
 
   await handleCreateRepo({
     orgSlug,
-    repoName,
+    repoName: String(repoName),
     description: String(cli.flags['repoDescription'] || ''),
     homepage: String(cli.flags['homepage'] || ''),
     default_branch: String(cli.flags['defaultBranch'] || ''),

--- a/src/commands/repos/cmd-repos-del.test.ts
+++ b/src/commands/repos/cmd-repos-del.test.ts
@@ -59,11 +59,11 @@ describe('socket repos del', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos del\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-        - A repository name argument \\x1b[31m(missing!)\\x1b[39m"
+          - Repository name argument (\\x1b[31minvalid\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/repos/cmd-repos-list.test.ts
+++ b/src/commands/repos/cmd-repos-list.test.ts
@@ -65,9 +65,9 @@ describe('socket repos list', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos list\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m"
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/repos/cmd-repos-list.ts
+++ b/src/commands/repos/cmd-repos-list.ts
@@ -1,12 +1,10 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleListRepos } from './handle-list-repos'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { getConfigValue } from '../../utils/config'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -78,17 +76,14 @@ async function run(
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
 
-  if (!orgSlug) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(stripIndents`${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
-
-      - Org name as the first argument ${!orgSlug ? colors.red('(missing!)') : colors.green('(ok)')}
-    `)
-    return
-  }
+  const wasBadInput = handleBadInput({
+    hide: defaultOrgSlug,
+    test: orgSlug,
+    message: 'Org name as the first argument',
+    pass: 'ok',
+    fail: 'missing'
+  })
+  if (wasBadInput) return
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)

--- a/src/commands/repos/cmd-repos-update.test.ts
+++ b/src/commands/repos/cmd-repos-update.test.ts
@@ -64,11 +64,11 @@ describe('socket repos update', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos update\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-        - Repository name using --repoName \\x1b[31m(missing!)\\x1b[39m"
+          - Repository name using --repoName (\\x1b[31minvalid\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/repos/cmd-repos-update.ts
+++ b/src/commands/repos/cmd-repos-update.ts
@@ -1,12 +1,10 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleUpdateRepo } from './handle-update-repo'
 import constants from '../../constants'
 import { commonFlags } from '../../flags'
 import { getConfigValue } from '../../utils/config'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -85,19 +83,22 @@ async function run(
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
 
-  if (!repoName || typeof repoName !== 'string' || !orgSlug) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(stripIndents`${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
-
-      ${defaultOrgSlug ? '' : `- Org name as the first argument ${!orgSlug ? colors.red('(missing!)') : colors.green('(ok)')}`}
-
-      - Repository name using --repoName ${!repoName ? colors.red('(missing!)') : typeof repoName !== 'string' ? colors.red('(invalid!)') : colors.green('(ok)')}
-    `)
-    return
-  }
+  const wasBadInput = handleBadInput(
+    {
+      hide: defaultOrgSlug,
+      test: orgSlug,
+      message: 'Org name as the first argument',
+      pass: 'ok',
+      fail: 'missing'
+    },
+    {
+      test: repoName,
+      message: 'Repository name using --repoName',
+      pass: 'ok',
+      fail: typeof repoName !== 'string' ? 'missing' : 'invalid'
+    }
+  )
+  if (wasBadInput) return
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)
@@ -106,7 +107,7 @@ async function run(
 
   await handleUpdateRepo({
     orgSlug,
-    repoName,
+    repoName: String(repoName),
     description: String(cli.flags['repoDescription'] || ''),
     homepage: String(cli.flags['homepage'] || ''),
     default_branch: String(cli.flags['defaultBranch'] || ''),

--- a/src/commands/repos/cmd-repos-view.test.ts
+++ b/src/commands/repos/cmd-repos-view.test.ts
@@ -62,10 +62,11 @@ describe('socket repos view', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos view\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m
-        - Repository name using --repoName \\x1b[31m(missing!)\\x1b[39m"
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
+
+          - Repository name using --repoName (\\x1b[31minvalid\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/repos/cmd-repos-view.ts
+++ b/src/commands/repos/cmd-repos-view.ts
@@ -1,12 +1,10 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleViewRepo } from './handle-view-repo'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { getConfigValue } from '../../utils/config'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -62,32 +60,22 @@ async function run(
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
 
-  if (!repoName || typeof repoName !== 'string' || !orgSlug) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(
-      stripIndents`
-      ${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
-
-      ${
-        defaultOrgSlug
-          ? ''
-          : `- Org name as the first argument ${
-              !orgSlug ? colors.red('(missing!)') : colors.green('(ok)')
-            }\n`
-      }- Repository name using --repoName ${
-        !repoName
-          ? colors.red('(missing!)')
-          : typeof repoName !== 'string'
-            ? colors.red('(invalid!)')
-            : colors.green('(ok)')
-      }
-    `
-    )
-    return
-  }
+  const wasBadInput = handleBadInput(
+    {
+      hide: defaultOrgSlug,
+      test: orgSlug,
+      message: 'Org name as the first argument',
+      pass: 'ok',
+      fail: 'missing'
+    },
+    {
+      test: repoName,
+      message: 'Repository name using --repoName',
+      pass: 'ok',
+      fail: typeof repoName !== 'string' ? 'missing' : 'invalid'
+    }
+  )
+  if (wasBadInput) return
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)
@@ -96,7 +84,7 @@ async function run(
 
   await handleViewRepo(
     orgSlug,
-    repoName,
+    String(repoName),
     json ? 'json' : markdown ? 'markdown' : 'text'
   )
 }

--- a/src/commands/scan/cmd-scan-create.test.ts
+++ b/src/commands/scan/cmd-scan-create.test.ts
@@ -85,6 +85,7 @@ describe('socket scan create', async () => {
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------
@@ -92,7 +93,6 @@ describe('socket scan create', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan create\`, cwd: <redacted>"
       `)
-      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
     }

--- a/src/commands/scan/cmd-scan-create.test.ts
+++ b/src/commands/scan/cmd-scan-create.test.ts
@@ -80,7 +80,9 @@ describe('socket scan create', async () => {
       '--repo',
       'xyz',
       '--branch',
-      'abc'
+      'abc',
+      '--config',
+      '{"apiKey": "abc"}'
     ],
     'should require args with just dry-run',
     async cmd => {

--- a/src/commands/scan/cmd-scan-create.test.ts
+++ b/src/commands/scan/cmd-scan-create.test.ts
@@ -85,7 +85,6 @@ describe('socket scan create', async () => {
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------
@@ -93,6 +92,7 @@ describe('socket scan create', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan create\`, cwd: <redacted>"
       `)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
     }

--- a/src/commands/scan/cmd-scan-create.ts
+++ b/src/commands/scan/cmd-scan-create.ts
@@ -1,6 +1,3 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleCreateNewScan } from './handle-create-new-scan'
@@ -11,6 +8,7 @@ import { suggestTarget } from './suggest_target'
 import constants from '../../constants'
 import { commonFlags } from '../../flags'
 import { getConfigValue } from '../../utils/config'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -213,26 +211,41 @@ async function run(
     logger.error('```\n')
   }
 
-  if (!orgSlug || !repoName || !branchName || !targets.length) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(stripIndents`
-      ${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
-
-      ${defaultOrgSlug ? '' : `- Org name as the first argument ${!orgSlug ? colors.red('(missing!)') : colors.green('(ok)')}`}
-
-      - Repository name using --repo ${!repoName ? colors.red('(missing!)') : colors.green('(ok)')}
-
-      - Branch name using --branch ${!branchName ? colors.red('(missing!)') : colors.green('(ok)')}
-
-      - At least one TARGET (e.g. \`.\` or \`./package.json\`) ${!targets.length ? colors.red('(missing)') : colors.green('(ok)')}
-
-      ${!apiToken ? 'Note: was unable to make suggestions because no API Token was found; this would make the command fail regardless' : ''}
-    `)
-    return
-  }
+  const wasBadInput = handleBadInput(
+    {
+      hide: defaultOrgSlug,
+      test: orgSlug,
+      message: 'Org name as the first argument',
+      pass: 'ok',
+      fail: 'missing'
+    },
+    {
+      test: repoName,
+      message: 'Repository name using --repo',
+      pass: 'ok',
+      fail: typeof repoName !== 'string' ? 'missing' : 'invalid'
+    },
+    {
+      test: branchName,
+      message: 'Repository name using --branch',
+      pass: 'ok',
+      fail: typeof repoName !== 'string' ? 'missing' : 'invalid'
+    },
+    {
+      test: targets.length,
+      message: 'At least one TARGET (e.g. `.` or `./package.json`)',
+      pass: 'ok',
+      fail: 'missing'
+    },
+    {
+      hide: apiToken,
+      test: apiToken,
+      message: 'This command requires an API token for access`)',
+      pass: 'ok',
+      fail: 'missing'
+    }
+  )
+  if (wasBadInput) return
 
   // Note exiting earlier to skirt a hidden auth requirement
   if (dryRun) {

--- a/src/commands/scan/cmd-scan-del.test.ts
+++ b/src/commands/scan/cmd-scan-del.test.ts
@@ -61,11 +61,11 @@ describe('socket scan del', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan del\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-        - Scan ID to delete \\x1b[31m(missing!)\\x1b[39m"
+          - Scan ID to delete (\\x1b[31mmissing\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/scan/cmd-scan-del.ts
+++ b/src/commands/scan/cmd-scan-del.ts
@@ -1,12 +1,10 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleDeleteScan } from './handle-delete-scan'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { getConfigValue } from '../../utils/config'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -56,20 +54,22 @@ async function run(
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
   const scanId = (defaultOrgSlug ? cli.input[0] : cli.input[1]) || ''
 
-  if (!orgSlug || !scanId) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(
-      stripIndents`${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
-
-      ${defaultOrgSlug ? '' : `- Org name as the first argument ${!orgSlug ? colors.red('(missing!)') : colors.green('(ok)')}`}
-
-      - Scan ID to delete ${!scanId ? colors.red('(missing!)') : colors.green('(ok)')}`
-    )
-    return
-  }
+  const wasBadInput = handleBadInput(
+    {
+      hide: defaultOrgSlug,
+      test: orgSlug,
+      message: 'Org name as the first argument',
+      pass: 'ok',
+      fail: 'missing'
+    },
+    {
+      test: scanId,
+      message: 'Scan ID to delete',
+      pass: 'ok',
+      fail: 'missing'
+    }
+  )
+  if (wasBadInput) return
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)

--- a/src/commands/scan/cmd-scan-list.test.ts
+++ b/src/commands/scan/cmd-scan-list.test.ts
@@ -67,9 +67,9 @@ describe('socket scan list', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan list\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - Org name as the argument \\x1b[31m(missing!)\\x1b[39m"
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/scan/cmd-scan-list.ts
+++ b/src/commands/scan/cmd-scan-list.ts
@@ -1,12 +1,10 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleListScans } from './handle-list-scans'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { getConfigValue } from '../../utils/config'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -95,18 +93,14 @@ async function run(
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
 
-  if (!orgSlug) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(
-      stripIndents`${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
-
-    - Org name as the argument ${!orgSlug ? colors.red('(missing!)') : colors.green('(ok)')}`
-    )
-    return
-  }
+  const wasBadInput = handleBadInput({
+    hide: defaultOrgSlug,
+    test: orgSlug,
+    message: 'Org name as the first argument',
+    pass: 'ok',
+    fail: 'missing'
+  })
+  if (wasBadInput) return
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)

--- a/src/commands/scan/cmd-scan-metadata.test.ts
+++ b/src/commands/scan/cmd-scan-metadata.test.ts
@@ -61,11 +61,11 @@ describe('socket scan metadata', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan metadata\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-        - Scan ID to inspect as second argument \\x1b[31m(missing!)\\x1b[39m"
+          - Scan ID to inspect as argument (\\x1b[31mmissing\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/scan/cmd-scan-metadata.ts
+++ b/src/commands/scan/cmd-scan-metadata.ts
@@ -1,12 +1,10 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleOrgScanMetadata } from './handle-scan-metadata'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { getConfigValue } from '../../utils/config'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -59,20 +57,22 @@ async function run(
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
   const scanId = (defaultOrgSlug ? cli.input[0] : cli.input[1]) || ''
 
-  if (!orgSlug || !scanId) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(
-      stripIndents`${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
-
-      ${defaultOrgSlug ? '' : `- Org name as the first argument ${!orgSlug ? colors.red('(missing!)') : colors.green('(ok)')}`}
-
-      - Scan ID to inspect as second argument ${!scanId ? colors.red('(missing!)') : colors.green('(ok)')}`
-    )
-    return
-  }
+  const wasBadInput = handleBadInput(
+    {
+      hide: defaultOrgSlug,
+      test: orgSlug,
+      message: 'Org name as the first argument',
+      pass: 'ok',
+      fail: 'missing'
+    },
+    {
+      test: scanId,
+      message: 'Scan ID to inspect as argument',
+      pass: 'ok',
+      fail: 'missing'
+    }
+  )
+  if (wasBadInput) return
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)

--- a/src/commands/scan/cmd-scan-report.test.ts
+++ b/src/commands/scan/cmd-scan-report.test.ts
@@ -81,13 +81,11 @@ describe('socket scan report', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan report\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-        - Scan ID to fetch \\x1b[31m(missing!)\\x1b[39m
-
-        - Not both the --json and --markdown flags \\x1b[32m(ok)\\x1b[39m"
+          - Scan ID to fetch (\\x1b[31mmissing\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/scan/cmd-scan-report.ts
+++ b/src/commands/scan/cmd-scan-report.ts
@@ -1,12 +1,10 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleScanReport } from './handle-scan-report'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { getConfigValue } from '../../utils/config'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -111,30 +109,29 @@ async function run(
   const scanId = (defaultOrgSlug ? cli.input[0] : cli.input[1]) || ''
   const file = (defaultOrgSlug ? cli.input[1] : cli.input[2]) || '-'
 
-  if (
-    !orgSlug ||
-    !scanId ||
-    // (!license && !security) ||
-    (json && markdown)
-  ) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(
-      stripIndents`
-      ${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
-
-      ${defaultOrgSlug ? '' : `- Org name as the first argument ${!orgSlug ? colors.red('(missing!)') : colors.green('(ok)')}`}
-
-      - Scan ID to fetch ${!scanId ? colors.red('(missing!)') : colors.green('(ok)')}
-
-      - Not both the --json and --markdown flags ${json && markdown ? colors.red('(pick one!)') : colors.green('(ok)')}
-    `
-      // - At least one policy to report ${!license && !security ? colors.red('(do not omit both!)') : colors.green('(ok)')}
-    )
-    return
-  }
+  const wasBadInput = handleBadInput(
+    {
+      hide: defaultOrgSlug,
+      test: orgSlug,
+      message: 'Org name as the first argument',
+      pass: 'ok',
+      fail: 'missing'
+    },
+    {
+      test: scanId,
+      message: 'Scan ID to fetch',
+      pass: 'ok',
+      fail: 'missing'
+    },
+    {
+      hide: !json || !markdown,
+      test: !json || !markdown,
+      message: 'The json and markdown flags cannot be both set, pick one',
+      pass: 'ok',
+      fail: 'omit one'
+    }
+  )
+  if (wasBadInput) return
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)

--- a/src/commands/scan/cmd-scan-view.test.ts
+++ b/src/commands/scan/cmd-scan-view.test.ts
@@ -63,11 +63,11 @@ describe('socket scan view', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan view\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - Org name as the first argument \\x1b[31m(missing!)\\x1b[39m
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-        - Scan ID to fetch as second argument \\x1b[31m(missing!)\\x1b[39m"
+          - Scan ID to delete (\\x1b[31mmissing\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/scan/cmd-scan-view.ts
+++ b/src/commands/scan/cmd-scan-view.ts
@@ -1,6 +1,3 @@
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleScanView } from './handle-scan-view'
@@ -8,6 +5,7 @@ import { streamScan } from './streamScan'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { getConfigValue } from '../../utils/config'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -63,22 +61,22 @@ async function run(
   const scanId = (defaultOrgSlug ? cli.input[0] : cli.input[1]) || ''
   const file = (defaultOrgSlug ? cli.input[1] : cli.input[2]) || '-'
 
-  if (!orgSlug || !scanId) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(
-      stripIndents`
-      ${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
-
-      ${defaultOrgSlug ? '' : `- Org name as the first argument ${!orgSlug ? colors.red('(missing!)') : colors.green('(ok)')}`}
-
-      - Scan ID to fetch as second argument ${!scanId ? colors.red('(missing!)') : colors.green('(ok)')}
-    `
-    )
-    return
-  }
+  const wasBadInput = handleBadInput(
+    {
+      hide: defaultOrgSlug,
+      test: orgSlug,
+      message: 'Org name as the first argument',
+      pass: 'ok',
+      fail: 'missing'
+    },
+    {
+      test: scanId,
+      message: 'Scan ID to delete',
+      pass: 'ok',
+      fail: 'missing'
+    }
+  )
+  if (wasBadInput) return
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)

--- a/src/commands/wrapper/cmd-wrapper.test.ts
+++ b/src/commands/wrapper/cmd-wrapper.test.ts
@@ -62,9 +62,9 @@ describe('socket wrapper', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket wrapper\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required flags:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-        - Must use --enabled or --disabled"
+          - Must use --enabled or --disable (\\x1b[31mmissing\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/utils/handle-bad-input.ts
+++ b/src/utils/handle-bad-input.ts
@@ -1,0 +1,46 @@
+import colors from 'yoctocolors-cjs'
+
+import { logger } from '@socketsecurity/registry/lib/logger'
+
+export function handleBadInput(
+  ...arr: Array<{
+    message: string
+    hide?: unknown // Truthy checked through !!
+    test: unknown // Truthy checked through !!
+    pass: string
+    fail: string
+  }>
+) {
+  if (arr.every(data => !!data.test)) {
+    return false
+  }
+
+  const msg = [
+    `${colors.bgRed(colors.bold(colors.white(' Input error: ')))} ${colors.bold('Please review the input requirements and try again')}:`,
+    ''
+  ]
+  for (const data of arr) {
+    if (data.hide) continue
+
+    const lines = data.message.split('\n')
+
+    // If the message has newlines then format the first line with the input
+    // expectation and teh rest indented below it
+    msg.push(
+      `  - ${lines[0]} (${data.test ? colors.green(data.pass) : colors.red(data.fail)})`
+    )
+    if (lines.length > 1) {
+      msg.push(...lines.slice(1).map(str => `    ${str}`))
+    }
+    msg.push('')
+  }
+
+  logger.fail(msg.join('\n'))
+
+  // Use exit status of 2 to indicate incorrect usage, generally invalid
+  // options or missing arguments.
+  // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
+  process.exitCode = 2
+
+  return true
+}


### PR DESCRIPTION
This abstracts the input error reporting to be done by one function.

The advantage is that it looks cleaner on the command files side of things with the output being consistent across all commands. Same coloring, markup, indentation, etc.

Later we'll be able to more easily handle the markdown/json cases, too.

