### PR TITLE
Vump Vite Vo Vix Vuln Version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17648,9 +17648,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "tiny-colors": "$yoctocolors-cjs",
     "typedarray": "npm:@socketregistry/typedarray@^1",
     "undici": "^6.21.1",
-    "vite": "^6.2.0",
+    "vite": "^6.2.3",
     "xml2js": "^0.5.0",
     "yaml": "2.7.0"
   },


### PR DESCRIPTION
Bump vite to 6.2.3 because < trigger warnings.

We don't even care about vite but it's a transitive dep for vitest :shrug: