### PR TITLE
Validate apiToken on input and threatfeed fixes

### DIFF
--- a/src/commands/analytics/cmd-analytics.test.ts
+++ b/src/commands/analytics/cmd-analytics.test.ts
@@ -62,6 +62,42 @@ describe('socket analytics', async () => {
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket analytics\`, cwd: <redacted>
+
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+
+          - Scope must be "repo" or "org" (\\x1b[32mok\\x1b[39m)
+
+          - The time filter must either be 7, 30 or 90 (\\x1b[32mok\\x1b[39m)
+
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+      `)
+
+      expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
+    }
+  )
+
+  cmdit(
+    [
+      'analytics',
+      'boo',
+      '--scope',
+      'org',
+      '--repo',
+      'bar',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
+    'should require args with just dry-run',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "

--- a/src/commands/audit-log/cmd-audit-log.test.ts
+++ b/src/commands/audit-log/cmd-audit-log.test.ts
@@ -69,7 +69,9 @@ describe('socket audit-log', async () => {
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-          - Org name should be the first arg (\\x1b[31mmissing\\x1b[39m)"
+          - Org name should be the first arg (\\x1b[31mmissing\\x1b[39m)
+
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -77,7 +79,13 @@ describe('socket audit-log', async () => {
   )
 
   cmdit(
-    ['audit-log', 'fakeorg', '--dry-run', '--config', '{}'],
+    [
+      'audit-log',
+      'fakeorg',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/audit-log/cmd-audit-log.ts
+++ b/src/commands/audit-log/cmd-audit-log.ts
@@ -7,6 +7,7 @@ import { getConfigValue } from '../../utils/config'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
+import { getDefaultToken } from '../../utils/sdk'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -77,12 +78,32 @@ async function run(
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
 
-  const wasBadInput = handleBadInput({
-    test: orgSlug,
-    message: 'Org name should be the first arg',
-    pass: 'ok',
-    fail: 'missing'
-  })
+  const apiToken = getDefaultToken()
+
+  const wasBadInput = handleBadInput(
+    {
+      test: orgSlug,
+      message: 'Org name should be the first arg',
+      pass: 'ok',
+      fail: 'missing'
+    },
+    {
+      nook: true,
+      test: apiToken,
+      message:
+        'You need to be logged in to use this command. See `socket login`.',
+      pass: 'ok',
+      fail: 'missing API token'
+    },
+    {
+      nook: true,
+      test: !json || !markdown,
+      message:
+        'The `--json` and `--markdown` flags can not be used at the same time',
+      pass: 'ok',
+      fail: 'bad'
+    }
+  )
   if (wasBadInput) {
     return
   }

--- a/src/commands/audit-log/fetch-audit-log.ts
+++ b/src/commands/audit-log/fetch-audit-log.ts
@@ -1,7 +1,6 @@
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { AuthError } from '../../utils/errors'
-import { getDefaultToken, setupSdk } from '../../utils/sdk'
+import { setupSdk } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
@@ -18,44 +17,13 @@ export async function fetchAuditLog({
   perPage: number
   logType: string
 }): Promise<SocketSdkReturnType<'getAuditLogEvents'>['data'] | void> {
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
+  const sockSdk = await setupSdk()
 
-  return await fetchAuditLogWithToken(apiToken, {
-    logType,
-    orgSlug,
-    outputKind,
-    page,
-    perPage
-  })
-}
-
-export async function fetchAuditLogWithToken(
-  apiToken: string,
-  {
-    logType,
-    orgSlug,
-    outputKind,
-    page,
-    perPage
-  }: {
-    outputKind: 'json' | 'markdown' | 'print'
-    orgSlug: string
-    page: number
-    perPage: number
-    logType: string
-  }
-): Promise<SocketSdkReturnType<'getAuditLogEvents'>['data'] | void> {
   // Lazily access constants.spinner.
   const { spinner } = constants
 
   spinner.start(`Looking up audit log for ${orgSlug}`)
 
-  const sockSdk = await setupSdk(apiToken)
   const result = await handleApiCall(
     sockSdk.getAuditLogEvents(orgSlug, {
       // I'm not sure this is used at all.

--- a/src/commands/cdxgen/cmd-cdxgen.test.ts
+++ b/src/commands/cdxgen/cmd-cdxgen.test.ts
@@ -86,7 +86,7 @@ describe('socket cdxgen', async () => {
 
   // cdxgen does not support --dry-run
   // cmdit(
-  //   ['cdxgen', '--help', '--config', '{}'],
+  //   ['cdxgen', '--help', '--config', '{"apiToken":"anything"}'],
   //   'should require args with just dry-run',
   //   async cmd => {
   //     const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/config/cmd-config-auto.ts
+++ b/src/commands/config/cmd-config-auto.ts
@@ -65,12 +65,22 @@ async function run(
   const { json, markdown } = cli.flags
   const [key = ''] = cli.input
 
-  const wasBadInput = handleBadInput({
-    test: supportedConfigKeys.has(key as keyof LocalConfig) && key !== 'test',
-    message: 'Config key should be the first arg',
-    pass: 'ok',
-    fail: key ? 'invalid config key' : 'missing'
-  })
+  const wasBadInput = handleBadInput(
+    {
+      test: supportedConfigKeys.has(key as keyof LocalConfig) && key !== 'test',
+      message: 'Config key should be the first arg',
+      pass: 'ok',
+      fail: key ? 'invalid config key' : 'missing'
+    },
+    {
+      nook: true,
+      test: !json || !markdown,
+      message:
+        'The `--json` and `--markdown` flags can not be used at the same time',
+      pass: 'ok',
+      fail: 'bad'
+    }
+  )
   if (wasBadInput) {
     return
   }

--- a/src/commands/config/cmd-config-get.test.ts
+++ b/src/commands/config/cmd-config-get.test.ts
@@ -79,7 +79,14 @@ describe('socket config get', async () => {
   )
 
   cmdit(
-    ['config', 'test', 'test', '--dry-run', '--config', '{}'],
+    [
+      'config',
+      'test',
+      'test',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/config/cmd-config-get.ts
+++ b/src/commands/config/cmd-config-get.ts
@@ -60,12 +60,22 @@ async function run(
   const { json, markdown } = cli.flags
   const [key = ''] = cli.input
 
-  const wasBadInput = handleBadInput({
-    test: supportedConfigKeys.has(key as keyof LocalConfig) || key === 'test',
-    message: 'Config key should be the first arg',
-    pass: 'ok',
-    fail: key ? 'invalid config key' : 'missing'
-  })
+  const wasBadInput = handleBadInput(
+    {
+      test: supportedConfigKeys.has(key as keyof LocalConfig) || key === 'test',
+      message: 'Config key should be the first arg',
+      pass: 'ok',
+      fail: key ? 'invalid config key' : 'missing'
+    },
+    {
+      nook: true,
+      test: !json || !markdown,
+      message:
+        'The `--json` and `--markdown` flags can not be used at the same time',
+      pass: 'ok',
+      fail: 'bad'
+    }
+  )
   if (wasBadInput) {
     return
   }

--- a/src/commands/config/cmd-config-list.test.ts
+++ b/src/commands/config/cmd-config-list.test.ts
@@ -58,7 +58,7 @@ describe('socket config get', async () => {
   )
 
   cmdit(
-    ['config', 'list', '--dry-run', '--config', '{}'],
+    ['config', 'list', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/config/cmd-config-list.ts
+++ b/src/commands/config/cmd-config-list.ts
@@ -4,6 +4,7 @@ import { outputConfigList } from './output-config-list'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { supportedConfigKeys } from '../../utils/config'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -61,6 +62,18 @@ async function run(
   })
 
   const { full, json, markdown } = cli.flags
+
+  const wasBadInput = handleBadInput({
+    nook: true,
+    test: !json || !markdown,
+    message:
+      'The `--json` and `--markdown` flags can not be used at the same time',
+    pass: 'ok',
+    fail: 'bad'
+  })
+  if (wasBadInput) {
+    return
+  }
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)

--- a/src/commands/config/cmd-config-set.test.ts
+++ b/src/commands/config/cmd-config-set.test.ts
@@ -86,7 +86,15 @@ describe('socket config get', async () => {
   )
 
   cmdit(
-    ['config', 'set', 'test', 'xyz', '--dry-run', '--config', '{}'],
+    [
+      'config',
+      'set',
+      'test',
+      'xyz',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/config/cmd-config-set.ts
+++ b/src/commands/config/cmd-config-set.ts
@@ -79,6 +79,14 @@ async function run(
         'Key value should be the remaining args (use `unset` to unset a value)',
       pass: 'ok',
       fail: 'missing'
+    },
+    {
+      nook: true,
+      test: !json || !markdown,
+      message:
+        'The `--json` and `--markdown` flags can not be used at the same time',
+      pass: 'ok',
+      fail: 'bad'
     }
   )
   if (wasBadInput) {

--- a/src/commands/config/cmd-config-unset.test.ts
+++ b/src/commands/config/cmd-config-unset.test.ts
@@ -79,7 +79,14 @@ describe('socket config unset', async () => {
   )
 
   cmdit(
-    ['config', 'unset', 'test', '--dry-run', '--config', '{}'],
+    [
+      'config',
+      'unset',
+      'test',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/config/cmd-config-unset.ts
+++ b/src/commands/config/cmd-config-unset.ts
@@ -60,12 +60,22 @@ async function run(
   const { json, markdown } = cli.flags
   const [key = ''] = cli.input
 
-  const wasBadInput = handleBadInput({
-    test: supportedConfigKeys.has(key as keyof LocalConfig) || key === 'test',
-    message: 'Config key should be the first arg',
-    pass: 'ok',
-    fail: key ? 'invalid config key' : 'missing'
-  })
+  const wasBadInput = handleBadInput(
+    {
+      test: supportedConfigKeys.has(key as keyof LocalConfig) || key === 'test',
+      message: 'Config key should be the first arg',
+      pass: 'ok',
+      fail: key ? 'invalid config key' : 'missing'
+    },
+    {
+      nook: true,
+      test: !json || !markdown,
+      message:
+        'The `--json` and `--markdown` flags can not be used at the same time',
+      pass: 'ok',
+      fail: 'bad'
+    }
+  )
   if (wasBadInput) {
     return
   }

--- a/src/commands/config/cmd-config.test.ts
+++ b/src/commands/config/cmd-config.test.ts
@@ -54,7 +54,7 @@ describe('socket config', async () => {
   )
 
   cmdit(
-    ['config', '--dry-run', '--config', '{}'],
+    ['config', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/dependencies/cmd-dependencies.test.ts
+++ b/src/commands/dependencies/cmd-dependencies.test.ts
@@ -51,7 +51,7 @@ describe('socket dependencies', async () => {
   )
 
   cmdit(
-    ['dependencies', '--dry-run', '--config', '{}'],
+    ['dependencies', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/dependencies/cmd-dependencies.ts
+++ b/src/commands/dependencies/cmd-dependencies.ts
@@ -3,8 +3,10 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { handleDependencies } from './handle-dependencies'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
+import { getDefaultToken } from '../../utils/sdk'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -62,6 +64,30 @@ async function run(
   })
 
   const { json, limit, markdown, offset } = cli.flags
+
+  const apiToken = getDefaultToken()
+
+  const wasBadInput = handleBadInput(
+    {
+      nook: true,
+      test: !json || !markdown,
+      message:
+        'The `--json` and `--markdown` flags can not be used at the same time',
+      pass: 'ok',
+      fail: 'bad'
+    },
+    {
+      nook: true,
+      test: apiToken,
+      message:
+        'You need to be logged in to use this command. See `socket login`.',
+      pass: 'ok',
+      fail: 'missing API token'
+    }
+  )
+  if (wasBadInput) {
+    return
+  }
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)

--- a/src/commands/dependencies/fetch-dependencies.ts
+++ b/src/commands/dependencies/fetch-dependencies.ts
@@ -1,7 +1,6 @@
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { AuthError } from '../../utils/errors'
-import { getDefaultToken, setupSdk } from '../../utils/sdk'
+import { setupSdk } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
@@ -12,42 +11,19 @@ export async function fetchDependencies({
   limit: number
   offset: number
 }): Promise<SocketSdkReturnType<'searchDependencies'>['data'] | undefined> {
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
+  const sockSdk = await setupSdk()
 
-  return await fetchDependenciesWithToken(apiToken, {
-    limit,
-    offset
-  })
-}
-
-async function fetchDependenciesWithToken(
-  apiToken: string,
-  {
-    limit,
-    offset
-  }: {
-    limit: number
-    offset: number
-  }
-): Promise<SocketSdkReturnType<'searchDependencies'>['data'] | undefined> {
   // Lazily access constants.spinner.
   const { spinner } = constants
 
   spinner.start('Fetching organization dependencies...')
-
-  const sockSdk = await setupSdk(apiToken)
 
   const result = await handleApiCall(
     sockSdk.searchDependencies({ limit, offset }),
     'Searching dependencies'
   )
 
-  spinner?.successAndStop('Received organization dependencies response.')
+  spinner.successAndStop('Received organization dependencies response.')
 
   if (!result.success) {
     handleUnsuccessfulApiResponse('searchDependencies', result)

--- a/src/commands/diff-scan/cmd-diff-scan-get.test.ts
+++ b/src/commands/diff-scan/cmd-diff-scan-get.test.ts
@@ -73,7 +73,9 @@ describe('socket diff-scan get', async () => {
           - Specify a before and after scan ID (\\x1b[31mmissing before and after\\x1b[39m)
             The args are expecting a full \`aaa0aa0a-aaaa-0000-0a0a-0000000a00a0\` scan ID.
 
-          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)"
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
+
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -87,7 +89,7 @@ describe('socket diff-scan get', async () => {
       'fakeorg',
       '--dry-run',
       '--config',
-      '{}',
+      '{"apiToken":"anything"}',
       '--before',
       'x',
       '--after',

--- a/src/commands/diff-scan/cmd-diff-scan-get.ts
+++ b/src/commands/diff-scan/cmd-diff-scan-get.ts
@@ -7,6 +7,7 @@ import { getConfigValue } from '../../utils/config'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
+import { getDefaultToken } from '../../utils/sdk'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -90,6 +91,8 @@ async function run(
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
 
+  const apiToken = getDefaultToken()
+
   const wasBadInput = handleBadInput(
     {
       test: !!(before && after),
@@ -105,10 +108,26 @@ async function run(
     },
     {
       test: !!orgSlug,
-      hide: !!defaultOrgSlug,
+      nook: true,
       message: 'Org name as the first argument',
       pass: 'ok',
       fail: 'missing'
+    },
+    {
+      nook: true,
+      test: !json || !markdown,
+      message:
+        'The `--json` and `--markdown` flags can not be used at the same time',
+      pass: 'ok',
+      fail: 'bad'
+    },
+    {
+      nook: true,
+      test: apiToken,
+      message:
+        'You need to be logged in to use this command. See `socket login`.',
+      pass: 'ok',
+      fail: 'missing API token'
     }
   )
   if (wasBadInput) {

--- a/src/commands/diff-scan/cmd-diff-scan.test.ts
+++ b/src/commands/diff-scan/cmd-diff-scan.test.ts
@@ -50,7 +50,7 @@ describe('socket diff-scan', async () => {
   )
 
   cmdit(
-    ['diff-scan', '--dry-run', '--config', '{}'],
+    ['diff-scan', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/diff-scan/fetch-diff-scan.ts
+++ b/src/commands/diff-scan/fetch-diff-scan.ts
@@ -2,7 +2,6 @@ import colors from 'yoctocolors-cjs'
 
 import constants from '../../constants'
 import { handleApiCall, handleApiError, queryApi } from '../../utils/api'
-import { AuthError } from '../../utils/errors'
 import { getDefaultToken } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
@@ -17,31 +16,7 @@ export async function fetchDiffScan({
   orgSlug: string
 }): Promise<SocketSdkReturnType<'GetOrgDiffScan'>['data'] | undefined> {
   const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
 
-  return await fetchDiffScanWithToken(apiToken, {
-    after,
-    before,
-    orgSlug
-  })
-}
-
-export async function fetchDiffScanWithToken(
-  apiToken: string,
-  {
-    after,
-    before,
-    orgSlug
-  }: {
-    after: string
-    before: string
-    orgSlug: string
-  }
-): Promise<SocketSdkReturnType<'GetOrgDiffScan'>['data'] | undefined> {
   // Lazily access constants.spinner.
   const { spinner } = constants
 
@@ -49,10 +24,10 @@ export async function fetchDiffScanWithToken(
 
   const response = await queryApi(
     `orgs/${orgSlug}/full-scans/diff?before=${encodeURIComponent(before)}&after=${encodeURIComponent(after)}`,
-    apiToken
+    apiToken || ''
   )
 
-  spinner?.successAndStop('Received diff-scan response')
+  spinner.successAndStop('Received diff-scan response')
 
   if (!response.ok) {
     const err = await handleApiError(response.status)

--- a/src/commands/fix/cmd-fix.test.ts
+++ b/src/commands/fix/cmd-fix.test.ts
@@ -42,7 +42,7 @@ describe('socket fix', async () => {
   )
 
   cmdit(
-    ['fix', '--dry-run', '--config', '{}'],
+    ['fix', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/info/cmd-info.test.ts
+++ b/src/commands/info/cmd-info.test.ts
@@ -74,7 +74,7 @@ describe('socket info', async () => {
   )
 
   cmdit(
-    ['info', 'mootools', '--dry-run', '--config', '{}'],
+    ['info', 'mootools', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/info/cmd-info.ts
+++ b/src/commands/info/cmd-info.ts
@@ -62,11 +62,19 @@ async function run(
       fail: 'missing'
     },
     {
+      nook: true,
       test: cli.input.length === 1,
-      hide: cli.input.length === 1,
       message: 'Can only accept one package at a time',
       pass: 'ok',
       fail: 'got ' + cli.input.length
+    },
+    {
+      nook: true,
+      test: !json || !markdown,
+      message:
+        'The `--json` and `--markdown` flags can not be used at the same time',
+      pass: 'ok',
+      fail: 'bad'
     }
   )
   if (wasBadInput) {

--- a/src/commands/login/cmd-login.test.ts
+++ b/src/commands/login/cmd-login.test.ts
@@ -50,7 +50,7 @@ describe('socket login', async () => {
   )
 
   cmdit(
-    ['login', 'mootools', '--dry-run', '--config', '{}'],
+    ['login', 'mootools', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/logout/cmd-logout.test.ts
+++ b/src/commands/logout/cmd-logout.test.ts
@@ -42,7 +42,7 @@ describe('socket logout', async () => {
   )
 
   cmdit(
-    ['logout', 'mootools', '--dry-run', '--config', '{}'],
+    ['logout', 'mootools', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/manifest/cmd-manifest-auto.test.ts
+++ b/src/commands/manifest/cmd-manifest-auto.test.ts
@@ -50,7 +50,7 @@ describe('socket manifest auto', async () => {
   )
 
   cmdit(
-    ['manifest', 'auto', '--dry-run', '--config', '{}'],
+    ['manifest', 'auto', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/manifest/cmd-manifest-gradle.test.ts
+++ b/src/commands/manifest/cmd-manifest-gradle.test.ts
@@ -100,7 +100,14 @@ describe('socket manifest gradle', async () => {
   )
 
   cmdit(
-    ['manifest', 'gradle', 'mootools', '--dry-run', '--config', '{}'],
+    [
+      'manifest',
+      'gradle',
+      'mootools',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/manifest/cmd-manifest-gradle.ts
+++ b/src/commands/manifest/cmd-manifest-gradle.ts
@@ -130,8 +130,8 @@ async function run(
       fail: target === '-' ? 'stdin is not supported' : 'missing'
     },
     {
+      nook: true,
       test: cli.input.length === 1,
-      hide: cli.input.length === 1,
       message: 'Can only accept one DIR (make sure to escape spaces!)',
       pass: 'ok',
       fail: 'received ' + cli.input.length

--- a/src/commands/manifest/cmd-manifest-kotlin.test.ts
+++ b/src/commands/manifest/cmd-manifest-kotlin.test.ts
@@ -100,7 +100,14 @@ describe('socket manifest kotlin', async () => {
   )
 
   cmdit(
-    ['manifest', 'kotlin', 'mootools', '--dry-run', '--config', '{}'],
+    [
+      'manifest',
+      'kotlin',
+      'mootools',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/manifest/cmd-manifest-kotlin.ts
+++ b/src/commands/manifest/cmd-manifest-kotlin.ts
@@ -135,8 +135,8 @@ async function run(
       fail: target === '-' ? 'stdin is not supported' : 'missing'
     },
     {
+      nook: true,
       test: cli.input.length === 1,
-      hide: cli.input.length === 1,
       message: 'Can only accept one DIR (make sure to escape spaces!)',
       pass: 'ok',
       fail: 'received ' + cli.input.length

--- a/src/commands/manifest/cmd-manifest-scala.test.ts
+++ b/src/commands/manifest/cmd-manifest-scala.test.ts
@@ -104,7 +104,14 @@ describe('socket manifest scala', async () => {
   )
 
   cmdit(
-    ['manifest', 'scala', 'mootools', '--dry-run', '--config', '{}'],
+    [
+      'manifest',
+      'scala',
+      'mootools',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/manifest/cmd-manifest-scala.ts
+++ b/src/commands/manifest/cmd-manifest-scala.ts
@@ -128,8 +128,8 @@ async function run(
       fail: target === '-' ? 'stdin is not supported' : 'missing'
     },
     {
+      nook: true,
       test: cli.input.length === 1,
-      hide: cli.input.length === 1,
       message: 'Can only accept one DIR (make sure to escape spaces!)',
       pass: 'ok',
       fail: 'received ' + cli.input.length

--- a/src/commands/manifest/cmd-manifest.test.ts
+++ b/src/commands/manifest/cmd-manifest.test.ts
@@ -53,7 +53,13 @@ describe('socket manifest', async () => {
   )
 
   cmdit(
-    ['manifest', 'mootools', '--dry-run', '--config', '{}'],
+    [
+      'manifest',
+      'mootools',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/npm/cmd-npm.test.ts
+++ b/src/commands/npm/cmd-npm.test.ts
@@ -38,7 +38,7 @@ describe('socket npm', async () => {
   )
 
   cmdit(
-    ['npm', '--dry-run', '--config', '{}'],
+    ['npm', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/npx/cmd-npx.test.ts
+++ b/src/commands/npx/cmd-npx.test.ts
@@ -38,7 +38,7 @@ describe('socket npx', async () => {
   )
 
   cmdit(
-    ['npx', '--dry-run', '--config', '{}'],
+    ['npx', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/oops/cmd-oops.test.ts
+++ b/src/commands/oops/cmd-oops.test.ts
@@ -40,7 +40,7 @@ describe('socket oops', async () => {
   )
 
   cmdit(
-    ['oops', '--dry-run', '--config', '{}'],
+    ['oops', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/optimize/cmd-optimize.test.ts
+++ b/src/commands/optimize/cmd-optimize.test.ts
@@ -50,7 +50,7 @@ describe('socket optimize', async () => {
   )
 
   cmdit(
-    ['optimize', '--dry-run', '--config', '{}'],
+    ['optimize', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/organization/cmd-organization-list.test.ts
+++ b/src/commands/organization/cmd-organization-list.test.ts
@@ -46,7 +46,13 @@ describe('socket organization list', async () => {
   )
 
   cmdit(
-    ['organization', 'list', '--dry-run', '--config', '{}'],
+    [
+      'organization',
+      'list',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should be ok with org name and id',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/organization/cmd-organization-list.ts
+++ b/src/commands/organization/cmd-organization-list.ts
@@ -6,6 +6,7 @@ import { commonFlags, outputFlags } from '../../flags'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
+import { getDefaultToken } from '../../utils/sdk'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -46,16 +47,27 @@ async function run(
     parentName
   })
 
-  const json = Boolean(cli.flags['json'])
-  const markdown = Boolean(cli.flags['markdown'])
+  const { json, markdown } = cli.flags
+  const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput({
-    hide: !json || !markdown,
-    test: !json || !markdown,
-    message: 'The json and markdown flags cannot be both set, pick one',
-    pass: 'ok',
-    fail: 'omit one'
-  })
+  const wasBadInput = handleBadInput(
+    {
+      nook: true,
+      test: !json || !markdown,
+      message:
+        'The `--json` and `--markdown` flags can not be used at the same time',
+      pass: 'ok',
+      fail: 'bad'
+    },
+    {
+      nook: true,
+      test: apiToken,
+      message:
+        'You need to be logged in to use this command. See `socket login`.',
+      pass: 'ok',
+      fail: 'missing API token'
+    }
+  )
   if (wasBadInput) {
     return
   }

--- a/src/commands/organization/cmd-organization-policy-license.test.ts
+++ b/src/commands/organization/cmd-organization-policy-license.test.ts
@@ -67,7 +67,9 @@ describe('socket organization policy license', async () => {
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)"
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
+
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if input bad').toBe(2)
@@ -82,7 +84,7 @@ describe('socket organization policy license', async () => {
       'fakeorg',
       '--dry-run',
       '--config',
-      '{}'
+      '{"apiToken":"anything"}'
     ],
     'should be ok with org name and id',
     async cmd => {

--- a/src/commands/organization/cmd-organization-policy-license.ts
+++ b/src/commands/organization/cmd-organization-policy-license.ts
@@ -7,6 +7,7 @@ import { getConfigValue } from '../../utils/config'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
+import { getDefaultToken } from '../../utils/sdk'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -60,21 +61,30 @@ async function run(
 
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
+  const apiToken = getDefaultToken()
 
   const wasBadInput = handleBadInput(
     {
-      hide: defaultOrgSlug,
+      nook: true,
       test: orgSlug,
       message: 'Org name as the first argument',
       pass: 'ok',
       fail: 'missing'
     },
     {
-      hide: !json || !markdown,
+      nook: true,
       test: !json || !markdown,
       message: 'The json and markdown flags cannot be both set, pick one',
       pass: 'ok',
       fail: 'omit one'
+    },
+    {
+      nook: true,
+      test: apiToken,
+      message:
+        'You need to be logged in to use this command. See `socket login`.',
+      pass: 'ok',
+      fail: 'missing API token'
     }
   )
   if (wasBadInput) {

--- a/src/commands/organization/cmd-organization-policy-security.test.ts
+++ b/src/commands/organization/cmd-organization-policy-security.test.ts
@@ -67,7 +67,9 @@ describe('socket organization policy security', async () => {
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)"
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
+
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if input bad').toBe(2)
@@ -82,7 +84,7 @@ describe('socket organization policy security', async () => {
       'fakeorg',
       '--dry-run',
       '--config',
-      '{}'
+      '{"apiToken":"anything"}'
     ],
     'should be ok with org name and id',
     async cmd => {

--- a/src/commands/organization/cmd-organization-policy-security.ts
+++ b/src/commands/organization/cmd-organization-policy-security.ts
@@ -7,6 +7,7 @@ import { getConfigValue } from '../../utils/config'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
+import { getDefaultToken } from '../../utils/sdk'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -60,21 +61,30 @@ async function run(
 
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
+  const apiToken = getDefaultToken()
 
   const wasBadInput = handleBadInput(
     {
-      hide: defaultOrgSlug,
+      nook: true,
       test: orgSlug,
       message: 'Org name as the first argument',
       pass: 'ok',
       fail: 'missing'
     },
     {
-      hide: !json || !markdown,
+      nook: true,
       test: !json || !markdown,
       message: 'The json and markdown flags cannot be both set, pick one',
       pass: 'ok',
       fail: 'omit one'
+    },
+    {
+      nook: true,
+      test: apiToken,
+      message:
+        'You need to be logged in to use this command. See `socket login`.',
+      pass: 'ok',
+      fail: 'missing API token'
     }
   )
   if (wasBadInput) {

--- a/src/commands/organization/cmd-organization-policy.test.ts
+++ b/src/commands/organization/cmd-organization-policy.test.ts
@@ -50,7 +50,13 @@ describe('socket organization list', async () => {
   )
 
   cmdit(
-    ['organization', 'policy', '--dry-run', '--config', '{}'],
+    [
+      'organization',
+      'policy',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should support --dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/organization/cmd-organization-quota.test.ts
+++ b/src/commands/organization/cmd-organization-quota.test.ts
@@ -46,7 +46,13 @@ describe('socket organization quota', async () => {
   )
 
   cmdit(
-    ['organization', 'quota', '--dry-run', '--config', '{}'],
+    [
+      'organization',
+      'quota',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should be ok with org name and id',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/organization/cmd-organization-quota.ts
+++ b/src/commands/organization/cmd-organization-quota.ts
@@ -6,6 +6,7 @@ import { commonFlags, outputFlags } from '../../flags'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
+import { getDefaultToken } from '../../utils/sdk'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -48,14 +49,25 @@ async function run(
 
   const json = Boolean(cli.flags['json'])
   const markdown = Boolean(cli.flags['markdown'])
+  const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput({
-    hide: !json || !markdown,
-    test: !json || !markdown,
-    message: 'The json and markdown flags cannot be both set, pick one',
-    pass: 'ok',
-    fail: 'omit one'
-  })
+  const wasBadInput = handleBadInput(
+    {
+      nook: true,
+      test: !json || !markdown,
+      message: 'The json and markdown flags cannot be both set, pick one',
+      pass: 'ok',
+      fail: 'omit one'
+    },
+    {
+      nook: true,
+      test: apiToken,
+      message:
+        'You need to be logged in to use this command. See `socket login`.',
+      pass: 'ok',
+      fail: 'missing API token'
+    }
+  )
   if (wasBadInput) {
     return
   }

--- a/src/commands/organization/cmd-organization.test.ts
+++ b/src/commands/organization/cmd-organization.test.ts
@@ -50,7 +50,7 @@ describe('socket organization', async () => {
   )
 
   cmdit(
-    ['organization', '--dry-run', '--config', '{}'],
+    ['organization', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should be ok with org name and id',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/organization/fetch-license-policy.ts
+++ b/src/commands/organization/fetch-license-policy.ts
@@ -22,10 +22,10 @@ async function fetchLicensePolicyWithToken(
   apiToken: string,
   orgSlug: string
 ): Promise<SocketSdkReturnType<'getOrgLicensePolicy'>['data'] | undefined> {
+  const sockSdk = await setupSdk(apiToken)
+
   // Lazily access constants.spinner.
   const { spinner } = constants
-
-  const sockSdk = await setupSdk(apiToken)
 
   spinner.start('Fetching organization license policy...')
 

--- a/src/commands/organization/fetch-organization-list.ts
+++ b/src/commands/organization/fetch-organization-list.ts
@@ -1,27 +1,13 @@
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { AuthError } from '../../utils/errors'
-import { getDefaultToken, setupSdk } from '../../utils/sdk'
+import { setupSdk } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function fetchOrganization(): Promise<
   SocketSdkReturnType<'getOrganizations'>['data'] | undefined
 > {
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
-
-  return await fetchOrganizationWithToken(apiToken)
-}
-
-async function fetchOrganizationWithToken(
-  apiToken: string
-): Promise<SocketSdkReturnType<'getOrganizations'>['data'] | undefined> {
-  const sockSdk = await setupSdk(apiToken)
+  const sockSdk = await setupSdk()
 
   // Lazily access constants.spinner.
   const { spinner } = constants

--- a/src/commands/organization/fetch-quota.ts
+++ b/src/commands/organization/fetch-quota.ts
@@ -1,29 +1,16 @@
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { AuthError } from '../../utils/errors'
-import { getDefaultToken, setupSdk } from '../../utils/sdk'
+import { setupSdk } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function fetchQuota(): Promise<
   SocketSdkReturnType<'getQuota'>['data'] | undefined
 > {
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
-  return await fetchQuotaWithToken(apiToken)
-}
+  const sockSdk = await setupSdk()
 
-async function fetchQuotaWithToken(
-  apiToken: string
-): Promise<SocketSdkReturnType<'getQuota'>['data'] | undefined> {
   // Lazily access constants.spinner.
   const { spinner } = constants
-
-  const sockSdk = await setupSdk(apiToken)
 
   spinner.start('Fetching organization quota...')
 
@@ -32,7 +19,7 @@ async function fetchQuotaWithToken(
     'looking up organization quota'
   )
 
-  spinner?.successAndStop('Recieved organization quota response.')
+  spinner.successAndStop('Received organization quota response.')
 
   if (!result.success) {
     handleUnsuccessfulApiResponse('getQuota', result)

--- a/src/commands/organization/fetch-security-policy.ts
+++ b/src/commands/organization/fetch-security-policy.ts
@@ -1,31 +1,16 @@
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { AuthError } from '../../utils/errors'
-import { getDefaultToken, setupSdk } from '../../utils/sdk'
+import { setupSdk } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function fetchSecurityPolicy(
   orgSlug: string
 ): Promise<SocketSdkReturnType<'getOrgSecurityPolicy'>['data'] | undefined> {
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
+  const sockSdk = await setupSdk()
 
-  return await fetchSecurityPolicyWithToken(apiToken, orgSlug)
-}
-
-async function fetchSecurityPolicyWithToken(
-  apiToken: string,
-  orgSlug: string
-): Promise<SocketSdkReturnType<'getOrgSecurityPolicy'>['data'] | undefined> {
   // Lazily access constants.spinner.
   const { spinner } = constants
-
-  const sockSdk = await setupSdk(apiToken)
 
   spinner.start('Fetching organization security policy...')
 
@@ -34,7 +19,7 @@ async function fetchSecurityPolicyWithToken(
     'looking up organization quota'
   )
 
-  spinner?.successAndStop('Received organization security policy response.')
+  spinner.successAndStop('Received organization security policy response.')
 
   if (!result.success) {
     handleUnsuccessfulApiResponse('getOrgSecurityPolicy', result)

--- a/src/commands/package/cmd-package-score.test.ts
+++ b/src/commands/package/cmd-package-score.test.ts
@@ -11,48 +11,51 @@ describe('socket package score', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['package', 'score', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
-        "Look up score for one package which reflects all of its transitive dependencies as well
+  cmdit(
+    ['package', 'score', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
+      "Look up score for one package which reflects all of its transitive dependencies as well
 
-          Usage
-            $ socket package score <<ecosystem> <name> | <purl>>
+        Usage
+          $ socket package score <<ecosystem> <name> | <purl>>
 
-          Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
-            --help            Print this help.
-            --json            Output result as json
-            --markdown        Output result as markdown
+        Options
+          --dryRun          Do input validation for a command and exit 0 when input is ok
+          --help            Print this help.
+          --json            Output result as json
+          --markdown        Output result as markdown
 
-          Requirements
-            - quota: 100
-            - scope: \`packages:list\`
+        Requirements
+          - quota: 100
+          - scope: \`packages:list\`
 
-          Show deep scoring details for one package. The score will reflect the package
-          itself, any of its dependencies, and any of its transitive dependencies.
+        Show deep scoring details for one package. The score will reflect the package
+        itself, any of its dependencies, and any of its transitive dependencies.
 
-          When you want to know whether to trust a package, this is the command to run.
+        When you want to know whether to trust a package, this is the command to run.
 
-          See also the \`socket package shallow\` command, which returns the shallow
-          score for any number of packages. That will not reflect the dependency scores.
+        See also the \`socket package shallow\` command, which returns the shallow
+        score for any number of packages. That will not reflect the dependency scores.
 
-          Only a few ecosystems are supported like npm, golang, and maven.
+        Only a few ecosystems are supported like npm, golang, and maven.
 
-          A "purl" is a standard package name formatting: \`pkg:eco/name@version\`
-          This command will automatically prepend "pkg:" when not present.
+        A "purl" is a standard package name formatting: \`pkg:eco/name@version\`
+        This command will automatically prepend "pkg:" when not present.
 
-          The version is optional but when given should be a direct match.
+        The version is optional but when given should be a direct match.
 
-          Examples
-            $ socket package score npm babel-cli
-            $ socket package score npm babel-cli@1.9.1
-            $ socket package score npm/babel-cli@1.9.1
-            $ socket package score pkg:npm/babel-cli@1.9.1"
-      `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        Examples
+          $ socket package score npm babel-cli
+          $ socket package score npm babel-cli@1.9.1
+          $ socket package score npm/babel-cli@1.9.1
+          $ socket package score pkg:npm/babel-cli@1.9.1"
+    `
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
@@ -60,14 +63,16 @@ describe('socket package score', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket package score\`, cwd: <redacted>"
       `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'header should include command (without params)').toContain(
-      '`socket package score`'
-    )
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(
+        stderr,
+        'header should include command (without params)'
+      ).toContain('`socket package score`')
+    }
+  )
 
   cmdit(
-    ['package', 'score', '--dry-run'],
+    ['package', 'score', '--dry-run', '--config', '{}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
@@ -79,11 +84,13 @@ describe('socket package score', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket package score\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[37mInput error\\x1b[39m\\x1b[49m: Please provide the required fields:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-              - First parameter should be an ecosystem or the arg must be a purl \\x1b[31m(bad!)\\x1b[39m
+          - First parameter must be an ecosystem or the whole purl (\\x1b[31mbad\\x1b[39m)
 
-              - Expecting the package to check \\x1b[31m(missing!)\\x1b[39m"
+          - Expecting at least one package (\\x1b[31mmissing\\x1b[39m)
+
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -91,7 +98,15 @@ describe('socket package score', async () => {
   )
 
   cmdit(
-    ['package', 'score', 'npm', 'babel', '--dry-run'],
+    [
+      'package',
+      'score',
+      'npm',
+      'babel',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/package/cmd-package-shallow.test.ts
+++ b/src/commands/package/cmd-package-shallow.test.ts
@@ -95,7 +95,15 @@ describe('socket package shallow', async () => {
   )
 
   cmdit(
-    ['package', 'shallow', 'npm', 'babel', '--dry-run', '--config', '{}'],
+    [
+      'package',
+      'shallow',
+      'npm',
+      'babel',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/package/cmd-package-shallow.ts
+++ b/src/commands/package/cmd-package-shallow.ts
@@ -100,7 +100,7 @@ async function run(
       fail: 'missing'
     },
     {
-      hide: !json || !markdown,
+      nook: true,
       test: !json || !markdown,
       message: 'The json and markdown flags cannot be both set, pick one',
       pass: 'ok',

--- a/src/commands/package/cmd-package.test.ts
+++ b/src/commands/package/cmd-package.test.ts
@@ -50,7 +50,7 @@ describe('socket package', async () => {
   )
 
   cmdit(
-    ['package', '--dry-run', '--config', '{}'],
+    ['package', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should be ok with org name and id',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/package/fetch-purl-deep-score.ts
+++ b/src/commands/package/fetch-purl-deep-score.ts
@@ -8,9 +8,6 @@ import { AuthError } from '../../utils/errors'
 import { getDefaultToken } from '../../utils/sdk'
 
 export async function fetchPurlDeepScore(purl: string) {
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
   const apiToken = getDefaultToken()
   if (!apiToken) {
     throw new AuthError(
@@ -18,13 +15,17 @@ export async function fetchPurlDeepScore(purl: string) {
     )
   }
 
+  // Lazily access constants.spinner.
+  const { spinner } = constants
+
   spinner.start('Getting deep package score...')
+
   let result
   try {
     result = await queryApi(`purl/score/${encodeURIComponent(purl)}`, apiToken)
-    spinner?.successAndStop('Received deep package score response.')
+    spinner.successAndStop('Received deep package score response.')
   } catch (e) {
-    spinner?.failAndStop('The request was unsuccessful.')
+    spinner.failAndStop('The request was unsuccessful.')
     const msg = (e as undefined | { message: string })?.message
     if (msg) {
       logger.fail(msg)

--- a/src/commands/package/fetch-purls-shallow-score.ts
+++ b/src/commands/package/fetch-purls-shallow-score.ts
@@ -16,12 +16,12 @@ export async function fetchPurlsShallowScore(
     `Requesting shallow score data for ${purls.length} package urls (purl): ${purls.join(', ')}`
   )
 
+  const sockSdk = await setupSdk(getPublicToken())
+
   // Lazily access constants.spinner.
   const { spinner } = constants
 
   spinner.start(`Requesting data ...`)
-
-  const sockSdk = await setupSdk(getPublicToken())
 
   const result: Awaited<SocketSdkResultType<'batchPackageFetch'>> =
     await handleApiCall(

--- a/src/commands/raw-npm/cmd-raw-npm.test.ts
+++ b/src/commands/raw-npm/cmd-raw-npm.test.ts
@@ -43,7 +43,7 @@ describe('socket raw-npm', async () => {
   )
 
   cmdit(
-    ['raw-npm', '--dry-run', '--config', '{}'],
+    ['raw-npm', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/raw-npx/cmd-raw-npx.test.ts
+++ b/src/commands/raw-npx/cmd-raw-npx.test.ts
@@ -43,7 +43,7 @@ describe('socket raw-npx', async () => {
   )
 
   cmdit(
-    ['raw-npx', '--dry-run', '--config', '{}'],
+    ['raw-npx', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/report/cmd-report-create.test.ts
+++ b/src/commands/report/cmd-report-create.test.ts
@@ -40,7 +40,7 @@ describe('socket report create', async () => {
   )
 
   cmdit(
-    ['report', 'create', '--dry-run', '--config', '{}'],
+    ['report', 'create', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/report/cmd-report-view.test.ts
+++ b/src/commands/report/cmd-report-view.test.ts
@@ -40,7 +40,7 @@ describe('socket report create', async () => {
   )
 
   cmdit(
-    ['report', 'create', '--dry-run', '--config', '{}'],
+    ['report', 'create', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/report/cmd-report-view.ts
+++ b/src/commands/report/cmd-report-view.ts
@@ -54,14 +54,14 @@ async function run(
       fail: 'missing'
     },
     {
-      hide: extraInput.length === 0,
+      nook: true,
       test: extraInput.length === 0,
       message: 'Can only handle a single report ID',
       pass: 'ok',
       fail: 'received ' + (extraInput.length + 1)
     },
     {
-      hide: !json || !markdown,
+      nook: true,
       test: !json || !markdown,
       message: 'The json and markdown flags cannot be both set, pick one',
       pass: 'ok',

--- a/src/commands/report/cmd-report.test.ts
+++ b/src/commands/report/cmd-report.test.ts
@@ -51,7 +51,7 @@ describe('socket report', async () => {
   )
 
   cmdit(
-    ['report', '--dry-run', '--config', '{}'],
+    ['report', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/report/fetch-report-data.ts
+++ b/src/commands/report/fetch-report-data.ts
@@ -45,7 +45,7 @@ export async function fetchReportData(
         spinner.stop(`Failed to fetch report`)
         throw err
       }
-      spinner?.fail(`Retrying report fetch ${retry} / ${MAX_TIMEOUT_RETRY}`)
+      spinner.fail(`Retrying report fetch ${retry} / ${MAX_TIMEOUT_RETRY}`)
     }
   }
 

--- a/src/commands/repos/cmd-repos-create.test.ts
+++ b/src/commands/repos/cmd-repos-create.test.ts
@@ -68,7 +68,9 @@ describe('socket repos create', async () => {
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - Repository name using --repoNam (\\x1b[31minvalid\\x1b[39m)"
+          - Repository name using --repoNam (\\x1b[31minvalid\\x1b[39m)
+
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -76,7 +78,16 @@ describe('socket repos create', async () => {
   )
 
   cmdit(
-    ['repos', 'create', 'a', '--repoName', 'b', '--dry-run', '--config', '{}'],
+    [
+      'repos',
+      'create',
+      'a',
+      '--repoName',
+      'b',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/repos/cmd-repos-create.ts
+++ b/src/commands/repos/cmd-repos-create.ts
@@ -7,6 +7,7 @@ import { getConfigValue } from '../../utils/config'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
+import { getDefaultToken } from '../../utils/sdk'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -82,10 +83,11 @@ async function run(
   const repoName = cli.flags['repoName']
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
+  const apiToken = getDefaultToken()
 
   const wasBadInput = handleBadInput(
     {
-      hide: defaultOrgSlug,
+      nook: true,
       test: orgSlug,
       message: 'Org name as the first argument',
       pass: 'ok',
@@ -96,6 +98,14 @@ async function run(
       message: 'Repository name using --repoNam',
       pass: 'ok',
       fail: typeof repoName !== 'string' ? 'missing' : 'invalid'
+    },
+    {
+      nook: true,
+      test: apiToken,
+      message:
+        'You need to be logged in to use this command. See `socket login`.',
+      pass: 'ok',
+      fail: 'missing API token'
     }
   )
   if (wasBadInput) {

--- a/src/commands/repos/cmd-repos-del.test.ts
+++ b/src/commands/repos/cmd-repos-del.test.ts
@@ -63,7 +63,9 @@ describe('socket repos del', async () => {
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - Repository name argument (\\x1b[31minvalid\\x1b[39m)"
+          - Repository name argument (\\x1b[31minvalid\\x1b[39m)
+
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -71,7 +73,15 @@ describe('socket repos del', async () => {
   )
 
   cmdit(
-    ['repos', 'del', 'a', 'b', '--dry-run', '--config', '{}'],
+    [
+      'repos',
+      'del',
+      'a',
+      'b',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/repos/cmd-repos-del.ts
+++ b/src/commands/repos/cmd-repos-del.ts
@@ -7,6 +7,7 @@ import { getConfigValue } from '../../utils/config'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
+import { getDefaultToken } from '../../utils/sdk'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -52,10 +53,11 @@ async function run(
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
   const repoName = (defaultOrgSlug ? cli.input[0] : cli.input[1]) || ''
+  const apiToken = getDefaultToken()
 
   const wasBadInput = handleBadInput(
     {
-      hide: defaultOrgSlug,
+      nook: true,
       test: orgSlug,
       message: 'Org name as the first argument',
       pass: 'ok',
@@ -66,6 +68,14 @@ async function run(
       message: 'Repository name argument',
       pass: 'ok',
       fail: typeof repoName !== 'string' ? 'missing' : 'invalid'
+    },
+    {
+      nook: true,
+      test: apiToken,
+      message:
+        'You need to be logged in to use this command. See `socket login`.',
+      pass: 'ok',
+      fail: 'missing API token'
     }
   )
   if (wasBadInput) {

--- a/src/commands/repos/cmd-repos-list.test.ts
+++ b/src/commands/repos/cmd-repos-list.test.ts
@@ -67,7 +67,9 @@ describe('socket repos list', async () => {
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)"
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
+
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -75,7 +77,7 @@ describe('socket repos list', async () => {
   )
 
   cmdit(
-    ['repos', 'list', 'a', '--dry-run', '--config', '{}'],
+    ['repos', 'list', 'a', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/repos/cmd-repos-list.ts
+++ b/src/commands/repos/cmd-repos-list.ts
@@ -7,6 +7,7 @@ import { getConfigValue } from '../../utils/config'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
+import { getDefaultToken } from '../../utils/sdk'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -73,16 +74,36 @@ async function run(
     parentName
   })
 
+  const { json, markdown } = cli.flags
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
+  const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput({
-    hide: defaultOrgSlug,
-    test: orgSlug,
-    message: 'Org name as the first argument',
-    pass: 'ok',
-    fail: 'missing'
-  })
+  const wasBadInput = handleBadInput(
+    {
+      nook: true,
+      test: orgSlug,
+      message: 'Org name as the first argument',
+      pass: 'ok',
+      fail: 'missing'
+    },
+    {
+      nook: true,
+      test: !json || !markdown,
+      message:
+        'The `--json` and `--markdown` flags can not be used at the same time',
+      pass: 'ok',
+      fail: 'bad'
+    },
+    {
+      nook: true,
+      test: apiToken,
+      message:
+        'You need to be logged in to use this command. See `socket login`.',
+      pass: 'ok',
+      fail: 'missing API token'
+    }
+  )
   if (wasBadInput) {
     return
   }
@@ -95,11 +116,7 @@ async function run(
   await handleListRepos({
     direction: cli.flags['direction'] === 'asc' ? 'asc' : 'desc',
     orgSlug,
-    outputKind: cli.flags['json']
-      ? 'json'
-      : cli.flags['markdown']
-        ? 'markdown'
-        : 'print',
+    outputKind: json ? 'json' : markdown ? 'markdown' : 'print',
     page: Number(cli.flags['page']) || 1,
     per_page: Number(cli.flags['perPage']) || 30,
     sort: String(cli.flags['sort'] || 'created_at')

--- a/src/commands/repos/cmd-repos-update.test.ts
+++ b/src/commands/repos/cmd-repos-update.test.ts
@@ -68,7 +68,9 @@ describe('socket repos update', async () => {
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - Repository name using --repoName (\\x1b[31minvalid\\x1b[39m)"
+          - Repository name using --repoName (\\x1b[31minvalid\\x1b[39m)
+
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -76,7 +78,16 @@ describe('socket repos update', async () => {
   )
 
   cmdit(
-    ['repos', 'update', 'a', '--repoName', 'b', '--dry-run', '--config', '{}'],
+    [
+      'repos',
+      'update',
+      'a',
+      '--repoName',
+      'b',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/repos/cmd-repos-update.ts
+++ b/src/commands/repos/cmd-repos-update.ts
@@ -7,6 +7,7 @@ import { getConfigValue } from '../../utils/config'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
+import { getDefaultToken } from '../../utils/sdk'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -82,10 +83,11 @@ async function run(
   const repoName = cli.flags['repoName']
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
+  const apiToken = getDefaultToken()
 
   const wasBadInput = handleBadInput(
     {
-      hide: defaultOrgSlug,
+      nook: true,
       test: orgSlug,
       message: 'Org name as the first argument',
       pass: 'ok',
@@ -96,6 +98,14 @@ async function run(
       message: 'Repository name using --repoName',
       pass: 'ok',
       fail: typeof repoName !== 'string' ? 'missing' : 'invalid'
+    },
+    {
+      nook: true,
+      test: apiToken,
+      message:
+        'You need to be logged in to use this command. See `socket login`.',
+      pass: 'ok',
+      fail: 'missing API token'
     }
   )
   if (wasBadInput) {

--- a/src/commands/repos/cmd-repos-view.test.ts
+++ b/src/commands/repos/cmd-repos-view.test.ts
@@ -66,7 +66,9 @@ describe('socket repos view', async () => {
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - Repository name using --repoName (\\x1b[31minvalid\\x1b[39m)"
+          - Repository name using --repoName (\\x1b[31minvalid\\x1b[39m)
+
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -74,7 +76,16 @@ describe('socket repos view', async () => {
   )
 
   cmdit(
-    ['repos', 'view', 'a', '--repoName', 'b', '--dry-run', '--config', '{}'],
+    [
+      'repos',
+      'view',
+      'a',
+      '--repoName',
+      'b',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/repos/cmd-repos-view.ts
+++ b/src/commands/repos/cmd-repos-view.ts
@@ -7,6 +7,7 @@ import { getConfigValue } from '../../utils/config'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
+import { getDefaultToken } from '../../utils/sdk'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -59,10 +60,11 @@ async function run(
 
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
+  const apiToken = getDefaultToken()
 
   const wasBadInput = handleBadInput(
     {
-      hide: defaultOrgSlug,
+      nook: true,
       test: orgSlug,
       message: 'Org name as the first argument',
       pass: 'ok',
@@ -73,6 +75,22 @@ async function run(
       message: 'Repository name using --repoName',
       pass: 'ok',
       fail: typeof repoName !== 'string' ? 'missing' : 'invalid'
+    },
+    {
+      nook: true,
+      test: !json || !markdown,
+      message:
+        'The `--json` and `--markdown` flags can not be used at the same time',
+      pass: 'ok',
+      fail: 'bad'
+    },
+    {
+      nook: true,
+      test: apiToken,
+      message:
+        'You need to be logged in to use this command. See `socket login`.',
+      pass: 'ok',
+      fail: 'missing API token'
     }
   )
   if (wasBadInput) {

--- a/src/commands/repos/cmd-repos.test.ts
+++ b/src/commands/repos/cmd-repos.test.ts
@@ -52,7 +52,7 @@ describe('socket repos', async () => {
   )
 
   cmdit(
-    ['repos', '--dry-run', '--config', '{}'],
+    ['repos', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/repos/fetch-create-repo.ts
+++ b/src/commands/repos/fetch-create-repo.ts
@@ -1,7 +1,6 @@
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { AuthError } from '../../utils/errors'
-import { getDefaultToken, setupSdk } from '../../utils/sdk'
+import { setupSdk } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
@@ -20,45 +19,10 @@ export async function fetchCreateRepo({
   default_branch: string
   visibility: string
 }): Promise<SocketSdkReturnType<'createOrgRepo'>['data'] | undefined> {
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
+  const sockSdk = await setupSdk()
 
-  return await fetchCreateRepoWithToken(apiToken, {
-    default_branch,
-    description,
-    homepage,
-    orgSlug,
-    repoName,
-    visibility
-  })
-}
-
-async function fetchCreateRepoWithToken(
-  apiToken: string,
-  {
-    default_branch,
-    description,
-    homepage,
-    orgSlug,
-    repoName,
-    visibility
-  }: {
-    orgSlug: string
-    repoName: string
-    description: string
-    homepage: string
-    default_branch: string
-    visibility: string
-  }
-): Promise<SocketSdkReturnType<'createOrgRepo'>['data'] | undefined> {
   // Lazily access constants.spinner.
   const { spinner } = constants
-
-  const sockSdk = await setupSdk(apiToken)
 
   spinner.start('Sending request ot create a repository...')
 

--- a/src/commands/repos/fetch-delete-repo.ts
+++ b/src/commands/repos/fetch-delete-repo.ts
@@ -1,7 +1,6 @@
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { AuthError } from '../../utils/errors'
-import { getDefaultToken, setupSdk } from '../../utils/sdk'
+import { setupSdk } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
@@ -9,25 +8,10 @@ export async function fetchDeleteRepo(
   orgSlug: string,
   repoName: string
 ): Promise<SocketSdkReturnType<'deleteOrgRepo'>['data'] | undefined> {
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
+  const sockSdk = await setupSdk()
 
-  return await fetchDeleteRepoWithToken(orgSlug, repoName, apiToken)
-}
-
-async function fetchDeleteRepoWithToken(
-  orgSlug: string,
-  repoName: string,
-  apiToken: string
-): Promise<SocketSdkReturnType<'deleteOrgRepo'>['data'] | undefined> {
   // Lazily access constants.spinner.
   const { spinner } = constants
-
-  const sockSdk = await setupSdk(apiToken)
 
   spinner.start('Sending request to delete a repository...')
 

--- a/src/commands/repos/fetch-list-repos.ts
+++ b/src/commands/repos/fetch-list-repos.ts
@@ -1,7 +1,6 @@
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { AuthError } from '../../utils/errors'
-import { getDefaultToken, setupSdk } from '../../utils/sdk'
+import { setupSdk } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
@@ -18,42 +17,10 @@ export async function fetchListRepos({
   per_page: number
   sort: string
 }): Promise<SocketSdkReturnType<'getOrgRepoList'>['data'] | undefined> {
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
+  const sockSdk = await setupSdk()
 
-  return await fetchListReposWithToken(apiToken, {
-    direction,
-    orgSlug,
-    page,
-    per_page,
-    sort
-  })
-}
-
-async function fetchListReposWithToken(
-  apiToken: string,
-  {
-    direction,
-    orgSlug,
-    page,
-    per_page,
-    sort
-  }: {
-    direction: string
-    orgSlug: string
-    page: number
-    per_page: number
-    sort: string
-  }
-): Promise<SocketSdkReturnType<'getOrgRepoList'>['data'] | undefined> {
   // Lazily access constants.spinner.
   const { spinner } = constants
-
-  const sockSdk = await setupSdk(apiToken)
 
   spinner.start('Fetching list of repositories...')
 

--- a/src/commands/repos/fetch-update-repo.ts
+++ b/src/commands/repos/fetch-update-repo.ts
@@ -1,7 +1,6 @@
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { AuthError } from '../../utils/errors'
-import { getDefaultToken, setupSdk } from '../../utils/sdk'
+import { setupSdk } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
@@ -20,47 +19,13 @@ export async function fetchUpdateRepo({
   default_branch: string
   visibility: string
 }): Promise<SocketSdkReturnType<'updateOrgRepo'>['data'] | undefined> {
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
+  const sockSdk = await setupSdk()
 
-  return await fetchUpdateRepoWithToken(apiToken, {
-    default_branch,
-    description,
-    homepage,
-    orgSlug,
-    repoName,
-    visibility
-  })
-}
-
-async function fetchUpdateRepoWithToken(
-  apiToken: string,
-  {
-    default_branch,
-    description,
-    homepage,
-    orgSlug,
-    repoName,
-    visibility
-  }: {
-    orgSlug: string
-    repoName: string
-    description: string
-    homepage: string
-    default_branch: string
-    visibility: string
-  }
-): Promise<SocketSdkReturnType<'updateOrgRepo'>['data'] | undefined> {
   // Lazily access constants.spinner.
   const { spinner } = constants
 
   spinner.start('Sending request to update a repository...')
 
-  const sockSdk = await setupSdk(apiToken)
   const result = await handleApiCall(
     sockSdk.updateOrgRepo(orgSlug, repoName, {
       orgSlug,

--- a/src/commands/repos/fetch-view-repo.ts
+++ b/src/commands/repos/fetch-view-repo.ts
@@ -1,7 +1,6 @@
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { AuthError } from '../../utils/errors'
-import { getDefaultToken, setupSdk } from '../../utils/sdk'
+import { setupSdk } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
@@ -9,24 +8,10 @@ export async function fetchViewRepo(
   orgSlug: string,
   repoName: string
 ): Promise<SocketSdkReturnType<'getOrgRepo'>['data'] | undefined> {
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
-  return await fetchViewRepoWithToken(orgSlug, repoName, apiToken)
-}
+  const sockSdk = await setupSdk()
 
-async function fetchViewRepoWithToken(
-  orgSlug: string,
-  repoName: string,
-  apiToken: string
-): Promise<SocketSdkReturnType<'getOrgRepo'>['data'] | undefined> {
   // Lazily access constants.spinner.
   const { spinner } = constants
-
-  const sockSdk = await setupSdk(apiToken)
 
   spinner.start('Fetching repository data...')
 

--- a/src/commands/repos/handle-delete-repo.ts
+++ b/src/commands/repos/handle-delete-repo.ts
@@ -1,33 +1,18 @@
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { AuthError } from '../../utils/errors'
-import { getDefaultToken, setupSdk } from '../../utils/sdk'
+import { setupSdk } from '../../utils/sdk'
 
 export async function handleDeleteRepo(
   orgSlug: string,
   repoName: string
 ): Promise<void> {
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
+  const sockSdk = await setupSdk()
 
-  await deleteRepoWithToken(orgSlug, repoName, apiToken)
-}
-
-async function deleteRepoWithToken(
-  orgSlug: string,
-  repoName: string,
-  apiToken: string
-): Promise<void> {
   // Lazily access constants.spinner.
   const { spinner } = constants
 
   spinner.start('Deleting repository...')
 
-  const sockSdk = await setupSdk(apiToken)
   const result = await handleApiCall(
     sockSdk.deleteOrgRepo(orgSlug, repoName),
     'deleting repository'

--- a/src/commands/scan/cmd-scan-create.test.ts
+++ b/src/commands/scan/cmd-scan-create.test.ts
@@ -82,7 +82,7 @@ describe('socket scan create', async () => {
       '--branch',
       'abc',
       '--config',
-      '{"apiKey": "abc"}'
+      '{"apiToken": "abc"}'
     ],
     'should require args with just dry-run',
     async cmd => {

--- a/src/commands/scan/cmd-scan-create.ts
+++ b/src/commands/scan/cmd-scan-create.ts
@@ -217,7 +217,7 @@ async function run(
 
   const wasBadInput = handleBadInput(
     {
-      hide: defaultOrgSlug,
+      nook: true,
       test: orgSlug,
       message: 'Org name as the first argument',
       pass: 'ok',
@@ -242,7 +242,7 @@ async function run(
       fail: 'missing'
     },
     {
-      hide: apiToken,
+      nook: true,
       test: apiToken,
       message: 'This command requires an API token for access`)',
       pass: 'ok',

--- a/src/commands/scan/cmd-scan-del.test.ts
+++ b/src/commands/scan/cmd-scan-del.test.ts
@@ -65,7 +65,9 @@ describe('socket scan del', async () => {
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - Scan ID to delete (\\x1b[31mmissing\\x1b[39m)"
+          - Scan ID to delete (\\x1b[31mmissing\\x1b[39m)
+
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -73,7 +75,15 @@ describe('socket scan del', async () => {
   )
 
   cmdit(
-    ['scan', 'del', 'fakeorg', 'scanidee', '--dry-run', '--config', '{}'],
+    [
+      'scan',
+      'del',
+      'fakeorg',
+      'scanidee',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/scan/cmd-scan-del.ts
+++ b/src/commands/scan/cmd-scan-del.ts
@@ -7,6 +7,7 @@ import { getConfigValue } from '../../utils/config'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
+import { getDefaultToken } from '../../utils/sdk'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -53,10 +54,11 @@ async function run(
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
   const scanId = (defaultOrgSlug ? cli.input[0] : cli.input[1]) || ''
+  const apiToken = getDefaultToken()
 
   const wasBadInput = handleBadInput(
     {
-      hide: defaultOrgSlug,
+      nook: true,
       test: orgSlug,
       message: 'Org name as the first argument',
       pass: 'ok',
@@ -67,6 +69,14 @@ async function run(
       message: 'Scan ID to delete',
       pass: 'ok',
       fail: 'missing'
+    },
+    {
+      nook: true,
+      test: apiToken,
+      message:
+        'You need to be logged in to use this command. See `socket login`.',
+      pass: 'ok',
+      fail: 'missing API token'
     }
   )
   if (wasBadInput) {

--- a/src/commands/scan/cmd-scan-list.test.ts
+++ b/src/commands/scan/cmd-scan-list.test.ts
@@ -69,7 +69,9 @@ describe('socket scan list', async () => {
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
 
-          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)"
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
+
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -77,7 +79,14 @@ describe('socket scan list', async () => {
   )
 
   cmdit(
-    ['scan', 'list', 'fakeorg', '--dry-run', '--config', '{}'],
+    [
+      'scan',
+      'list',
+      'fakeorg',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/scan/cmd-scan-metadata.test.ts
+++ b/src/commands/scan/cmd-scan-metadata.test.ts
@@ -65,7 +65,9 @@ describe('socket scan metadata', async () => {
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - Scan ID to inspect as argument (\\x1b[31mmissing\\x1b[39m)"
+          - Scan ID to inspect as argument (\\x1b[31mmissing\\x1b[39m)
+
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -73,7 +75,15 @@ describe('socket scan metadata', async () => {
   )
 
   cmdit(
-    ['scan', 'metadata', 'fakeorg', 'scanidee', '--dry-run', '--config', '{}'],
+    [
+      'scan',
+      'metadata',
+      'fakeorg',
+      'scanidee',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/scan/cmd-scan-report.test.ts
+++ b/src/commands/scan/cmd-scan-report.test.ts
@@ -85,7 +85,9 @@ describe('socket scan report', async () => {
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - Scan ID to fetch (\\x1b[31mmissing\\x1b[39m)"
+          - Scan ID to fetch (\\x1b[31mmissing\\x1b[39m)
+
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -93,7 +95,15 @@ describe('socket scan report', async () => {
   )
 
   cmdit(
-    ['scan', 'report', 'org', 'report-id', '--dry-run', '--config', '{}'],
+    [
+      'scan',
+      'report',
+      'org',
+      'report-id',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should be ok with org name and id',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/scan/cmd-scan-report.ts
+++ b/src/commands/scan/cmd-scan-report.ts
@@ -7,6 +7,7 @@ import { getConfigValue } from '../../utils/config'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
+import { getDefaultToken } from '../../utils/sdk'
 
 import type {
   CliCommandConfig,
@@ -108,10 +109,11 @@ async function run(
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
   const scanId = (defaultOrgSlug ? cli.input[0] : cli.input[1]) || ''
   const file = (defaultOrgSlug ? cli.input[1] : cli.input[2]) || '-'
+  const apiToken = getDefaultToken()
 
   const wasBadInput = handleBadInput(
     {
-      hide: defaultOrgSlug,
+      nook: true,
       test: orgSlug,
       message: 'Org name as the first argument',
       pass: 'ok',
@@ -124,11 +126,19 @@ async function run(
       fail: 'missing'
     },
     {
-      hide: !json || !markdown,
+      nook: true,
       test: !json || !markdown,
       message: 'The json and markdown flags cannot be both set, pick one',
       pass: 'ok',
       fail: 'omit one'
+    },
+    {
+      nook: true,
+      test: apiToken,
+      message:
+        'You need to be logged in to use this command. See `socket login`.',
+      pass: 'ok',
+      fail: 'missing API token'
     }
   )
   if (wasBadInput) {

--- a/src/commands/scan/cmd-scan-view.test.ts
+++ b/src/commands/scan/cmd-scan-view.test.ts
@@ -67,7 +67,9 @@ describe('socket scan view', async () => {
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - Scan ID to delete (\\x1b[31mmissing\\x1b[39m)"
+          - Scan ID to delete (\\x1b[31mmissing\\x1b[39m)
+
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -75,7 +77,15 @@ describe('socket scan view', async () => {
   )
 
   cmdit(
-    ['scan', 'view', 'fakeorg', 'scanidee', '--dry-run', '--config', '{}'],
+    [
+      'scan',
+      'view',
+      'fakeorg',
+      'scanidee',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/scan/cmd-scan.test.ts
+++ b/src/commands/scan/cmd-scan.test.ts
@@ -52,7 +52,7 @@ describe('socket scan', async () => {
   )
 
   cmdit(
-    ['scan', '--dry-run', '--config', '{}'],
+    ['scan', '--dry-run', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/scan/fetch-delete-org-full-scan.ts
+++ b/src/commands/scan/fetch-delete-org-full-scan.ts
@@ -1,7 +1,6 @@
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { AuthError } from '../../utils/errors'
-import { getDefaultToken, setupSdk } from '../../utils/sdk'
+import { setupSdk } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
@@ -9,25 +8,10 @@ export async function fetchDeleteOrgFullScan(
   orgSlug: string,
   scanId: string
 ): Promise<SocketSdkReturnType<'deleteOrgFullScan'>['data'] | void> {
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
+  const sockSdk = await setupSdk()
 
-  await fetchDeleteOrgFullScanWithToken(apiToken, orgSlug, scanId)
-}
-
-async function fetchDeleteOrgFullScanWithToken(
-  apiToken: string,
-  orgSlug: string,
-  scanId: string
-): Promise<SocketSdkReturnType<'deleteOrgFullScan'>['data'] | void> {
   // Lazily access constants.spinner.
   const { spinner } = constants
-
-  const sockSdk = await setupSdk(apiToken)
 
   spinner.start('Requesting the scan to be deleted...')
 

--- a/src/commands/scan/fetch-list-scans.ts
+++ b/src/commands/scan/fetch-list-scans.ts
@@ -1,7 +1,6 @@
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { AuthError } from '../../utils/errors'
-import { getDefaultToken, setupSdk } from '../../utils/sdk'
+import { setupSdk } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
@@ -20,45 +19,10 @@ export async function fetchListScans({
   per_page: number
   sort: string
 }): Promise<SocketSdkReturnType<'getOrgFullScanList'>['data'] | void> {
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
+  const sockSdk = await setupSdk()
 
-  await fetchListScansWithToken(apiToken, {
-    direction,
-    from_time,
-    orgSlug,
-    page,
-    per_page,
-    sort
-  })
-}
-
-async function fetchListScansWithToken(
-  apiToken: string,
-  {
-    direction,
-    from_time,
-    orgSlug,
-    page,
-    per_page,
-    sort
-  }: {
-    direction: string
-    from_time: string // seconds
-    orgSlug: string
-    page: number
-    per_page: number
-    sort: string
-  }
-): Promise<SocketSdkReturnType<'getOrgFullScanList'>['data'] | void> {
   // Lazily access constants.spinner.
   const { spinner } = constants
-
-  const sockSdk = await setupSdk(apiToken)
 
   spinner.start('Fetching list of scans...')
 

--- a/src/commands/scan/fetch-report-data.ts
+++ b/src/commands/scan/fetch-report-data.ts
@@ -73,7 +73,7 @@ export async function fetchReportData(
         `Fetching ${needs.join(needs.length > 2 ? ', ' : ' and ')}...${haves.length ? ` Completed fetching ${haves.join(haves.length > 2 ? ', ' : ' and ')}.` : ''}`
       )
     } else {
-      spinner?.successAndStop(
+      spinner.successAndStop(
         `Completed fetching ${haves.join(haves.length > 2 ? ', ' : ' and ')}.`
       )
     }

--- a/src/commands/scan/fetch-scan-metadata.ts
+++ b/src/commands/scan/fetch-scan-metadata.ts
@@ -1,7 +1,6 @@
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { AuthError } from '../../utils/errors'
-import { getDefaultToken, setupSdk } from '../../utils/sdk'
+import { setupSdk } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
@@ -9,25 +8,10 @@ export async function fetchScanMetadata(
   orgSlug: string,
   scanId: string
 ): Promise<SocketSdkReturnType<'getOrgFullScanMetadata'>['data'] | void> {
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
+  const sockSdk = await setupSdk()
 
-  await fetchScanMetadataWithToken(apiToken, orgSlug, scanId)
-}
-
-async function fetchScanMetadataWithToken(
-  apiToken: string,
-  orgSlug: string,
-  scanId: string
-): Promise<SocketSdkReturnType<'getOrgFullScanMetadata'>['data'] | void> {
   // Lazily access constants.spinner.
   const { spinner } = constants
-
-  const sockSdk = await setupSdk(apiToken)
 
   spinner.start('Fetching meta data for a full scan...')
 

--- a/src/commands/scan/fetch-scan.ts
+++ b/src/commands/scan/fetch-scan.ts
@@ -13,15 +13,15 @@ export async function fetchScan(
   orgSlug: string,
   scanId: string
 ): Promise<Array<components['schemas']['SocketArtifact']> | undefined> {
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
   const apiToken = getDefaultToken()
   if (!apiToken) {
     throw new AuthError(
       'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
     )
   }
+
+  // Lazily access constants.spinner.
+  const { spinner } = constants
 
   spinner.start('Fetching full-scan...')
 

--- a/src/commands/scan/handle-scan-metadata.ts
+++ b/src/commands/scan/handle-scan-metadata.ts
@@ -4,7 +4,7 @@ import { outputScanMetadata } from './output-scan-metadata'
 export async function handleOrgScanMetadata(
   orgSlug: string,
   scanId: string,
-  outputKind: 'json' | 'markdown' | 'print'
+  outputKind: 'json' | 'markdown' | 'text'
 ): Promise<void> {
   const data = await fetchScanMetadata(orgSlug, scanId)
   if (!data) {

--- a/src/commands/scan/output-scan-metadata.ts
+++ b/src/commands/scan/output-scan-metadata.ts
@@ -5,7 +5,7 @@ import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 export async function outputScanMetadata(
   data: SocketSdkReturnType<'getOrgFullScanMetadata'>['data'],
   scanId: string,
-  outputKind: 'json' | 'markdown' | 'print'
+  outputKind: 'json' | 'markdown' | 'text'
 ): Promise<void> {
   if (outputKind === 'json') {
     logger.log(data)

--- a/src/commands/scan/streamScan.ts
+++ b/src/commands/scan/streamScan.ts
@@ -29,7 +29,7 @@ export async function streamScan(
     'Fetching a scan'
   )
 
-  spinner?.successAndStop(
+  spinner.successAndStop(
     file ? `Full scan details written to ${file}` : 'stdout'
   )
 

--- a/src/commands/threat-feed/cmd-threat-feed.test.ts
+++ b/src/commands/threat-feed/cmd-threat-feed.test.ts
@@ -85,6 +85,30 @@ describe('socket threat-feed', async () => {
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket threat-feed\`, cwd: <redacted>
+
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
+
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+      `)
+
+      expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
+    }
+  )
+
+  cmdit(
+    ['threat-feed', 'boo', '--dry-run', '--config', '{"apiToken":"anything"}'],
+    'should require args with just dry-run',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "

--- a/src/commands/threat-feed/fetch-threat-feed.ts
+++ b/src/commands/threat-feed/fetch-threat-feed.ts
@@ -1,0 +1,48 @@
+import constants from '../../constants'
+import { queryApi } from '../../utils/api'
+import { AuthError } from '../../utils/errors'
+import { getDefaultToken } from '../../utils/sdk'
+
+import type { ThreadFeedResponse } from './types'
+
+export async function fetchThreatFeed({
+  direction,
+  ecosystem,
+  filter,
+  page,
+  perPage
+}: {
+  direction: string
+  ecosystem: string
+  filter: string
+  page: string
+  perPage: number
+}): Promise<ThreadFeedResponse | { error: { message: string } }> {
+  const queryParams = new URLSearchParams([
+    ['direction', direction],
+    ['ecosystem', ecosystem],
+    ['filter', filter],
+    ['page', page],
+    ['per_page', String(perPage)]
+  ])
+
+  const apiToken = getDefaultToken()
+  if (!apiToken) {
+    throw new AuthError(
+      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
+    )
+  }
+
+  // Lazily access constants.spinner.
+  const { spinner } = constants
+
+  spinner.start('Fetching Threat Feed data...')
+
+  const response = await queryApi(`threat-feed?${queryParams}`, apiToken)
+
+  spinner.successAndStop('Threat feed data fetched')
+
+  const data = await response.json()
+
+  return data as ThreadFeedResponse | { error: { message: string } }
+}

--- a/src/commands/threat-feed/handle-threat-feed.ts
+++ b/src/commands/threat-feed/handle-threat-feed.ts
@@ -1,0 +1,40 @@
+import { fetchThreatFeed } from './fetch-threat-feed'
+import { outputThreatFeed } from './output-threat-feed'
+
+import type { ThreadFeedResponse } from './types'
+
+export async function handleThreatFeed({
+  direction,
+  ecosystem,
+  filter,
+  outputKind,
+  page,
+  perPage
+}: {
+  direction: string
+  ecosystem: string
+  filter: string
+  outputKind: 'json' | 'markdown' | 'text'
+  page: string
+  perPage: number
+}): Promise<void> {
+  const data = await fetchThreatFeed({
+    direction,
+    ecosystem,
+    filter,
+    page,
+    perPage
+  })
+  if (!data) {
+    return
+  }
+
+  if ('error' in data && data.error) {
+    console.log(data.error.message)
+    return
+  }
+
+  await outputThreatFeed(data as ThreadFeedResponse, {
+    outputKind
+  })
+}

--- a/src/commands/threat-feed/types.ts
+++ b/src/commands/threat-feed/types.ts
@@ -1,0 +1,15 @@
+export interface ThreadFeedResponse {
+  results: ThreatResult[]
+  nextPage: string
+}
+
+export type ThreatResult = {
+  createdAt: string
+  description: string
+  id: number
+  locationHtmlUrl: string
+  packageHtmlUrl: string
+  purl: string
+  removedAt: string | null
+  threatType: string
+}

--- a/src/commands/wrapper/cmd-wrapper.test.ts
+++ b/src/commands/wrapper/cmd-wrapper.test.ts
@@ -72,7 +72,7 @@ describe('socket wrapper', async () => {
   )
 
   cmdit(
-    ['wrapper', '--dry-run', '--enable'],
+    ['wrapper', '--dry-run', '--enable', '--config', '{"apiToken":"anything"}'],
     'should require args with just dry-run',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)

--- a/src/commands/wrapper/cmd-wrapper.ts
+++ b/src/commands/wrapper/cmd-wrapper.ts
@@ -80,7 +80,7 @@ async function run(
       fail: 'missing'
     },
     {
-      hide: !enable || !disable,
+      nook: true,
       test: !enable || !disable,
       message: 'Do not use both --enable and --disable',
       pass: 'ok',

--- a/src/utils/handle-bad-input.ts
+++ b/src/utils/handle-bad-input.ts
@@ -5,7 +5,7 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 export function handleBadInput(
   ...arr: Array<{
     message: string
-    hide?: unknown // Truthy checked through !!
+    nook?: unknown // Only display error when test is not OK
     test: unknown // Truthy checked through !!
     pass: string
     fail: string
@@ -20,7 +20,8 @@ export function handleBadInput(
     ''
   ]
   for (const data of arr) {
-    if (data.hide) {
+    // If nook, then ignore when test is ok
+    if (data.nook && data.test) {
       continue
     }
     const lines = data.message.split('\n')


### PR DESCRIPTION
- make apiToken reject command at input validation, rather than throw a hard error. removed the hard error for it; just let setupSdk() fail over it if it does reach there anyways.
- update the input validation to also check for the json+markdown flag
- change the input validation schema to accept a `nook` flag rather than `hide`, to prevent repeated expressions. nook is not-ok, indicating to print the message only when the test fails
- harden the threat-feed logic in case of errors. try to make sure it never infinite-loop-freezes the terminal. make sure the escape keys are bound to the screen before anything else.