### PR TITLE
Make badge consistent, poish other error handling cases

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,6 @@ import { pathToFileURL } from 'node:url'
 
 import { messageWithCauses, stackWithCauses } from 'pony-cause'
 import updateNotifier from 'tiny-updater'
-import colors from 'yoctocolors-cjs'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 
@@ -35,6 +34,7 @@ import { cmdThreatFeed } from './commands/threat-feed/cmd-threat-feed'
 import { cmdWrapper } from './commands/wrapper/cmd-wrapper'
 import constants from './constants'
 import { AuthError, InputError, captureException } from './utils/errors'
+import { failMsgWithBadge } from './utils/fail-msg-with-badge'
 import { meowWithSubcommands } from './utils/meow-with-subcommands'
 
 const { SOCKET_CLI_BIN_NAME } = constants
@@ -107,9 +107,7 @@ void (async () => {
     } else {
       errorTitle = 'Unexpected error with no details'
     }
-    logger.fail(
-      `${colors.bgRed(colors.white(`${errorTitle}:`))} ${errorMessage}`
-    )
+    logger.fail(failMsgWithBadge(errorTitle, errorMessage))
     if (errorBody) {
       logger.error(`\n${errorBody}`)
     }

--- a/src/commands/analytics/cmd-analytics.test.ts
+++ b/src/commands/analytics/cmd-analytics.test.ts
@@ -70,7 +70,7 @@ describe('socket analytics', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket analytics\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Scope must be "repo" or "org" (\\x1b[32mok\\x1b[39m)
 

--- a/src/commands/analytics/display-analytics.ts
+++ b/src/commands/analytics/display-analytics.ts
@@ -10,9 +10,7 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { fetchOrgAnalyticsData } from './fetch-org-analytics'
 import { fetchRepoAnalyticsData } from './fetch-repo-analytics'
 import constants from '../../constants'
-import { AuthError } from '../../utils/errors'
 import { mdTableStringNumber } from '../../utils/markdown'
-import { getDefaultToken } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 import type { Widgets } from 'blessed' // Note: Widgets does not seem to actually work as code :'(
@@ -77,38 +75,6 @@ export async function displayAnalytics({
   outputKind: 'json' | 'markdown' | 'print'
   filePath: string
 }): Promise<void> {
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API token.'
-    )
-  }
-
-  await outputAnalyticsWithToken({
-    apiToken,
-    filePath,
-    outputKind,
-    repo,
-    scope,
-    time
-  })
-}
-
-async function outputAnalyticsWithToken({
-  apiToken,
-  filePath,
-  outputKind,
-  repo,
-  scope,
-  time
-}: {
-  apiToken: string
-  scope: string
-  time: number
-  repo: string
-  outputKind: 'json' | 'markdown' | 'print'
-  filePath: string
-}): Promise<void> {
   // Lazily access constants.spinner.
   const { spinner } = constants
 
@@ -119,9 +85,9 @@ async function outputAnalyticsWithToken({
     | SocketSdkReturnType<'getOrgAnalytics'>['data']
     | SocketSdkReturnType<'getRepoAnalytics'>['data']
   if (scope === 'org') {
-    data = await fetchOrgAnalyticsData(time, spinner, apiToken)
+    data = await fetchOrgAnalyticsData(time, spinner)
   } else if (repo) {
-    data = await fetchRepoAnalyticsData(repo, time, spinner, apiToken)
+    data = await fetchRepoAnalyticsData(repo, time, spinner)
   }
 
   // A message should already have been printed if we have no data here

--- a/src/commands/analytics/fetch-org-analytics.ts
+++ b/src/commands/analytics/fetch-org-analytics.ts
@@ -8,10 +8,9 @@ import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function fetchOrgAnalyticsData(
   time: number,
-  spinner: Spinner,
-  apiToken: string
+  spinner: Spinner
 ): Promise<SocketSdkReturnType<'getOrgAnalytics'>['data'] | undefined> {
-  const sockSdk = await setupSdk(apiToken)
+  const sockSdk = await setupSdk()
   const result = await handleApiCall(
     sockSdk.getOrgAnalytics(time.toString()),
     'fetching analytics data'

--- a/src/commands/analytics/fetch-repo-analytics.ts
+++ b/src/commands/analytics/fetch-repo-analytics.ts
@@ -9,10 +9,9 @@ import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 export async function fetchRepoAnalyticsData(
   repo: string,
   time: number,
-  spinner: Spinner,
-  apiToken: string
+  spinner: Spinner
 ): Promise<SocketSdkReturnType<'getRepoAnalytics'>['data'] | undefined> {
-  const sockSdk = await setupSdk(apiToken)
+  const sockSdk = await setupSdk()
   const result = await handleApiCall(
     sockSdk.getRepoAnalytics(repo, time.toString()),
     'fetching analytics data'

--- a/src/commands/audit-log/cmd-audit-log.test.ts
+++ b/src/commands/audit-log/cmd-audit-log.test.ts
@@ -67,7 +67,7 @@ describe('socket audit-log', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket audit-log\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Org name should be the first arg (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/cdxgen/cmd-cdxgen.ts
+++ b/src/commands/cdxgen/cmd-cdxgen.ts
@@ -147,16 +147,6 @@ async function run(
     importMeta,
     parentName
   })
-  // if (cli.input.length)
-  //   logger.fail(
-  //     stripIndents`
-  //       ${colors.bgRed(colors.white('Input error'))}: Please provide the required fields:
-  //
-  //       - Unexpected arguments
-  //   `)
-  //   config.help(parentName, config)
-  //   return
-  // }
 
   // TODO: Convert to meow.
   const yargv = {

--- a/src/commands/config/cmd-config-get.test.ts
+++ b/src/commands/config/cmd-config-get.test.ts
@@ -69,7 +69,7 @@ describe('socket config get', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket config get\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Config key should be the first arg (\\x1b[31mmissing\\x1b[39m)"
       `)

--- a/src/commands/config/cmd-config-set.test.ts
+++ b/src/commands/config/cmd-config-set.test.ts
@@ -74,7 +74,7 @@ describe('socket config get', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket config set\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Config key should be the first arg (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/config/cmd-config-unset.test.ts
+++ b/src/commands/config/cmd-config-unset.test.ts
@@ -69,7 +69,7 @@ describe('socket config unset', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket config unset\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Config key should be the first arg (\\x1b[31mmissing\\x1b[39m)"
       `)

--- a/src/commands/diff-scan/cmd-diff-scan-get.test.ts
+++ b/src/commands/diff-scan/cmd-diff-scan-get.test.ts
@@ -68,7 +68,7 @@ describe('socket diff-scan get', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Specify a before and after scan ID (\\x1b[31mmissing before and after\\x1b[39m)
             The args are expecting a full \`aaa0aa0a-aaaa-0000-0a0a-0000000a00a0\` scan ID.

--- a/src/commands/diff-scan/fetch-diff-scan.ts
+++ b/src/commands/diff-scan/fetch-diff-scan.ts
@@ -1,7 +1,8 @@
-import colors from 'yoctocolors-cjs'
+import { logger } from '@socketsecurity/registry/lib/logger'
 
 import constants from '../../constants'
 import { handleApiCall, handleApiError, queryApi } from '../../utils/api'
+import { failMsgWithBadge } from '../../utils/fail-msg-with-badge'
 import { getDefaultToken } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
@@ -31,9 +32,7 @@ export async function fetchDiffScan({
 
   if (!response.ok) {
     const err = await handleApiError(response.status)
-    spinner.errorAndStop(
-      `${colors.bgRed(colors.white(response.statusText))}: ${err}`
-    )
+    logger.fail(failMsgWithBadge(response.statusText, err))
     return
   }
 

--- a/src/commands/info/cmd-info.test.ts
+++ b/src/commands/info/cmd-info.test.ts
@@ -62,7 +62,7 @@ describe('socket info', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket info\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Expecting a package name (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/manifest/cmd-manifest-gradle.test.ts
+++ b/src/commands/manifest/cmd-manifest-gradle.test.ts
@@ -88,7 +88,7 @@ describe('socket manifest gradle', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest gradle\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - The DIR arg is required (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/manifest/cmd-manifest-kotlin.test.ts
+++ b/src/commands/manifest/cmd-manifest-kotlin.test.ts
@@ -88,7 +88,7 @@ describe('socket manifest kotlin', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest kotlin\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - The DIR arg is required (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/manifest/cmd-manifest-scala.test.ts
+++ b/src/commands/manifest/cmd-manifest-scala.test.ts
@@ -92,7 +92,7 @@ describe('socket manifest scala', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest scala\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - The DIR arg is required (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/organization/cmd-organization-policy-license.test.ts
+++ b/src/commands/organization/cmd-organization-policy-license.test.ts
@@ -65,7 +65,7 @@ describe('socket organization policy license', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy license\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/organization/cmd-organization-policy-security.test.ts
+++ b/src/commands/organization/cmd-organization-policy-security.test.ts
@@ -65,7 +65,7 @@ describe('socket organization policy security', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy security\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/organization/fetch-license-policy.ts
+++ b/src/commands/organization/fetch-license-policy.ts
@@ -1,28 +1,13 @@
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { AuthError } from '../../utils/errors'
-import { getDefaultToken, setupSdk } from '../../utils/sdk'
+import { setupSdk } from '../../utils/sdk'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function fetchLicensePolicy(
   orgSlug: string
 ): Promise<SocketSdkReturnType<'getOrgLicensePolicy'>['data'] | undefined> {
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
-
-  return await fetchLicensePolicyWithToken(apiToken, orgSlug)
-}
-
-async function fetchLicensePolicyWithToken(
-  apiToken: string,
-  orgSlug: string
-): Promise<SocketSdkReturnType<'getOrgLicensePolicy'>['data'] | undefined> {
-  const sockSdk = await setupSdk(apiToken)
+  const sockSdk = await setupSdk()
 
   // Lazily access constants.spinner.
   const { spinner } = constants

--- a/src/commands/package/cmd-package-score.test.ts
+++ b/src/commands/package/cmd-package-score.test.ts
@@ -84,7 +84,7 @@ describe('socket package score', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket package score\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - First parameter must be an ecosystem or the whole purl (\\x1b[31mbad\\x1b[39m)
 

--- a/src/commands/package/cmd-package-shallow.test.ts
+++ b/src/commands/package/cmd-package-shallow.test.ts
@@ -83,7 +83,7 @@ describe('socket package shallow', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket package shallow\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - First parameter should be an ecosystem or all args must be purls (\\x1b[31mbad\\x1b[39m)
 

--- a/src/commands/package/fetch-purl-deep-score.ts
+++ b/src/commands/package/fetch-purl-deep-score.ts
@@ -1,10 +1,9 @@
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import constants from '../../constants'
 import { handleApiCall, handleApiError, queryApi } from '../../utils/api'
 import { AuthError } from '../../utils/errors'
+import { failMsgWithBadge } from '../../utils/fail-msg-with-badge'
 import { getDefaultToken } from '../../utils/sdk'
 
 export async function fetchPurlDeepScore(purl: string) {
@@ -42,9 +41,7 @@ export async function fetchPurlDeepScore(purl: string) {
 
   if (!result.ok) {
     const err = await handleApiError(result.status)
-    logger.fail(
-      `${colors.bgRed(colors.bold(colors.white(' ' + result.statusText + ' ')))}: ${err}`
-    )
+    logger.fail(failMsgWithBadge(result.statusText, err))
     process.exitCode = 1
     return
   }

--- a/src/commands/package/fetch-purls-shallow-score.ts
+++ b/src/commands/package/fetch-purls-shallow-score.ts
@@ -11,7 +11,7 @@ import type {
 
 export async function fetchPurlsShallowScore(
   purls: string[]
-): Promise<SocketSdkReturnType<'batchPackageFetch'>> {
+): Promise<SocketSdkReturnType<'batchPackageFetch'> | undefined> {
   logger.error(
     `Requesting shallow score data for ${purls.length} package urls (purl): ${purls.join(', ')}`
   )
@@ -40,8 +40,10 @@ export async function fetchPurlsShallowScore(
 
   spinner.successAndStop('Request completed')
 
-  if (result.success) {
-    return result
+  if (!result.success) {
+    handleUnsuccessfulApiResponse('batchPackageFetch', result)
+    return
   }
-  handleUnsuccessfulApiResponse('batchPackageFetch', result)
+
+  return result
 }

--- a/src/commands/package/handle-purls-shallow-score.ts
+++ b/src/commands/package/handle-purls-shallow-score.ts
@@ -11,11 +11,13 @@ export async function handlePurlsShallowScore({
   purls: string[]
 }) {
   const packageData = await fetchPurlsShallowScore(purls)
-  if (packageData) {
-    outputPurlsShallowScore(
-      purls,
-      packageData.data as Array<components['schemas']['SocketArtifact']>,
-      outputKind
-    )
+  if (!packageData) {
+    return
   }
+
+  outputPurlsShallowScore(
+    purls,
+    packageData.data as Array<components['schemas']['SocketArtifact']>,
+    outputKind
+  )
 }

--- a/src/commands/repos/cmd-repos-create.test.ts
+++ b/src/commands/repos/cmd-repos-create.test.ts
@@ -64,7 +64,7 @@ describe('socket repos create', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos create\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/repos/cmd-repos-del.test.ts
+++ b/src/commands/repos/cmd-repos-del.test.ts
@@ -59,7 +59,7 @@ describe('socket repos del', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos del\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/repos/cmd-repos-list.test.ts
+++ b/src/commands/repos/cmd-repos-list.test.ts
@@ -65,7 +65,7 @@ describe('socket repos list', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos list\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/repos/cmd-repos-update.test.ts
+++ b/src/commands/repos/cmd-repos-update.test.ts
@@ -64,7 +64,7 @@ describe('socket repos update', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos update\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/repos/cmd-repos-view.test.ts
+++ b/src/commands/repos/cmd-repos-view.test.ts
@@ -62,7 +62,7 @@ describe('socket repos view', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos view\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/scan/cmd-scan-del.test.ts
+++ b/src/commands/scan/cmd-scan-del.test.ts
@@ -61,7 +61,7 @@ describe('socket scan del', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan del\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/scan/cmd-scan-list.test.ts
+++ b/src/commands/scan/cmd-scan-list.test.ts
@@ -67,7 +67,7 @@ describe('socket scan list', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan list\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/scan/cmd-scan-metadata.test.ts
+++ b/src/commands/scan/cmd-scan-metadata.test.ts
@@ -61,7 +61,7 @@ describe('socket scan metadata', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan metadata\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/scan/cmd-scan-report.test.ts
+++ b/src/commands/scan/cmd-scan-report.test.ts
@@ -81,7 +81,7 @@ describe('socket scan report', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan report\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/scan/cmd-scan-view.test.ts
+++ b/src/commands/scan/cmd-scan-view.test.ts
@@ -63,7 +63,7 @@ describe('socket scan view', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan view\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/scan/fetch-scan.ts
+++ b/src/commands/scan/fetch-scan.ts
@@ -1,10 +1,9 @@
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import constants from '../../constants'
 import { handleApiError, queryApi } from '../../utils/api'
 import { AuthError } from '../../utils/errors'
+import { failMsgWithBadge } from '../../utils/fail-msg-with-badge'
 import { getDefaultToken } from '../../utils/sdk'
 
 import type { components } from '@socketsecurity/sdk/types/api'
@@ -23,20 +22,18 @@ export async function fetchScan(
   // Lazily access constants.spinner.
   const { spinner } = constants
 
-  spinner.start('Fetching full-scan...')
+  spinner.start('Fetching scan data...')
 
   const response = await queryApi(
     `orgs/${orgSlug}/full-scans/${encodeURIComponent(scanId)}`,
     apiToken
   )
 
-  spinner.stop('Fetch complete.')
+  spinner.successAndStop('Received response while fetching scan data.')
 
   if (!response.ok) {
     const err = await handleApiError(response.status)
-    logger.fail(
-      `${colors.bgRed(colors.white(response.statusText))}: Fetch error: ${err}`
-    )
+    logger.fail(failMsgWithBadge(response.statusText, `Fetch error: ${err}`))
     return
   }
 

--- a/src/commands/scan/handle-create-new-scan.ts
+++ b/src/commands/scan/handle-create-new-scan.ts
@@ -1,16 +1,10 @@
-import process from 'node:process'
-
-import { stripIndents } from 'common-tags'
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { fetchCreateOrgFullScan } from './fetch-create-org-full-scan'
 import { fetchSupportedScanFileNames } from './fetch-supported-scan-file-names'
 import { outputCreateNewScan } from './output-create-new-scan'
-import { AuthError } from '../../utils/errors'
+import { handleBadInput } from '../../utils/handle-bad-input'
 import { getPackageFilesForScan } from '../../utils/path-resolve'
-import { getDefaultToken } from '../../utils/sdk'
 
 export async function handleCreateNewScan({
   branchName,
@@ -35,15 +29,6 @@ export async function handleCreateNewScan({
   targets: string[]
   tmp: boolean
 }): Promise<void> {
-  const apiToken = getDefaultToken()
-
-  // Note: you need an apiToken to request supportedScanFileNames from the API
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to create and submit new scans. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
-
   const supportedFileNames = await fetchSupportedScanFileNames()
   if (!supportedFileNames) {
     return
@@ -56,16 +41,13 @@ export async function handleCreateNewScan({
     // socketConfig
   )
 
-  if (!packagePaths.length) {
-    // Use exit status of 2 to indicate incorrect usage, generally invalid
-    // options or missing arguments.
-    // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
-    process.exitCode = 2
-    logger.fail(stripIndents`
-      ${colors.bgRed(colors.white('Input error'))}: The TARGET did not contain any matching / supported files for a scan
-    `)
-    return
-  }
+  handleBadInput({
+    nook: true,
+    test: packagePaths.length > 0,
+    pass: 'ok',
+    fail: 'found none',
+    message: 'TARGET must contain matching / supported file types for a scan'
+  })
 
   if (readOnly) {
     logger.log('[ReadOnly] Bailing now')

--- a/src/commands/scan/streamScan.ts
+++ b/src/commands/scan/streamScan.ts
@@ -1,7 +1,6 @@
 import constants from '../../constants'
 import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
-import { AuthError } from '../../utils/errors'
-import { getDefaultToken, setupSdk } from '../../utils/sdk'
+import { setupSdk } from '../../utils/sdk'
 
 import type { SocketSdkResultType } from '@socketsecurity/sdk'
 
@@ -13,14 +12,7 @@ export async function streamScan(
   // Lazily access constants.spinner.
   const { spinner } = constants
 
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    throw new AuthError(
-      'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    )
-  }
-
-  const sockSdk = await setupSdk(apiToken)
+  const sockSdk = await setupSdk()
 
   spinner.start('Fetching scan...')
 

--- a/src/commands/threat-feed/cmd-threat-feed.test.ts
+++ b/src/commands/threat-feed/cmd-threat-feed.test.ts
@@ -93,7 +93,7 @@ describe('socket threat-feed', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket threat-feed\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/threat-feed/fetch-threat-feed.ts
+++ b/src/commands/threat-feed/fetch-threat-feed.ts
@@ -40,7 +40,7 @@ export async function fetchThreatFeed({
 
   const response = await queryApi(`threat-feed?${queryParams}`, apiToken)
 
-  spinner.successAndStop('Threat feed data fetched')
+  spinner.successAndStop('Received response while fetching Threat Feed data.')
 
   const data = await response.json()
 

--- a/src/commands/threat-feed/handle-threat-feed.ts
+++ b/src/commands/threat-feed/handle-threat-feed.ts
@@ -1,5 +1,8 @@
+import { logger } from '@socketsecurity/registry/lib/logger'
+
 import { fetchThreatFeed } from './fetch-threat-feed'
 import { outputThreatFeed } from './output-threat-feed'
+import { failMsgWithBadge } from '../../utils/fail-msg-with-badge'
 
 import type { ThreadFeedResponse } from './types'
 
@@ -30,7 +33,7 @@ export async function handleThreatFeed({
   }
 
   if ('error' in data && data.error) {
-    console.log(data.error.message)
+    logger.fail(failMsgWithBadge('Server Error', data.error.message))
     return
   }
 

--- a/src/commands/wrapper/cmd-wrapper.test.ts
+++ b/src/commands/wrapper/cmd-wrapper.test.ts
@@ -62,7 +62,7 @@ describe('socket wrapper', async () => {
           |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket wrapper\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m:
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
           - Must use --enabled or --disable (\\x1b[31mmissing\\x1b[39m)"
       `)

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,13 +1,12 @@
 import process from 'node:process'
 
-import colors from 'yoctocolors-cjs'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 import { isNonEmptyString } from '@socketsecurity/registry/lib/strings'
 
 import { getConfigValue } from './config'
 import { AuthError } from './errors'
 import constants from '../constants'
+import { failMsgWithBadge } from './fail-msg-with-badge'
 
 import type {
   SocketSdkErrorType,
@@ -28,9 +27,7 @@ export function handleUnsuccessfulApiResponse<T extends SocketSdkOperations>(
 
     throw new AuthError(message)
   }
-  logger.fail(
-    `${colors.bgRed(colors.white('API returned an error:'))} ${message}`
-  )
+  logger.fail(failMsgWithBadge('API returned an error:', message))
   // eslint-disable-next-line n/no-process-exit
   process.exit(1)
 }
@@ -52,9 +49,9 @@ export async function handleApiError(code: number) {
   if (code === 400) {
     return 'One of the options passed might be incorrect.'
   } else if (code === 403) {
-    return 'You might be trying to access an organization that is not linked to the API key you are logged in with.'
+    return 'Your API token may not have the required permissions for this command or you might be trying to access (data from) an organization that is not linked to the API key you are logged in with.'
   } else if (code === 404) {
-    return 'The requested Socket API endpoint was not found (404). This could be a temporary problem caused by an incident or a bug in the CLI. If the problem persists please let us know.'
+    return 'The requested Socket API endpoint was not found (404) or there was no result for the requested parameters. This could be a temporary problem caused by an incident or a bug in the CLI. If the problem persists please let us know.'
   } else {
     return `Server responded with status code ${code}`
   }

--- a/src/utils/fail-msg-with-badge.ts
+++ b/src/utils/fail-msg-with-badge.ts
@@ -1,0 +1,5 @@
+import colors from 'yoctocolors-cjs'
+
+export function failMsgWithBadge(badge: string, msg: string): string {
+  return `${colors.bgRed(colors.bold(colors.white(` ${badge}: `)))} ${colors.bold(msg)}`
+}

--- a/src/utils/handle-bad-input.ts
+++ b/src/utils/handle-bad-input.ts
@@ -2,6 +2,8 @@ import colors from 'yoctocolors-cjs'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import { failMsgWithBadge } from './fail-msg-with-badge'
+
 export function handleBadInput(
   ...arr: Array<{
     message: string
@@ -16,7 +18,10 @@ export function handleBadInput(
   }
 
   const msg = [
-    `${colors.bgRed(colors.bold(colors.white(' Input error: ')))} ${colors.bold('Please review the input requirements and try again')}:`,
+    failMsgWithBadge(
+      'Input error',
+      'Please review the input requirements and try again'
+    ),
     ''
   ]
   for (const data of arr) {


### PR DESCRIPTION
Basically set a token without any permissions and ran through each relevant command to see how it would respond to a 403 from the server.

Polished a bunch of error reporting, made the error badge consistent (abstracted), etc.