### PR TITLE
Make audit-logs default to markdown report, add test

### DIFF
--- a/src/commands/audit-log/audit-fixture.json
+++ b/src/commands/audit-log/audit-fixture.json
@@ -1,0 +1,180 @@
+{
+  "results": [
+    {
+      "event_id": "123112",
+      "created_at": "2025-04-02T01:47:26.914Z",
+      "updated_at": "2025-04-02T01:47:26.914Z",
+      "country_code": "",
+      "organization_id": "1381",
+      "ip_address": "",
+      "payload": {
+        "settingKey": "vantaViewSelector",
+        "settingValue": {
+          "ignoreAlerts": "",
+          "ignoreIngress": ""
+        }
+      },
+      "status_code": 0,
+      "type": "updateOrganizationSetting",
+      "user_agent": "",
+      "user_id": "7d8b2478-abcd-4cc9-abcd-c869de8fc924",
+      "user_email": "person@socket.dev",
+      "user_image": "",
+      "organization_name": "SocketDev"
+    },
+    {
+      "event_id": "122421",
+      "created_at": "2025-03-31T15:19:55.299Z",
+      "updated_at": "2025-03-31T15:19:55.299Z",
+      "country_code": "",
+      "organization_id": "1381",
+      "ip_address": "123.123.321.213",
+      "payload": {
+        "name": "zero-access",
+        "token": "sktsec_...LZEh_api",
+        "scopes": []
+      },
+      "status_code": 0,
+      "type": "createApiToken",
+      "user_agent": "",
+      "user_id": "e110f7e0-abcd-41bb-abcd-5745be143db8",
+      "user_email": "person@socket.dev",
+      "user_image": "",
+      "organization_name": "SocketDev"
+    },
+    {
+      "event_id": "121392",
+      "created_at": "2025-03-27T16:24:36.344Z",
+      "updated_at": "2025-03-27T16:24:36.344Z",
+      "country_code": "",
+      "organization_id": "1381",
+      "ip_address": "",
+      "payload": {
+        "settingKey": "sso",
+        "settingValue": {
+          "defaultMemberRole": "member"
+        }
+      },
+      "status_code": 0,
+      "type": "updateOrganizationSetting",
+      "user_agent": "super ai .com",
+      "user_id": "6dc7b702-abcd-438a-abcd-51e227962ebd",
+      "user_email": "person@socket.dev",
+      "user_image": "",
+      "organization_name": "SocketDev"
+    },
+    {
+      "event_id": "121391",
+      "created_at": "2025-03-27T16:24:33.912Z",
+      "updated_at": "2025-03-27T16:24:33.912Z",
+      "country_code": "",
+      "organization_id": "1381",
+      "ip_address": "",
+      "payload": {
+        "settingKey": "sso",
+        "settingValue": {
+          "defaultMemberRole": "member",
+          "requireSSOOnLogin": true
+        }
+      },
+      "status_code": 0,
+      "type": "updateOrganizationSetting",
+      "user_agent": "",
+      "user_id": "6dc7b702-abcd-438a-abcd-51e227962ebd",
+      "user_email": "person@socket.dev",
+      "user_image": "",
+      "organization_name": "SocketDev"
+    },
+    {
+      "event_id": "120287",
+      "created_at": "2025-03-24T21:52:12.879Z",
+      "updated_at": "2025-03-24T21:52:12.879Z",
+      "country_code": "",
+      "organization_id": "1381",
+      "ip_address": "",
+      "payload": {
+        "alertKey": "Q2URU2WWK6G4jQd3ReRfK-ZUo4xkF_CffmpkhbfgOd3c",
+        "alertTriageNote": "",
+        "alertTriageState": null
+      },
+      "status_code": 0,
+      "type": "updateAlertTriage",
+      "user_agent": "",
+      "user_id": "b5d98911-abcd-425b-abcd-c71534f0ef88",
+      "user_email": "person@socket.dev",
+      "user_image": "",
+      "organization_name": "SocketDev"
+    },
+    {
+      "event_id": "118431",
+      "created_at": "2025-03-17T15:57:29.885Z",
+      "updated_at": "2025-03-17T15:57:29.885Z",
+      "country_code": "",
+      "organization_id": "1381",
+      "ip_address": "",
+      "payload": {
+        "settingKey": "licensePolicy",
+        "settingValue": {
+          "allow": {
+            "strings": ["0BSD", "ADSL", "AFL-1.1"]
+          },
+          "options": {
+            "strings": ["toplevelOnly"]
+          }
+        }
+      },
+      "status_code": 0,
+      "type": "updateOrganizationSetting",
+      "user_agent": "",
+      "user_id": "7d8b2478-abcd-4cc9-abcd-c869de8fc924",
+      "user_email": "person@socket.dev",
+      "user_image": "",
+      "organization_name": "SocketDev"
+    },
+    {
+      "event_id": "116928",
+      "created_at": "2025-03-10T22:53:35.734Z",
+      "updated_at": "2025-03-10T22:53:35.734Z",
+      "country_code": "",
+      "organization_id": "1381",
+      "ip_address": "",
+      "payload": {
+        "token": "sktsec_...wnTa_api",
+        "scopes": [
+          "report",
+          "repo",
+          "full-scans",
+          "packages",
+          "audit-log",
+          "integration",
+          "threat-feed",
+          "security-policy",
+          "alerts",
+          "dependencies",
+          "historical"
+        ],
+        "oldScopes": [
+          "report",
+          "repo",
+          "full-scans",
+          "packages",
+          "audit-log",
+          "integration",
+          "threat-feed",
+          "security-policy",
+          "alerts",
+          "dependencies",
+          "historical"
+        ]
+      },
+      "status_code": 0,
+      "type": "updateApiTokenScopes",
+      "user_agent": "",
+      "user_id": "1fc4346e-abcd-4537-abcd-113e0e9609b5",
+      "user_email": "person@socket.dev",
+      "user_image": "",
+      "organization_name": "SocketDev"
+    }
+  ],
+  "nextPage": "2"
+}

--- a/src/commands/audit-log/output-audit-log.test.ts
+++ b/src/commands/audit-log/output-audit-log.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+
+import FIXTURE from './audit-fixture.json' with { type: 'json' }
+import { outputAsJson, outputAsMarkdown } from './output-audit-log'
+
+describe('output-audit-log', () => {
+  describe('json', () => {
+    it('should return formatted json string', async () => {
+      const r = await outputAsJson(
+        JSON.parse(JSON.stringify(FIXTURE.results)),
+        {
+          logType: '',
+          orgSlug: 'noorgslug',
+          page: 1,
+          perPage: 10
+        }
+      )
+      expect(r).toMatchInlineSnapshot(`
+        "{
+          "desc": "Audit logs for given query",
+          "generated": "<redacted>",
+          "org": "noorgslug",
+          "logType": "",
+          "page": 1,
+          "perPage": 10,
+          "logs": [
+            {
+              "event_id": "123112",
+              "created_at": "2025-04-02T01:47:26.914Z",
+              "ip_address": "",
+              "type": "updateOrganizationSetting",
+              "user_agent": "",
+              "user_email": "person@socket.dev"
+            },
+            {
+              "event_id": "122421",
+              "created_at": "2025-03-31T15:19:55.299Z",
+              "ip_address": "123.123.321.213",
+              "type": "createApiToken",
+              "user_agent": "",
+              "user_email": "person@socket.dev"
+            },
+            {
+              "event_id": "121392",
+              "created_at": "2025-03-27T16:24:36.344Z",
+              "ip_address": "",
+              "type": "updateOrganizationSetting",
+              "user_agent": "super ai .com",
+              "user_email": "person@socket.dev"
+            },
+            {
+              "event_id": "121391",
+              "created_at": "2025-03-27T16:24:33.912Z",
+              "ip_address": "",
+              "type": "updateOrganizationSetting",
+              "user_agent": "",
+              "user_email": "person@socket.dev"
+            },
+            {
+              "event_id": "120287",
+              "created_at": "2025-03-24T21:52:12.879Z",
+              "ip_address": "",
+              "type": "updateAlertTriage",
+              "user_agent": "",
+              "user_email": "person@socket.dev"
+            },
+            {
+              "event_id": "118431",
+              "created_at": "2025-03-17T15:57:29.885Z",
+              "ip_address": "",
+              "type": "updateOrganizationSetting",
+              "user_agent": "",
+              "user_email": "person@socket.dev"
+            },
+            {
+              "event_id": "116928",
+              "created_at": "2025-03-10T22:53:35.734Z",
+              "ip_address": "",
+              "type": "updateApiTokenScopes",
+              "user_agent": "",
+              "user_email": "person@socket.dev"
+            }
+          ]
+        }"
+      `)
+    })
+
+    it('should return empty object string on error', async () => {
+      const r = await outputAsJson(
+        {},
+        {
+          logType: '',
+          orgSlug: 'noorgslug',
+          page: 1,
+          perPage: 10
+        }
+      )
+      expect(r).toMatchInlineSnapshot(`"{}"`)
+    })
+  })
+
+  describe('markdown', () => {
+    it('should return markdown report', async () => {
+      const r = await outputAsMarkdown(
+        JSON.parse(JSON.stringify(FIXTURE.results)),
+        {
+          logType: '',
+          orgSlug: 'noorgslug',
+          page: 1,
+          perPage: 10
+        }
+      )
+      expect(r).toMatchInlineSnapshot(`
+        "
+        # Socket Audit Logs
+
+        These are the Socket.dev audit logs as per requested query.
+        - org: noorgslug
+        - type filter: (none)
+        - page: 1
+        - per page: 10
+        - generated: <redacted>
+
+        | -------- | ------------------------ | ------------------------- | ----------------- | --------------- | ------------- |
+        | event_id | created_at               | type                      | user_email        | ip_address      | user_agent    |
+        | -------- | ------------------------ | ------------------------- | ----------------- | --------------- | ------------- |
+        | 123112   | 2025-04-02T01:47:26.914Z | updateOrganizationSetting | person@socket.dev |                 |               |
+        | 122421   | 2025-03-31T15:19:55.299Z | createApiToken            | person@socket.dev | 123.123.321.213 |               |
+        | 121392   | 2025-03-27T16:24:36.344Z | updateOrganizationSetting | person@socket.dev |                 | super ai .com |
+        | 121391   | 2025-03-27T16:24:33.912Z | updateOrganizationSetting | person@socket.dev |                 |               |
+        | 120287   | 2025-03-24T21:52:12.879Z | updateAlertTriage         | person@socket.dev |                 |               |
+        | 118431   | 2025-03-17T15:57:29.885Z | updateOrganizationSetting | person@socket.dev |                 |               |
+        | 116928   | 2025-03-10T22:53:35.734Z | updateApiTokenScopes      | person@socket.dev |                 |               |
+        | -------- | ------------------------ | ------------------------- | ----------------- | --------------- | ------------- |
+        "
+      `)
+    })
+
+    it('should return empty string on error', async () => {
+      const r = await outputAsMarkdown(
+        {},
+        {
+          logType: '',
+          orgSlug: 'noorgslug',
+          page: 1,
+          perPage: 10
+        }
+      )
+      expect(r).toMatchInlineSnapshot(`""`)
+    })
+  })
+})


### PR DESCRIPTION
The old output without markdown/json was using a select interaction but it didn't really make sense tbh. So instead I dropped it and default to the markdown report.

Added a fixture and tests to cover the output.