### PR TITLE
Polish the config/token override stuff

### DIFF
--- a/src/commands/config/cmd-config-get.test.ts
+++ b/src/commands/config/cmd-config-get.test.ts
@@ -104,4 +104,224 @@ describe('socket config get', async () => {
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
     }
   )
+
+  describe('env vars', () => {
+    describe('token', () => {
+      cmdit(
+        ['config', 'get', 'apiToken', '--config', '{"apiToken":null}'],
+        'should return undefined when token not set in config',
+        async cmd => {
+          const { code, stderr, stdout } = await invokeNpm(entryPath, cmd, {})
+          expect(stdout).toMatchInlineSnapshot(
+            `
+            "apiToken: null
+
+            Note: the config is in read-only mode, meaning at least one key was temporarily overridden from an env var or command flag."
+          `
+          )
+          expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+            "
+               _____         _       _        /---------------
+              |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+              |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+              |_____|___|___|_,_|___|_|.dev   | Command: \`socket config get\`, cwd: <redacted>"
+          `)
+
+          expect(stdout.includes('apiToken: null')).toBe(true)
+        }
+      )
+
+      cmdit(
+        ['config', 'get', 'apiToken', '--config', '{"apiToken":null}'],
+        'should return the env var token when set',
+        async cmd => {
+          const { code, stderr, stdout } = await invokeNpm(entryPath, cmd, {
+            SOCKET_SECURITY_API_TOKEN: 'abc'
+          })
+          expect(stdout).toMatchInlineSnapshot(
+            `
+            "apiToken: abc
+
+            Note: the config is in read-only mode, meaning at least one key was temporarily overridden from an env var or command flag."
+          `
+          )
+          expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+            "
+               _____         _       _        /---------------
+              |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+              |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+              |_____|___|___|_,_|___|_|.dev   | Command: \`socket config get\`, cwd: <redacted>"
+          `)
+
+          expect(stdout.includes('apiToken: abc')).toBe(true)
+        }
+      )
+
+      // Migrate this away...?
+      cmdit(
+        ['config', 'get', 'apiToken', '--config', '{"apiToken":null}'],
+        'should backwards compat support api key as well env var',
+        async cmd => {
+          const { code, stderr, stdout } = await invokeNpm(entryPath, cmd, {
+            SOCKET_SECURITY_API_KEY: 'abc'
+          })
+          expect(stdout).toMatchInlineSnapshot(
+            `
+            "apiToken: abc
+
+            Note: the config is in read-only mode, meaning at least one key was temporarily overridden from an env var or command flag."
+          `
+          )
+          expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+            "
+               _____         _       _        /---------------
+              |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+              |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+              |_____|___|___|_,_|___|_|.dev   | Command: \`socket config get\`, cwd: <redacted>"
+          `)
+
+          expect(stdout.includes('apiToken: abc')).toBe(true)
+        }
+      )
+
+      cmdit(
+        ['config', 'get', 'apiToken', '--config', '{"apiToken":null}'],
+        'should be nice and support cli prefixed env var for token as well',
+        async cmd => {
+          const { code, stderr, stdout } = await invokeNpm(entryPath, cmd, {
+            SOCKET_CLI_API_TOKEN: 'abc'
+          })
+          expect(stdout).toMatchInlineSnapshot(
+            `
+            "apiToken: abc
+
+            Note: the config is in read-only mode, meaning at least one key was temporarily overridden from an env var or command flag."
+          `
+          )
+          expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+            "
+               _____         _       _        /---------------
+              |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+              |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+              |_____|___|___|_,_|___|_|.dev   | Command: \`socket config get\`, cwd: <redacted>"
+          `)
+
+          expect(stdout.includes('apiToken: abc')).toBe(true)
+        }
+      )
+
+      // Migrate this away...?
+      cmdit(
+        ['config', 'get', 'apiToken', '--config', '{"apiToken":null}'],
+        'should be very nice and support cli prefixed env var for key as well since it is an easy mistake to make',
+        async cmd => {
+          const { code, stderr, stdout } = await invokeNpm(entryPath, cmd, {
+            SOCKET_CLI_API_KEY: 'abc'
+          })
+          expect(stdout).toMatchInlineSnapshot(
+            `
+            "apiToken: abc
+
+            Note: the config is in read-only mode, meaning at least one key was temporarily overridden from an env var or command flag."
+          `
+          )
+          expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+            "
+               _____         _       _        /---------------
+              |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+              |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+              |_____|___|___|_,_|___|_|.dev   | Command: \`socket config get\`, cwd: <redacted>"
+          `)
+
+          expect(stdout.includes('apiToken: abc')).toBe(true)
+        }
+      )
+
+      cmdit(
+        [
+          'config',
+          'get',
+          'apiToken',
+          '--config',
+          '{"apiToken":"ignoremebecausetheenvvarshouldbemoreimportant"}'
+        ],
+        'should use the env var token when the config override also has a token set',
+        async cmd => {
+          const { code, stderr, stdout } = await invokeNpm(entryPath, cmd, {
+            SOCKET_CLI_API_KEY: 'abc'
+          })
+          expect(stdout).toMatchInlineSnapshot(
+            `
+            "apiToken: abc
+
+            Note: the config is in read-only mode, meaning at least one key was temporarily overridden from an env var or command flag."
+          `
+          )
+          expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+            "
+               _____         _       _        /---------------
+              |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+              |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+              |_____|___|___|_,_|___|_|.dev   | Command: \`socket config get\`, cwd: <redacted>"
+          `)
+
+          expect(stdout.includes('apiToken: abc')).toBe(true)
+        }
+      )
+
+      cmdit(
+        [
+          'config',
+          'get',
+          'apiToken',
+          '--config',
+          '{"apiToken":"pickmepickme"}'
+        ],
+        'should use the config override when there is no env var',
+        async cmd => {
+          const { code, stderr, stdout } = await invokeNpm(entryPath, cmd, {})
+          expect(stdout).toMatchInlineSnapshot(
+            `
+            "apiToken: pickmepickme
+
+            Note: the config is in read-only mode, meaning at least one key was temporarily overridden from an env var or command flag."
+          `
+          )
+          expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+            "
+               _____         _       _        /---------------
+              |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+              |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+              |_____|___|___|_,_|___|_|.dev   | Command: \`socket config get\`, cwd: <redacted>"
+          `)
+
+          expect(stdout.includes('apiToken: pickmepickme')).toBe(true)
+        }
+      )
+
+      cmdit(
+        ['config', 'get', 'apiToken', '--config', '{}'],
+        'should yield no token when override has none',
+        async cmd => {
+          const { code, stderr, stdout } = await invokeNpm(entryPath, cmd, {})
+          expect(stdout).toMatchInlineSnapshot(
+            `
+            "apiToken: undefined
+
+            Note: the config is in read-only mode, meaning at least one key was temporarily overridden from an env var or command flag."
+          `
+          )
+          expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+            "
+               _____         _       _        /---------------
+              |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+              |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+              |_____|___|___|_,_|___|_|.dev   | Command: \`socket config get\`, cwd: <redacted>"
+          `)
+
+          expect(stdout.includes('apiToken: undefined')).toBe(true)
+        }
+      )
+    })
+  })
 })

--- a/src/commands/config/handle-config-get.ts
+++ b/src/commands/config/handle-config-get.ts
@@ -1,5 +1,5 @@
 import { outputConfigGet } from './output-config-get'
-import { getConfigValue } from '../../utils/config'
+import { getConfigValue, isReadOnlyConfig } from '../../utils/config'
 
 import type { LocalConfig } from '../../utils/config'
 
@@ -11,6 +11,7 @@ export async function handleConfigGet({
   outputKind: 'json' | 'markdown' | 'text'
 }) {
   const value = getConfigValue(key)
+  const readOnly = isReadOnlyConfig()
 
-  await outputConfigGet(key, value, outputKind)
+  await outputConfigGet(key, value, readOnly, outputKind)
 }

--- a/src/commands/config/handle-config-set.ts
+++ b/src/commands/config/handle-config-set.ts
@@ -1,5 +1,5 @@
 import { outputConfigSet } from './output-config-set'
-import { updateConfigValue } from '../../utils/config'
+import { isReadOnlyConfig, updateConfigValue } from '../../utils/config'
 
 import type { LocalConfig } from '../../utils/config'
 
@@ -13,5 +13,7 @@ export async function handleConfigSet({
   value: string
 }) {
   updateConfigValue(key, value)
-  await outputConfigSet(key, value, outputKind)
+  const readOnly = isReadOnlyConfig()
+
+  await outputConfigSet(key, value, readOnly, outputKind)
 }

--- a/src/commands/config/output-config-get.ts
+++ b/src/commands/config/output-config-get.ts
@@ -5,15 +5,30 @@ import { LocalConfig } from '../../utils/config'
 export async function outputConfigGet(
   key: keyof LocalConfig,
   value: unknown,
+  readOnly: boolean, // Is config in read-only mode? (Overrides applied)
   outputKind: 'json' | 'markdown' | 'text'
 ) {
   if (outputKind === 'json') {
-    logger.log(JSON.stringify({ success: true, result: { key, value } }))
+    logger.log(
+      JSON.stringify({ success: true, result: { key, value }, readOnly })
+    )
   } else if (outputKind === 'markdown') {
     logger.log(`# Config Value`)
     logger.log('')
     logger.log(`Config key '${key}' has value '${value}`)
+    if (readOnly) {
+      logger.log('')
+      logger.log(
+        'Note: the config is in read-only mode, meaning at least one key was temporarily\n      overridden from an env var or command flag.'
+      )
+    }
   } else {
     logger.log(`${key}: ${value}`)
+    if (readOnly) {
+      logger.log('')
+      logger.log(
+        'Note: the config is in read-only mode, meaning at least one key was temporarily overridden from an env var or command flag.'
+      )
+    }
   }
 }

--- a/src/commands/config/output-config-list.ts
+++ b/src/commands/config/output-config-list.ts
@@ -2,6 +2,7 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 
 import {
   getConfigValue,
+  isReadOnlyConfig,
   sensitiveConfigKeys,
   supportedConfigKeys
 } from '../../utils/config'
@@ -13,6 +14,7 @@ export async function outputConfigList({
   full: boolean
   outputKind: 'json' | 'markdown' | 'text'
 }) {
+  const readOnly = isReadOnlyConfig()
   if (outputKind === 'json') {
     const obj: Record<string, unknown> = {}
     for (const key of supportedConfigKeys.keys()) {
@@ -29,7 +31,8 @@ export async function outputConfigList({
         {
           success: true,
           full,
-          config: obj
+          config: obj,
+          readOnly
         },
         null,
         2
@@ -55,6 +58,12 @@ export async function outputConfigList({
           `- ${key}:${' '.repeat(Math.max(0, maxWidth - key.length + 3))} ${Array.isArray(value) ? value.join(', ') || '<none>' : (value ?? '<none>')}`
         )
       }
+    }
+    if (readOnly) {
+      logger.log('')
+      logger.log(
+        'Note: the config is in read-only mode, meaning at least one key was temporarily\n      overridden from an env var or command flag.'
+      )
     }
   }
 }

--- a/src/commands/config/output-config-set.ts
+++ b/src/commands/config/output-config-set.ts
@@ -5,20 +5,34 @@ import type { LocalConfig } from '../../utils/config'
 export async function outputConfigSet(
   key: keyof LocalConfig,
   _value: string,
+  readOnly: boolean,
   outputKind: 'json' | 'markdown' | 'text'
 ) {
   if (outputKind === 'json') {
     logger.log(
       JSON.stringify({
         success: true,
-        message: `Config key '${key}' was updated`
+        message: `Config key '${key}' was updated${readOnly ? ' (Note: since at least one value was overridden from flag/env, the config was not persisted)' : ''}`,
+        readOnly
       })
     )
   } else if (outputKind === 'markdown') {
     logger.log(`# Update config`)
     logger.log('')
     logger.log(`Config key '${key}' was updated`)
+    if (readOnly) {
+      logger.log('')
+      logger.log(
+        'Note: The change was not persisted because the config is in read-only mode,\n      meaning at least one key was temporarily overridden from an env var or\n      command flag.'
+      )
+    }
   } else {
     logger.log(`OK`)
+    if (readOnly) {
+      logger.log('')
+      logger.log(
+        'Note: The change was not persisted because the config is in read-only mode, meaning at least one key was temporarily overridden from an env var or command flag.'
+      )
+    }
   }
 }

--- a/src/commands/logout/attempt-logout.ts
+++ b/src/commands/logout/attempt-logout.ts
@@ -1,11 +1,18 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { applyLogout } from './apply-logout'
+import { isReadOnlyConfig } from '../../utils/config'
 
 export function attemptLogout() {
   try {
     applyLogout()
     logger.success('Successfully logged out')
+    if (!isReadOnlyConfig()) {
+      logger.log('')
+      logger.warn(
+        'Note: config is in read-only mode, at least one key was overridden through flag/env, so the logout was not persisted!'
+      )
+    }
   } catch {
     logger.fail('Failed to complete logout steps')
   }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -80,9 +80,12 @@ export function overrideCachedConfig(
   return { ok: true, message: undefined }
 }
 
-export function overrideConfigApiToken(apiToken: string | undefined) {
+export function overrideConfigApiToken(apiToken: unknown) {
   // Set token to the local cached config and mark it read-only so it doesn't persist
-  _cachedConfig = { ...config, apiToken } as LocalConfig
+  _cachedConfig = {
+    ...config,
+    ...(apiToken === undefined ? {} : { apiToken: String(apiToken) })
+  } as LocalConfig
   _readOnlyConfig = true
 }
 

--- a/src/utils/meow-with-subcommands.ts
+++ b/src/utils/meow-with-subcommands.ts
@@ -150,31 +150,27 @@ export async function meowWithSubcommands(
       String(cli.flags['config'] || '')
     )
   }
-  if (
+
+  if (process.env['SOCKET_CLI_NO_API_TOKEN']) {
+    // This overrides the config override and even the explicit token env var.
+    // The config will be marked as readOnly to prevent persisting it.
+    overrideConfigApiToken(undefined)
+  } else {
     // Note: these are SOCKET_SECURITY prefixed because they're not specific to
     //       the CLI. For the sake of consistency we'll also support the env
     //       keys that do have the SOCKET_CLI prefix, it's an easy mistake.
     // In case multiple are supplied, the tokens supersede the keys and the
     // security prefix supersedes the cli prefix. "Adventure mode" ;)
-    process.env['SOCKET_CLI_API_KEY'] ||
-    process.env['SOCKET_SECURITY_API_KEY'] ||
-    process.env['SOCKET_CLI_API_TOKEN'] ||
-    process.env['SOCKET_SECURITY_API_TOKEN']
-  ) {
-    // This will set the token (even if there was a config override) and
-    // set it to readOnly, making sure the temp token won't be persisted.
-    overrideConfigApiToken(
+    const tokenOverride =
       process.env['SOCKET_CLI_API_KEY'] ||
-        process.env['SOCKET_SECURITY_API_KEY'] ||
-        process.env['SOCKET_CLI_API_TOKEN'] ||
-        process.env['SOCKET_SECURITY_API_TOKEN'] ||
-        undefined
-    )
-  }
-  if (process.env['SOCKET_CLI_NO_API_TOKEN']) {
-    // This overrides the config override and even the explicit token env var.
-    // The config will be marked as readOnly to prevent persisting it.
-    overrideConfigApiToken(undefined)
+      process.env['SOCKET_SECURITY_API_KEY'] ||
+      process.env['SOCKET_CLI_API_TOKEN'] ||
+      process.env['SOCKET_SECURITY_API_TOKEN']
+    if (tokenOverride) {
+      // This will set the token (even if there was a config override) and
+      // set it to readOnly, making sure the temp token won't be persisted.
+      overrideConfigApiToken(tokenOverride)
+    }
   }
 
   if (configOverrideResult?.ok === false) {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -33,7 +33,8 @@ export function cmdit(
 
 export async function invokeNpm(
   entryPath: string,
-  args: string[]
+  args: string[],
+  env = {}
 ): Promise<{
   status: boolean
   code: number
@@ -46,7 +47,8 @@ export async function invokeNpm(
       constants.execPath,
       [entryPath, ...args],
       {
-        cwd: npmFixturesPath
+        cwd: npmFixturesPath,
+        env: { ...process.env, ...env }
       }
     )
     return {


### PR DESCRIPTION
- Fixes using the `SOCKET_SECURITY_API_TOKEN` env var. Also supports API_KEY and the prefix SOCKET_CLI for consistency. In a next major we'll probably deprecate the KEY variants.
- Make the CLI emit a proper error message when the config override cannot be parsed, rather than a generic JSON error with stack trace.
- Add some tests around this
- Add notice to `config` commands when the config is in read-only mode
- Warn when logging in/out while config is in read-only mode