### PR TITLE
Add --report to socket scan create, to immediately generate a report

### DIFF
--- a/src/commands/scan/cmd-scan-create.test.ts
+++ b/src/commands/scan/cmd-scan-create.test.ts
@@ -40,21 +40,30 @@ describe('socket scan create', async () => {
           When a FILE is given only that FILE is targeted. Otherwise any eligible
           files in the given DIR will be considered.
 
+          Note: for a first run you probably want to set --defaultBranch to indicate
+                the default branch name, like "main" or "master".
+
+          Note: --pendingHead is enabled by default and makes a scan show up in your
+                dashboard. You can use \`--no-pendingHead\` to have it not show up.
+
           Options
             --branch          Branch name
             --commitHash      Commit hash
             --commitMessage   Commit message
             --committers      Committers
             --cwd             working directory, defaults to process.cwd()
-            --defaultBranch   Make default branch
+            --defaultBranch   Set the default branch of the repository to the branch of this full-scan. Should only need to be done once, for example for the "main" or "master" branch.
             --dryRun          run input validation part of command without any concrete side effects
             --help            Print this help
-            --pendingHead     Set as pending head
+            --json            Output result as json
+            --markdown        Output result as markdown
+            --pendingHead     Designate this full-scan as the latest scan of a given branch. This must be set to have it show up in the dashboard.
             --pullRequest     Commit hash
             --readOnly        Similar to --dry-run except it can read from remote, stops before it would create an actual report
             --repo            Repository name
+            --report          Wait for the scan creation to complete, then basically run \`socket scan report\` on it
             --tmp             Set the visibility (true/false) of the scan in your dashboard
-            --view            Will wait for and return the created report. Use --no-view to disable.
+            --view            Will wait for and return the created scan details. Use --no-view to disable.
 
           Examples
             $ socket scan create --repo=test-repo --branch=main FakeOrg ./package.json"

--- a/src/commands/scan/cmd-scan-create.ts
+++ b/src/commands/scan/cmd-scan-create.ts
@@ -6,7 +6,7 @@ import { suggestRepoSlug } from './suggest-repo-slug'
 import { suggestBranchSlug } from './suggest_branch_slug'
 import { suggestTarget } from './suggest_target'
 import constants from '../../constants'
-import { commonFlags } from '../../flags'
+import { commonFlags, outputFlags } from '../../flags'
 import { getConfigValue } from '../../utils/config'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
@@ -23,6 +23,7 @@ const config: CliCommandConfig = {
   hidden: false,
   flags: {
     ...commonFlags,
+    ...outputFlags,
     repo: {
       type: 'string',
       shortFlag: 'r',
@@ -51,6 +52,18 @@ const config: CliCommandConfig = {
       type: 'string',
       description: 'working directory, defaults to process.cwd()'
     },
+    defaultBranch: {
+      type: 'boolean',
+      default: false,
+      description:
+        'Set the default branch of the repository to the branch of this full-scan. Should only need to be done once, for example for the "main" or "master" branch.'
+    },
+    pendingHead: {
+      type: 'boolean',
+      default: true,
+      description:
+        'Designate this full-scan as the latest scan of a given branch. This must be set to have it show up in the dashboard.'
+    },
     dryRun: {
       type: 'boolean',
       description:
@@ -67,23 +80,17 @@ const config: CliCommandConfig = {
       default: '',
       description: 'Committers'
     },
-    defaultBranch: {
-      type: 'boolean',
-      shortFlag: 'db',
-      default: false,
-      description: 'Make default branch'
-    },
-    pendingHead: {
-      type: 'boolean',
-      shortFlag: 'ph',
-      default: false,
-      description: 'Set as pending head'
-    },
     readOnly: {
       type: 'boolean',
       default: false,
       description:
         'Similar to --dry-run except it can read from remote, stops before it would create an actual report'
+    },
+    report: {
+      type: 'boolean',
+      default: false,
+      description:
+        'Wait for the scan creation to complete, then basically run `socket scan report` on it'
     },
     tmp: {
       type: 'boolean',
@@ -123,6 +130,12 @@ const config: CliCommandConfig = {
     When a FILE is given only that FILE is targeted. Otherwise any eligible
     files in the given DIR will be considered.
 
+    Note: for a first run you probably want to set --defaultBranch to indicate
+          the default branch name, like "main" or "master".
+
+    Note: --pendingHead is enabled by default and makes a scan show up in your
+          dashboard. You can use \`--no-pendingHead\` to have it not show up.
+
     Options
       ${getFlagListOutput(config.flags, 6)}
 
@@ -149,9 +162,26 @@ async function run(
     parentName
   })
 
-  const { cwd: cwdOverride, dryRun } = cli.flags as {
+  const {
+    cwd: cwdOverride,
+    defaultBranch,
+    dryRun,
+    json,
+    markdown,
+    pendingHead,
+    readOnly,
+    report,
+    tmp
+  } = cli.flags as {
     cwd: string
     dryRun: boolean
+    report: boolean
+    json: boolean
+    markdown: boolean
+    defaultBranch: boolean
+    pendingHead: boolean
+    readOnly: boolean
+    tmp: boolean
   }
   const defaultOrgSlug = getConfigValue('defaultOrg')
   let orgSlug = defaultOrgSlug || cli.input[0] || ''
@@ -220,7 +250,7 @@ async function run(
     )
     logger.error('```')
     logger.error(
-      `    socket scan create [other flags...] --repo ${repoName} --branch ${branchName} ${orgSlug} ${targets.join(' ')}`
+      `    socket scan create [other flags...] --repo ${repoName} --branch ${branchName} ${defaultOrgSlug ? '' : orgSlug} ${targets.join(' ')}`
     )
     logger.error('```\n')
   }
@@ -253,6 +283,13 @@ async function run(
     },
     {
       nook: true,
+      test: !json || !markdown,
+      message: 'The json and markdown flags cannot be both set, pick one',
+      pass: 'ok',
+      fail: 'omit one'
+    },
+    {
+      nook: true,
       test: apiToken,
       message: 'This command requires an API token for access`)',
       pass: 'ok',
@@ -273,12 +310,14 @@ async function run(
     branchName: branchName as string,
     commitMessage: (cli.flags['commitMessage'] as string | undefined) ?? '',
     cwd,
-    defaultBranch: Boolean(cli.flags['defaultBranch']),
+    defaultBranch: Boolean(defaultBranch),
     orgSlug,
-    pendingHead: Boolean(cli.flags['pendingHead']),
-    readOnly: Boolean(cli.flags['readOnly']),
+    outputKind: json ? 'json' : markdown ? 'markdown' : 'text',
+    pendingHead: Boolean(pendingHead),
+    readOnly: Boolean(readOnly),
     repoName: repoName,
+    report,
     targets,
-    tmp: Boolean(cli.flags['tmp'])
+    tmp: Boolean(tmp)
   })
 }

--- a/src/commands/scan/output-create-new-scan.ts
+++ b/src/commands/scan/output-create-new-scan.ts
@@ -7,8 +7,42 @@ import { confirm } from '@socketsecurity/registry/lib/prompts'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function outputCreateNewScan(
-  data: SocketSdkReturnType<'CreateOrgFullScan'>['data']
+  data: SocketSdkReturnType<'CreateOrgFullScan'>['data'],
+  outputKind: 'json' | 'markdown' | 'text'
 ) {
+  if (!data.id) {
+    logger.fail('Did not receive a scan ID from the API...')
+    process.exitCode = 1
+  }
+
+  if (outputKind === 'json') {
+    const json = data.id
+      ? { success: true, data }
+      : { success: false, message: 'No scan ID received' }
+
+    logger.log(JSON.stringify(json, null, 2))
+    logger.log('')
+
+    return
+  }
+
+  if (outputKind === 'markdown') {
+    logger.log('# Create New Scan')
+    logger.log('')
+    if (data.id) {
+      logger.log(
+        `A [new Scan](${data.html_report_url}) was created with ID: ${data.id}`
+      )
+      logger.log('')
+    } else {
+      logger.log(
+        `The server did not return a Scan ID while trying to create a new Scan. This could be an indication something went wrong.`
+      )
+    }
+    logger.log('')
+    return
+  }
+
   const link = colors.underline(colors.cyan(`${data.html_report_url}`))
   logger.log(`Available at: ${link}`)
 


### PR DESCRIPTION
The old report workflow, attached to `socket ci`, is to do create a report and then ask for the results in a report view. While you could do the same in the scan creation flow, it would require some slightly awkward shell script to handle the json result and fire a report request etc. Anyways, `--report` takes care of that.

The only concern is a timeout from the server while waiting for the scan to complete...

Also clarified flags desc for pendingHead and defaultBranch a bit.

Fixed a bug with `defaultOrg` (nobody uses this yet) with the suggestion flow.

Added support for `--json` and `--markdown` in the `socket scan create` flow. A bit superficial but it does what it should do.

