### PR TITLE
Support `./` for scan create too

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from 'node:url'
 import { messageWithCauses, stackWithCauses } from 'pony-cause'
 import updateNotifier from 'tiny-updater'
 
+import { debugLog } from '@socketsecurity/registry/lib/debug'
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { cmdAnalytics } from './commands/analytics/cmd-analytics'
@@ -107,9 +108,10 @@ void (async () => {
     } else {
       errorTitle = 'Unexpected error with no details'
     }
+    logger.error('\n') // Any-spinner-newline
     logger.fail(failMsgWithBadge(errorTitle, errorMessage))
     if (errorBody) {
-      logger.error(`\n${errorBody}`)
+      debugLog(`${errorBody}`)
     }
     await captureException(e)
   }

--- a/src/commands/scan/cmd-scan-create.ts
+++ b/src/commands/scan/cmd-scan-create.ts
@@ -161,6 +161,7 @@ async function run(
   })
 
   const {
+    branch: branchName = '',
     cwd: cwdOverride,
     defaultBranch,
     dryRun,
@@ -168,17 +169,20 @@ async function run(
     markdown,
     pendingHead,
     readOnly,
+    repo: repoName = '',
     report,
     tmp
   } = cli.flags as {
+    branch: string
     cwd: string
+    defaultBranch: boolean
     dryRun: boolean
-    report: boolean
     json: boolean
     markdown: boolean
-    defaultBranch: boolean
     pendingHead: boolean
     readOnly: boolean
+    repo: string
+    report: boolean
     tmp: boolean
   }
   const defaultOrgSlug = getConfigValue('defaultOrg')
@@ -189,10 +193,6 @@ async function run(
     cwdOverride && cwdOverride !== 'process.cwd()'
       ? String(cwdOverride)
       : process.cwd()
-  const { branch: branchName = '', repo: repoName = '' } = cli.flags as {
-    branch: string
-    repo: string
-  }
 
   // We're going to need an api token to suggest data because those suggestions
   // must come from data we already know. Don't error on missing api token yet.

--- a/src/utils/path-resolve.ts
+++ b/src/utils/path-resolve.ts
@@ -172,7 +172,7 @@ function ignorePatternToMinimatch(pattern: string): string {
 
 function pathsToPatterns(paths: string[] | readonly string[]): string[] {
   // TODO: Does not support `~/` paths.
-  return paths.map(p => (p === '.' ? '**/*' : p))
+  return paths.map(p => (p === '.' || p === './' ? '**/*' : p))
 }
 
 export function findBinPathDetailsSync(binName: string): {
@@ -262,9 +262,11 @@ export async function getPackageFilesForScan(
   // Lazily access constants.spinner.
   const { spinner } = constants
 
+  const pats = pathsToPatterns(inputPaths)
+
   spinner.start('Searching for local files to include in scan...')
 
-  const entries = await globWithGitIgnore(pathsToPatterns(inputPaths), {
+  const entries = await globWithGitIgnore(pats, {
     cwd,
     socketConfig: config
   })


### PR DESCRIPTION
When doing `scan report create .` we special case the dot to `*/**`.

But when somebody uses `./` instead the result fails.

This PR will also map `./` to the `*/**` glob.

This PR will also cleanup a few stack traces and error artifacts and tuck them under a debug log instead.
