### PR TITLE
When scan create has no files, do not proceed to upload

### DIFF
--- a/src/commands/scan/handle-create-new-scan.ts
+++ b/src/commands/scan/handle-create-new-scan.ts
@@ -45,13 +45,18 @@ export async function handleCreateNewScan({
     supportedFileNames
   )
 
-  handleBadInput({
-    nook: true,
-    test: packagePaths.length > 0,
-    pass: 'ok',
-    fail: 'found none',
-    message: 'TARGET must contain matching / supported file types for a scan'
-  })
+  if (
+    handleBadInput({
+      nook: true,
+      test: packagePaths.length > 0,
+      pass: 'ok',
+      fail: 'found no eligible files to scan',
+      message:
+        'TARGET (file/dir) must contain matching / supported file types for a scan'
+    })
+  ) {
+    return
+  }
 
   if (readOnly) {
     logger.log('[ReadOnly] Bailing now')


### PR DESCRIPTION
Fixes a confusing 400 response from the server when trying to create a scan without any files.