### PR TITLE
Unhide package commands with beta tag

### DIFF
--- a/src/commands/info/cmd-info.test.ts
+++ b/src/commands/info/cmd-info.test.ts
@@ -23,7 +23,7 @@ describe('socket info', async () => {
           Usage
             $ socket info <name>
 
-          Note: this command will be deprecated in favor of \`socket package score\` soon.
+          Note: this command will be deprecated in favor of \`socket package score\` soon
 
           Options
             --all             Include all issues

--- a/src/commands/info/cmd-info.test.ts
+++ b/src/commands/info/cmd-info.test.ts
@@ -23,6 +23,8 @@ describe('socket info', async () => {
           Usage
             $ socket info <name>
 
+          Note: this command will be deprecated in favor of \`socket package score\` soon.
+
           Options
             --all             Include all issues
             --dryRun          Do input validation for a command and exit 0 when input is ok

--- a/src/commands/info/cmd-info.ts
+++ b/src/commands/info/cmd-info.ts
@@ -24,7 +24,7 @@ const config: CliCommandConfig = {
     Usage
       $ ${command} <name>
 
-    Note: this command will be deprecated in favor of \`socket package score\` soon.
+    Note: this command will be deprecated in favor of \`socket package score\` soon
 
     Options
       ${getFlagListOutput(config.flags, 6)}

--- a/src/commands/info/cmd-info.ts
+++ b/src/commands/info/cmd-info.ts
@@ -24,6 +24,8 @@ const config: CliCommandConfig = {
     Usage
       $ ${command} <name>
 
+    Note: this command will be deprecated in favor of \`socket package score\` soon.
+
     Options
       ${getFlagListOutput(config.flags, 6)}
 

--- a/src/commands/package/cmd-package-score.test.ts
+++ b/src/commands/package/cmd-package-score.test.ts
@@ -18,7 +18,7 @@ describe('socket package score', async () => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-        "Look up score for one package which reflects all of its transitive dependencies as well
+        "[beta] Look up score for one package which reflects all of its transitive dependencies as well
 
           Usage
             $ socket package score <<ecosystem> <name> | <purl>>

--- a/src/commands/package/cmd-package-score.ts
+++ b/src/commands/package/cmd-package-score.ts
@@ -16,8 +16,8 @@ const { DRY_RUN_BAIL_TEXT } = constants
 const config: CliCommandConfig = {
   commandName: 'score',
   description:
-    'Look up score for one package which reflects all of its transitive dependencies as well',
-  hidden: true,
+    '[beta] Look up score for one package which reflects all of its transitive dependencies as well',
+  hidden: false,
   flags: {
     ...commonFlags,
     ...outputFlags

--- a/src/commands/package/cmd-package-shallow.test.ts
+++ b/src/commands/package/cmd-package-shallow.test.ts
@@ -18,7 +18,7 @@ describe('socket package shallow', async () => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-        "Look up info regarding one or more packages but not their transitives
+        "[beta] Look up info regarding one or more packages but not their transitives
 
           Usage
             $ socket package shallow <<ecosystem> <name> [<name> ...] | <purl> [<purl> ...]>

--- a/src/commands/package/cmd-package-shallow.ts
+++ b/src/commands/package/cmd-package-shallow.ts
@@ -15,8 +15,8 @@ const { DRY_RUN_BAIL_TEXT } = constants
 const config: CliCommandConfig = {
   commandName: 'shallow',
   description:
-    'Look up info regarding one or more packages but not their transitives',
-  hidden: true,
+    '[beta] Look up info regarding one or more packages but not their transitives',
+  hidden: false,
   flags: {
     ...commonFlags,
     ...outputFlags

--- a/src/commands/package/cmd-package.test.ts
+++ b/src/commands/package/cmd-package.test.ts
@@ -24,7 +24,8 @@ describe('socket package', async () => {
             $ socket package <command>
 
           Commands
-            (none)
+            score             [beta] Look up score for one package which reflects all of its transitive dependencies as well
+            shallow           [beta] Look up info regarding one or more packages but not their transitives
 
           Options
             --dryRun          Do input validation for a command and exit 0 when input is ok

--- a/src/commands/package/cmd-package.ts
+++ b/src/commands/package/cmd-package.ts
@@ -8,7 +8,7 @@ const description = 'Commands relating to looking up published packages'
 
 export const cmdPackage: CliSubcommand = {
   description,
-  hidden: true, // [beta]
+  hidden: false,
   async run(argv, importMeta, { parentName }) {
     await meowWithSubcommands(
       {


### PR DESCRIPTION
The new package commands were hidden while we were testing the API. Time is right to open them up.