### PR TITLE
Set exit code for report commands

### DIFF
--- a/src/commands/report/cmd-report-create.test.ts
+++ b/src/commands/report/cmd-report-create.test.ts
@@ -55,7 +55,7 @@ describe('socket report create', async () => {
         \\x1b[31m\\xd7\\x1b[39m This command has been sunset. Instead, please look at \`socket scan create\` to create scans and \`socket scan report\` to view a report of your scans."
       `)
 
-      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+      expect(code).toBe(1)
     }
   )
 })

--- a/src/commands/report/cmd-report-create.ts
+++ b/src/commands/report/cmd-report-create.ts
@@ -52,4 +52,6 @@ async function run(
   logger.fail(
     'This command has been sunset. Instead, please look at `socket scan create` to create scans and `socket scan report` to view a report of your scans.'
   )
+
+  process.exitCode = 1
 }

--- a/src/commands/report/cmd-report-view.test.ts
+++ b/src/commands/report/cmd-report-view.test.ts
@@ -55,7 +55,7 @@ describe('socket report create', async () => {
         \\x1b[31m\\xd7\\x1b[39m This command has been sunset. Instead, please look at \`socket scan create\` to create scans and \`socket scan report\` to view a report of your scans."
       `)
 
-      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+      expect(code).toBe(1)
     }
   )
 })

--- a/src/commands/report/cmd-report-view.ts
+++ b/src/commands/report/cmd-report-view.ts
@@ -41,4 +41,6 @@ async function run(
   logger.fail(
     'This command has been sunset. Instead, please look at `socket scan create` to create scans and `socket scan report` to view a report of your scans.'
   )
+
+  process.exitCode = 1
 }


### PR DESCRIPTION
The commands were deprecated but they still return zero. They should at least return non-zero.