### PR TITLE
Give better signal that orgslug is missing

### DIFF
--- a/src/commands/scan/cmd-scan-create.ts
+++ b/src/commands/scan/cmd-scan-create.ts
@@ -241,7 +241,7 @@ async function run(
       pass: 'ok',
       fail:
         orgSlug === '.'
-          ? 'dot is an invalid org, most likely you forget the org name here?'
+          ? 'dot is an invalid org, most likely you forgot the org name here?'
           : 'missing'
     },
     {

--- a/src/commands/scan/cmd-scan-create.ts
+++ b/src/commands/scan/cmd-scan-create.ts
@@ -235,11 +235,14 @@ async function run(
 
   const wasBadInput = handleBadInput(
     {
-      nook: true,
-      test: orgSlug,
+      nook: !!defaultOrgSlug,
+      test: orgSlug && orgSlug !== '.',
       message: 'Org name as the first argument',
       pass: 'ok',
-      fail: 'missing'
+      fail:
+        orgSlug === '.'
+          ? 'dot is an invalid org, most likely you forget the org name here?'
+          : 'missing'
     },
     {
       test: targets.length,

--- a/src/commands/scan/cmd-scan-del.ts
+++ b/src/commands/scan/cmd-scan-del.ts
@@ -62,11 +62,14 @@ async function run(
 
   const wasBadInput = handleBadInput(
     {
-      nook: true,
-      test: orgSlug,
+      nook: !!defaultOrgSlug,
+      test: orgSlug && orgSlug !== '.',
       message: 'Org name as the first argument',
       pass: 'ok',
-      fail: 'missing'
+      fail:
+        orgSlug === '.'
+          ? 'dot is an invalid org, most likely you forget the org name here?'
+          : 'missing'
     },
     {
       test: scanId,

--- a/src/commands/scan/cmd-scan-del.ts
+++ b/src/commands/scan/cmd-scan-del.ts
@@ -68,7 +68,7 @@ async function run(
       pass: 'ok',
       fail:
         orgSlug === '.'
-          ? 'dot is an invalid org, most likely you forget the org name here?'
+          ? 'dot is an invalid org, most likely you forgot the org name here?'
           : 'missing'
     },
     {

--- a/src/commands/scan/cmd-scan-list.ts
+++ b/src/commands/scan/cmd-scan-list.ts
@@ -102,11 +102,14 @@ async function run(
 
   const wasBadInput = handleBadInput(
     {
-      nook: true,
-      test: orgSlug,
+      nook: !!defaultOrgSlug,
+      test: orgSlug && orgSlug !== '.',
       message: 'Org name as the first argument',
       pass: 'ok',
-      fail: 'missing'
+      fail:
+        orgSlug === '.'
+          ? 'dot is an invalid org, most likely you forget the org name here?'
+          : 'missing'
     },
     {
       nook: true,

--- a/src/commands/scan/cmd-scan-list.ts
+++ b/src/commands/scan/cmd-scan-list.ts
@@ -108,7 +108,7 @@ async function run(
       pass: 'ok',
       fail:
         orgSlug === '.'
-          ? 'dot is an invalid org, most likely you forget the org name here?'
+          ? 'dot is an invalid org, most likely you forgot the org name here?'
           : 'missing'
     },
     {

--- a/src/commands/scan/cmd-scan-metadata.ts
+++ b/src/commands/scan/cmd-scan-metadata.ts
@@ -72,7 +72,7 @@ async function run(
       pass: 'ok',
       fail:
         orgSlug === '.'
-          ? 'dot is an invalid org, most likely you forget the org name here?'
+          ? 'dot is an invalid org, most likely you forgot the org name here?'
           : 'missing'
     },
     {

--- a/src/commands/scan/cmd-scan-metadata.ts
+++ b/src/commands/scan/cmd-scan-metadata.ts
@@ -66,11 +66,14 @@ async function run(
 
   const wasBadInput = handleBadInput(
     {
-      nook: true,
-      test: orgSlug,
+      nook: !!defaultOrgSlug,
+      test: orgSlug && orgSlug !== '.',
       message: 'Org name as the first argument',
       pass: 'ok',
-      fail: 'missing'
+      fail:
+        orgSlug === '.'
+          ? 'dot is an invalid org, most likely you forget the org name here?'
+          : 'missing'
     },
     {
       test: scanId,

--- a/src/commands/scan/cmd-scan-report.ts
+++ b/src/commands/scan/cmd-scan-report.ts
@@ -105,11 +105,14 @@ async function run(
 
   const wasBadInput = handleBadInput(
     {
-      nook: true,
-      test: orgSlug,
+      nook: !!defaultOrgSlug,
+      test: orgSlug && orgSlug !== '.',
       message: 'Org name as the first argument',
       pass: 'ok',
-      fail: 'missing'
+      fail:
+        orgSlug === '.'
+          ? 'dot is an invalid org, most likely you forget the org name here?'
+          : 'missing'
     },
     {
       test: scanId,

--- a/src/commands/scan/cmd-scan-report.ts
+++ b/src/commands/scan/cmd-scan-report.ts
@@ -111,7 +111,7 @@ async function run(
       pass: 'ok',
       fail:
         orgSlug === '.'
-          ? 'dot is an invalid org, most likely you forget the org name here?'
+          ? 'dot is an invalid org, most likely you forgot the org name here?'
           : 'missing'
     },
     {

--- a/src/commands/scan/cmd-scan-view.ts
+++ b/src/commands/scan/cmd-scan-view.ts
@@ -70,11 +70,14 @@ async function run(
 
   const wasBadInput = handleBadInput(
     {
-      nook: true,
-      test: orgSlug,
+      nook: !!defaultOrgSlug,
+      test: orgSlug && orgSlug !== '.',
       message: 'Org name as the first argument',
       pass: 'ok',
-      fail: 'missing'
+      fail:
+        orgSlug === '.'
+          ? 'dot is an invalid org, most likely you forget the org name here?'
+          : 'missing'
     },
     {
       test: scanId,

--- a/src/commands/scan/cmd-scan-view.ts
+++ b/src/commands/scan/cmd-scan-view.ts
@@ -76,7 +76,7 @@ async function run(
       pass: 'ok',
       fail:
         orgSlug === '.'
-          ? 'dot is an invalid org, most likely you forget the org name here?'
+          ? 'dot is an invalid org, most likely you forgot the org name here?'
           : 'missing'
     },
     {


### PR DESCRIPTION
It's easy to overlook and not super intuitive that you need to enter the orgslug in the first place.

But that's how it was and we'll fix it in a major. For now, try to guide the user to resolve the issues faster by a clearer message.