### PR TITLE
Fix flags of scan create

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,8 +80,8 @@ void (async () => {
       {
         aliases: {
           ci: {
-            description: 'Alias for "report create --view --strict"',
-            argv: ['report', 'create', '--view', '--strict']
+            description: 'Alias for "scan create --report"',
+            argv: ['scan', 'create', '--report']
           }
         },
         argv: process.argv.slice(2),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,8 +80,8 @@ void (async () => {
       {
         aliases: {
           ci: {
-            description: 'Alias for "scan create --report"',
-            argv: ['scan', 'create', '--report']
+            description: 'Alias for "report create --view --strict"',
+            argv: ['report', 'create', '--view', '--strict']
           }
         },
         argv: process.argv.slice(2),

--- a/src/commands/scan/cmd-scan-create.test.ts
+++ b/src/commands/scan/cmd-scan-create.test.ts
@@ -63,7 +63,6 @@ describe('socket scan create', async () => {
             --repo            Repository name
             --report          Wait for the scan creation to complete, then basically run \`socket scan report\` on it
             --tmp             Set the visibility (true/false) of the scan in your dashboard
-            --view            Will wait for and return the created scan details. Use --no-view to disable.
 
           Examples
             $ socket scan create --repo=test-repo --branch=main FakeOrg ./package.json"

--- a/src/commands/scan/cmd-scan-create.ts
+++ b/src/commands/scan/cmd-scan-create.ts
@@ -59,7 +59,7 @@ const config: CliCommandConfig = {
     dryRun: {
       type: 'boolean',
       description:
-        'run input validation part of command without any concrete side effects'
+        'Run input validation part of command without any concrete side effects'
     },
     pendingHead: {
       type: 'boolean',

--- a/src/commands/scan/cmd-scan-create.ts
+++ b/src/commands/scan/cmd-scan-create.ts
@@ -22,12 +22,6 @@ const config: CliCommandConfig = {
   flags: {
     ...commonFlags,
     ...outputFlags,
-    repo: {
-      type: 'string',
-      shortFlag: 'r',
-      default: 'socket-default-repository',
-      description: 'Repository name'
-    },
     branch: {
       type: 'string',
       shortFlag: 'b',
@@ -46,6 +40,12 @@ const config: CliCommandConfig = {
       default: '',
       description: 'Commit hash'
     },
+    committers: {
+      type: 'string',
+      shortFlag: 'c',
+      default: '',
+      description: 'Committers'
+    },
     cwd: {
       type: 'string',
       description: 'working directory, defaults to process.cwd()'
@@ -56,33 +56,33 @@ const config: CliCommandConfig = {
       description:
         'Set the default branch of the repository to the branch of this full-scan. Should only need to be done once, for example for the "main" or "master" branch.'
     },
+    dryRun: {
+      type: 'boolean',
+      description:
+        'run input validation part of command without any concrete side effects'
+    },
     pendingHead: {
       type: 'boolean',
       default: true,
       description:
         'Designate this full-scan as the latest scan of a given branch. This must be set to have it show up in the dashboard.'
     },
-    dryRun: {
-      type: 'boolean',
-      description:
-        'run input validation part of command without any concrete side effects'
-    },
     pullRequest: {
       type: 'number',
       shortFlag: 'pr',
       description: 'Commit hash'
-    },
-    committers: {
-      type: 'string',
-      shortFlag: 'c',
-      default: '',
-      description: 'Committers'
     },
     readOnly: {
       type: 'boolean',
       default: false,
       description:
         'Similar to --dry-run except it can read from remote, stops before it would create an actual report'
+    },
+    repo: {
+      type: 'string',
+      shortFlag: 'r',
+      default: 'socket-default-repository',
+      description: 'Repository name'
     },
     report: {
       type: 'boolean',
@@ -96,13 +96,6 @@ const config: CliCommandConfig = {
       default: false,
       description:
         'Set the visibility (true/false) of the scan in your dashboard'
-    },
-    view: {
-      type: 'boolean',
-      shortFlag: 'v',
-      default: true,
-      description:
-        'Will wait for and return the created scan details. Use --no-view to disable.'
     }
   },
   // TODO: your project's "socket.yml" file's "projectIgnorePaths"
@@ -162,12 +155,16 @@ async function run(
 
   const {
     branch: branchName = '',
+    commitHash,
+    commitMessage,
+    committers,
     cwd: cwdOverride,
     defaultBranch,
     dryRun,
     json,
     markdown,
     pendingHead,
+    pullRequest,
     readOnly,
     repo: repoName = '',
     report,
@@ -175,11 +172,15 @@ async function run(
   } = cli.flags as {
     branch: string
     cwd: string
+    commitHash: string
+    commitMessage: string
+    committers: string
     defaultBranch: boolean
     dryRun: boolean
     json: boolean
     markdown: boolean
     pendingHead: boolean
+    pullRequest: number
     readOnly: boolean
     repo: string
     report: boolean
@@ -274,12 +275,15 @@ async function run(
 
   await handleCreateNewScan({
     branchName: branchName as string,
-    commitMessage: (cli.flags['commitMessage'] as string | undefined) ?? '',
+    commitHash: (commitHash && String(commitHash)) || '',
+    commitMessage: (commitMessage && String(commitMessage)) || '',
+    committers: (committers && String(committers)) || '',
     cwd,
     defaultBranch: Boolean(defaultBranch),
     orgSlug,
     outputKind: json ? 'json' : markdown ? 'markdown' : 'text',
     pendingHead: Boolean(pendingHead),
+    pullRequest: Number(pullRequest),
     readOnly: Boolean(readOnly),
     repoName: repoName,
     report,

--- a/src/commands/scan/fetch-create-org-full-scan.ts
+++ b/src/commands/scan/fetch-create-org-full-scan.ts
@@ -7,13 +7,25 @@ import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 export async function fetchCreateOrgFullScan(
   packagePaths: string[],
   orgSlug: string,
-  repoName: string,
-  branchName: string,
-  commitMessage: string,
   defaultBranch: boolean,
   pendingHead: boolean,
   tmp: boolean,
-  cwd: string
+  cwd: string,
+  {
+    branchName,
+    commitHash,
+    commitMessage,
+    committers,
+    pullRequest,
+    repoName
+  }: {
+    branchName: string
+    commitHash: string
+    commitMessage: string
+    committers: string
+    pullRequest: number
+    repoName: string
+  }
 ): Promise<SocketSdkReturnType<'CreateOrgFullScan'>['data'] | undefined> {
   const sockSdk = await setupSdk()
 
@@ -28,10 +40,13 @@ export async function fetchCreateOrgFullScan(
     sockSdk.createOrgFullScan(
       orgSlug,
       {
-        repo: repoName,
-        branch: branchName,
-        commit_message: commitMessage,
+        ...(branchName ? { branch: branchName } : {}),
+        ...(commitHash ? { commit_hash: commitHash } : {}),
+        ...(commitMessage ? { commit_message: commitMessage } : {}),
+        ...(committers ? { committers } : {}),
         make_default_branch: String(defaultBranch),
+        ...(pullRequest ? { pull_request: String(pullRequest) } : {}),
+        repo: repoName || 'socket-default-repository', // mandatory, this is server default for repo
         set_as_pending_head: String(pendingHead),
         tmp: String(tmp)
       },

--- a/src/commands/scan/handle-create-new-scan.ts
+++ b/src/commands/scan/handle-create-new-scan.ts
@@ -9,12 +9,15 @@ import { getPackageFilesForScan } from '../../utils/path-resolve'
 
 export async function handleCreateNewScan({
   branchName,
+  commitHash,
   commitMessage,
+  committers,
   cwd,
   defaultBranch,
   orgSlug,
   outputKind,
   pendingHead,
+  pullRequest,
   readOnly,
   repoName,
   report,
@@ -22,11 +25,14 @@ export async function handleCreateNewScan({
   tmp
 }: {
   branchName: string
+  commitHash: string
   commitMessage: string
+  committers: string
   cwd: string
   defaultBranch: boolean
   orgSlug: string
   pendingHead: boolean
+  pullRequest: number
   outputKind: 'json' | 'markdown' | 'text'
   readOnly: boolean
   repoName: string
@@ -66,13 +72,18 @@ export async function handleCreateNewScan({
   const data = await fetchCreateOrgFullScan(
     packagePaths,
     orgSlug,
-    repoName,
-    branchName,
-    commitMessage,
     defaultBranch,
     pendingHead,
     tmp,
-    cwd
+    cwd,
+    {
+      commitHash,
+      commitMessage,
+      committers,
+      pullRequest,
+      repoName,
+      branchName
+    }
   )
   if (!data) {
     return


### PR DESCRIPTION
Remove the --view flag, which wasn't doing anything
Connect the various commit meta data flags, which were not forwarding the data to the API call
