### PR TITLE
Fix namedspaced purl parsing for package commands

### DIFF
--- a/src/commands/package/fetch-purl-deep-score.ts
+++ b/src/commands/package/fetch-purl-deep-score.ts
@@ -9,6 +9,8 @@ import { getDefaultToken } from '../../utils/sdk'
 const { SOCKET_CLI_ISSUES_URL } = constants
 
 export async function fetchPurlDeepScore(purl: string) {
+  logger.info(`Requesting deep score data for this purl: ${purl}`)
+
   const apiToken = getDefaultToken()
   if (!apiToken) {
     throw new AuthError(

--- a/src/commands/package/fetch-purls-shallow-score.ts
+++ b/src/commands/package/fetch-purls-shallow-score.ts
@@ -12,7 +12,7 @@ import type {
 export async function fetchPurlsShallowScore(
   purls: string[]
 ): Promise<SocketSdkReturnType<'batchPackageFetch'> | undefined> {
-  logger.error(
+  logger.info(
     `Requesting shallow score data for ${purls.length} package urls (purl): ${purls.join(', ')}`
   )
 

--- a/src/commands/package/parse-package-specifiers.test.ts
+++ b/src/commands/package/parse-package-specifiers.test.ts
@@ -21,6 +21,19 @@ describe('parse-package-specifiers', async () => {
     `)
   })
 
+  it('should support npm scoped packages', () => {
+    expect(
+      parsePackageSpecifiers('npm', ['@babel/core'])
+    ).toMatchInlineSnapshot(`
+      {
+        "purls": [
+          "pkg:npm/@babel/core",
+        ],
+        "valid": true,
+      }
+    `)
+  })
+
   it('should parse a simple purl without prefix', () => {
     expect(parsePackageSpecifiers('npm/babel', [])).toMatchInlineSnapshot(`
       {
@@ -52,7 +65,7 @@ describe('parse-package-specifiers', async () => {
     ).toMatchInlineSnapshot(`
       {
         "purls": [
-          "pkg:golang/foo",
+          "pkg:npm/golang/foo",
           "pkg:npm/babel",
           "pkg:npm/tenko",
         ],

--- a/src/commands/package/parse-package-specifiers.ts
+++ b/src/commands/package/parse-package-specifiers.ts
@@ -19,9 +19,6 @@ export function parsePackageSpecifiers(
       } else if (pkg.startsWith('pkg:')) {
         // keep
         purls.push(pkg)
-      } else if (pkg.includes('/')) {
-        // Looks like this arg was already namespaced
-        purls.push('pkg:' + pkg)
       } else {
         purls.push('pkg:' + ecosystem + '/' + pkg)
       }


### PR DESCRIPTION
Apparently we couldn't do something like `socket score npm @babel/core`. This fixes it.