### PR TITLE
Fix wrong flag suggestion in manifest help

### DIFF
--- a/src/commands/manifest/cmd-manifest-gradle.test.ts
+++ b/src/commands/manifest/cmd-manifest-gradle.test.ts
@@ -21,7 +21,7 @@ describe('socket manifest gradle', async () => {
         "[beta] Use Gradle to generate a manifest file (\`pom.xml\`) for a Gradle/Java/Kotlin/etc project
 
           Usage
-            $ socket manifest gradle [--gradle=path/to/gradle/binary] [--out=path/to/result] DIR
+            $ socket manifest gradle [--bin=path/to/gradle/binary] [--out=path/to/result] DIR
 
           Options
             --bin             Location of gradlew binary to use, default: CWD/gradlew
@@ -57,7 +57,7 @@ describe('socket manifest gradle', async () => {
           Examples
 
             $ socket manifest gradle .
-            $ socket manifest gradle --gradlew=../gradlew ."
+            $ socket manifest gradle --bin=../gradlew ."
       `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`

--- a/src/commands/manifest/cmd-manifest-gradle.ts
+++ b/src/commands/manifest/cmd-manifest-gradle.ts
@@ -56,7 +56,7 @@ const config: CliCommandConfig = {
   },
   help: (command, config) => `
     Usage
-      $ ${command} [--gradle=path/to/gradle/binary] [--out=path/to/result] DIR
+      $ ${command} [--bin=path/to/gradle/binary] [--out=path/to/result] DIR
 
     Options
       ${getFlagListOutput(config.flags, 6)}
@@ -84,7 +84,7 @@ const config: CliCommandConfig = {
     Examples
 
       $ ${command} .
-      $ ${command} --gradlew=../gradlew .
+      $ ${command} --bin=../gradlew .
   `
 }
 

--- a/src/commands/manifest/cmd-manifest-kotlin.test.ts
+++ b/src/commands/manifest/cmd-manifest-kotlin.test.ts
@@ -21,7 +21,7 @@ describe('socket manifest kotlin', async () => {
         "[beta] Use Gradle to generate a manifest file (\`pom.xml\`) for a Kotlin project
 
           Usage
-            $ socket manifest kotlin [--gradle=path/to/gradle/binary] [--out=path/to/result] DIR
+            $ socket manifest kotlin [--bin=path/to/gradle/binary] [--out=path/to/result] DIR
 
           Options
             --bin             Location of gradlew binary to use, default: CWD/gradlew
@@ -57,7 +57,7 @@ describe('socket manifest kotlin', async () => {
           Examples
 
             $ socket manifest kotlin .
-            $ socket manifest kotlin --gradlew=../gradlew ."
+            $ socket manifest kotlin --bin=../gradlew ."
       `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`

--- a/src/commands/manifest/cmd-manifest-kotlin.ts
+++ b/src/commands/manifest/cmd-manifest-kotlin.ts
@@ -61,7 +61,7 @@ const config: CliCommandConfig = {
   },
   help: (command, config) => `
     Usage
-      $ ${command} [--gradle=path/to/gradle/binary] [--out=path/to/result] DIR
+      $ ${command} [--bin=path/to/gradle/binary] [--out=path/to/result] DIR
 
     Options
       ${getFlagListOutput(config.flags, 6)}
@@ -89,7 +89,7 @@ const config: CliCommandConfig = {
     Examples
 
       $ ${command} .
-      $ ${command} --gradlew=../gradlew .
+      $ ${command} --bin=../gradlew .
   `
 }
 

--- a/src/commands/manifest/cmd-manifest-scala.test.ts
+++ b/src/commands/manifest/cmd-manifest-scala.test.ts
@@ -21,7 +21,7 @@ describe('socket manifest scala', async () => {
         "[beta] Generate a manifest file (\`pom.xml\`) from Scala's \`build.sbt\` file
 
           Usage
-            $ socket manifest scala [--sbt=path/to/sbt/binary] [--out=path/to/result] FILE|DIR
+            $ socket manifest scala [--bin=path/to/sbt/binary] [--out=path/to/result] FILE|DIR
 
           Options
             --bin             Location of sbt binary to use

--- a/src/commands/manifest/cmd-manifest-scala.ts
+++ b/src/commands/manifest/cmd-manifest-scala.ts
@@ -49,7 +49,7 @@ const config: CliCommandConfig = {
   },
   help: (command, config) => `
     Usage
-      $ ${command} [--sbt=path/to/sbt/binary] [--out=path/to/result] FILE|DIR
+      $ ${command} [--bin=path/to/sbt/binary] [--out=path/to/result] FILE|DIR
 
     Options
       ${getFlagListOutput(config.flags, 6)}


### PR DESCRIPTION
These flags should be `--bin` but the examples were showing something else :(