### PR TITLE
Fix `socket manifest gradle/kotlin` pathing

### DIFF
--- a/src/commands/manifest/cmd-manifest-gradle.test.ts
+++ b/src/commands/manifest/cmd-manifest-gradle.test.ts
@@ -29,8 +29,6 @@ describe('socket manifest gradle', async () => {
             --dryRun          Do input validation for a command and exit 0 when input is ok
             --gradleOpts      Additional options to pass on to ./gradlew, see \`./gradlew --help\`
             --help            Print this help
-            --out             Path of output file; where to store the resulting manifest, see also --stdout
-            --stdout          Print resulting pom.xml to stdout (supersedes --out)
             --task            Task to target. By default targets all
             --verbose         Print debug messages
 

--- a/src/commands/manifest/cmd-manifest-gradle.ts
+++ b/src/commands/manifest/cmd-manifest-gradle.ts
@@ -106,7 +106,6 @@ async function run(
     logger.groupEnd()
   }
 
-  const { cwd = process.cwd() } = cli.flags
   const [target = ''] = cli.input
 
   // TODO: I'm not sure it's feasible to parse source file from stdin. We could
@@ -132,12 +131,7 @@ async function run(
     return
   }
 
-  let bin: string
-  if (cli.flags['bin']) {
-    bin = cli.flags['bin'] as string
-  } else {
-    bin = path.join(target, 'gradlew')
-  }
+  const { bin = path.join(target, 'gradlew'), cwd = process.cwd() } = cli.flags
 
   if (verbose) {
     logger.group()
@@ -159,5 +153,11 @@ async function run(
     return
   }
 
-  await convertGradleToMaven(target, bin, cwd, verbose, gradleOpts)
+  await convertGradleToMaven(
+    target,
+    String(bin),
+    String(cwd),
+    verbose,
+    gradleOpts
+  )
 }

--- a/src/commands/manifest/cmd-manifest-gradle.ts
+++ b/src/commands/manifest/cmd-manifest-gradle.ts
@@ -34,16 +34,6 @@ const config: CliCommandConfig = {
       description:
         'Additional options to pass on to ./gradlew, see `./gradlew --help`'
     },
-    out: {
-      type: 'string',
-      default: './socket.pom.xml',
-      description:
-        'Path of output file; where to store the resulting manifest, see also --stdout'
-    },
-    stdout: {
-      type: 'boolean',
-      description: 'Print resulting pom.xml to stdout (supersedes --out)'
-    },
     task: {
       type: 'string',
       default: 'all',
@@ -116,6 +106,7 @@ async function run(
     logger.groupEnd()
   }
 
+  const { cwd = process.cwd() } = cli.flags
   const [target = ''] = cli.input
 
   // TODO: I'm not sure it's feasible to parse source file from stdin. We could
@@ -148,19 +139,10 @@ async function run(
     bin = path.join(target, 'gradlew')
   }
 
-  let out: string = './socket.pom.xml'
-  if (cli.flags['out']) {
-    out = cli.flags['out'] as string
-  }
-  if (cli.flags['stdout']) {
-    out = '-'
-  }
-
   if (verbose) {
     logger.group()
     logger.log('- target:', target)
     logger.log('- gradle bin:', bin)
-    logger.log('- out:', out)
     logger.groupEnd()
   }
 
@@ -177,5 +159,5 @@ async function run(
     return
   }
 
-  await convertGradleToMaven(target, bin, out, verbose, gradleOpts)
+  await convertGradleToMaven(target, bin, cwd, verbose, gradleOpts)
 }

--- a/src/commands/manifest/cmd-manifest-kotlin.test.ts
+++ b/src/commands/manifest/cmd-manifest-kotlin.test.ts
@@ -29,8 +29,6 @@ describe('socket manifest kotlin', async () => {
             --dryRun          Do input validation for a command and exit 0 when input is ok
             --gradleOpts      Additional options to pass on to ./gradlew, see \`./gradlew --help\`
             --help            Print this help
-            --out             Path of output file; where to store the resulting manifest, see also --stdout
-            --stdout          Print resulting pom.xml to stdout (supersedes --out)
             --task            Task to target. By default targets all
             --verbose         Print debug messages
 

--- a/src/commands/manifest/cmd-manifest-kotlin.ts
+++ b/src/commands/manifest/cmd-manifest-kotlin.ts
@@ -158,5 +158,11 @@ async function run(
     return
   }
 
-  await convertGradleToMaven(target, bin, cwd, verbose, gradleOpts)
+  await convertGradleToMaven(
+    target,
+    String(bin),
+    String(cwd),
+    verbose,
+    gradleOpts
+  )
 }

--- a/src/commands/manifest/cmd-manifest-kotlin.ts
+++ b/src/commands/manifest/cmd-manifest-kotlin.ts
@@ -39,16 +39,6 @@ const config: CliCommandConfig = {
       description:
         'Additional options to pass on to ./gradlew, see `./gradlew --help`'
     },
-    out: {
-      type: 'string',
-      default: './socket.pom.xml',
-      description:
-        'Path of output file; where to store the resulting manifest, see also --stdout'
-    },
-    stdout: {
-      type: 'boolean',
-      description: 'Print resulting pom.xml to stdout (supersedes --out)'
-    },
     task: {
       type: 'string',
       default: 'all',
@@ -146,26 +136,12 @@ async function run(
     return
   }
 
-  let bin: string
-  if (cli.flags['bin']) {
-    bin = cli.flags['bin'] as string
-  } else {
-    bin = path.join(target, 'gradlew')
-  }
-
-  let out: string = './socket.pom.xml'
-  if (cli.flags['out']) {
-    out = cli.flags['out'] as string
-  }
-  if (cli.flags['stdout']) {
-    out = '-'
-  }
+  const { bin = path.join(target, 'gradlew'), cwd = process.cwd() } = cli.flags
 
   if (verbose) {
     logger.group()
     logger.log('- target:', target)
     logger.log('- gradle bin:', bin)
-    logger.log('- out:', out)
     logger.groupEnd()
   }
 
@@ -182,5 +158,5 @@ async function run(
     return
   }
 
-  await convertGradleToMaven(target, bin, out, verbose, gradleOpts)
+  await convertGradleToMaven(target, bin, cwd, verbose, gradleOpts)
 }


### PR DESCRIPTION
- Fix relative path args not properly resolving for `socket manifest gradle` (and kotlin, which uses same logic)
- Fix `--cwd` flags for these commands, they were being ignored
- Remove the `--out` and `--stdout` flags for these commands, they were being ignored and it's not actually realistic to make them work
- Make the core logic resolve the input paths against the cwd, defaulting to `process.cwd()`
  - Internally, this should also prevent the globber package we use from complaining about relative paths
- Tried to cleanup spiner logic and put it tight around gradlew execution. I think the spinner is currently not working completely as I don't see a spinner running. Not sure what's up there. End message is printed though.
- Warn more explicitly when input paths cannot be resolved.
- Only consider the execution an error when the exit code is non-zero, not when there's stderr output.
