### PR TITLE
Show repo in scan list

### DIFF
--- a/src/commands/scan/output-list-scans.ts
+++ b/src/commands/scan/output-list-scans.ts
@@ -19,6 +19,7 @@ export async function outputListScans(
     columns: [
       { field: 'id', name: colors.magenta('ID') },
       { field: 'report_url', name: colors.magenta('Scan URL') },
+      { field: 'repo', name: colors.magenta('Repo') },
       { field: 'branch', name: colors.magenta('Branch') },
       { field: 'created_at', name: colors.magenta('Created at') }
     ]
@@ -35,6 +36,7 @@ export async function outputListScans(
             day: 'numeric'
           })
         : '',
+      repo: d.repo,
       branch: d.branch
     }
   })


### PR DESCRIPTION
This adds a `repo` column in the `socket scan list` so you can see the repo to which a scan belongs. Weird that it was missing but eh.