### PR TITLE
Add --repo and --branch filters to `socket scan list`

### DIFF
--- a/src/commands/scan/cmd-scan-list.test.ts
+++ b/src/commands/scan/cmd-scan-list.test.ts
@@ -28,6 +28,7 @@ describe('socket scan list', async () => {
             - Permissions: full-scans:list
 
           Options
+            --branch          Filter to show only scans with this branch name
             --direction       Direction option (\`desc\` or \`asc\`) - Default is \`desc\`
             --dryRun          Do input validation for a command and exit 0 when input is ok
             --fromTime        From time - as a unix timestamp
@@ -36,6 +37,7 @@ describe('socket scan list', async () => {
             --markdown        Output result as markdown
             --page            Page number - Default is 1
             --perPage         Results per page - Default is 30
+            --repo            Filter to show only scans with this repository name
             --sort            Sorting option (\`name\` or \`created_at\`) - default is \`created_at\`
             --untilTime       Until time - as a unix timestamp
 

--- a/src/commands/scan/cmd-scan-list.ts
+++ b/src/commands/scan/cmd-scan-list.ts
@@ -23,12 +23,9 @@ const config: CliCommandConfig = {
   flags: {
     ...commonFlags,
     ...outputFlags,
-    sort: {
+    branch: {
       type: 'string',
-      shortFlag: 's',
-      default: 'created_at',
-      description:
-        'Sorting option (`name` or `created_at`) - default is `created_at`'
+      description: 'Filter to show only scans with this branch name'
     },
     direction: {
       type: 'string',
@@ -36,11 +33,11 @@ const config: CliCommandConfig = {
       default: 'desc',
       description: 'Direction option (`desc` or `asc`) - Default is `desc`'
     },
-    perPage: {
-      type: 'number',
-      shortFlag: 'pp',
-      default: 30,
-      description: 'Results per page - Default is 30'
+    fromTime: {
+      type: 'string',
+      shortFlag: 'f',
+      default: '',
+      description: 'From time - as a unix timestamp'
     },
     page: {
       type: 'number',
@@ -48,11 +45,22 @@ const config: CliCommandConfig = {
       default: 1,
       description: 'Page number - Default is 1'
     },
-    fromTime: {
+    perPage: {
+      type: 'number',
+      shortFlag: 'pp',
+      default: 30,
+      description: 'Results per page - Default is 30'
+    },
+    repo: {
       type: 'string',
-      shortFlag: 'f',
-      default: '',
-      description: 'From time - as a unix timestamp'
+      description: 'Filter to show only scans with this repository name'
+    },
+    sort: {
+      type: 'string',
+      shortFlag: 's',
+      default: 'created_at',
+      description:
+        'Sorting option (`name` or `created_at`) - default is `created_at`'
     },
     untilTime: {
       type: 'string',
@@ -95,7 +103,7 @@ async function run(
     parentName
   })
 
-  const { json, markdown } = cli.flags
+  const { branch, json, markdown, repo } = cli.flags
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
   const apiToken = getDefaultToken()
@@ -137,12 +145,14 @@ async function run(
   }
 
   await handleListScans({
+    branch: branch ? String(branch) : '',
     direction: String(cli.flags['direction'] || ''),
     from_time: String(cli.flags['fromTime'] || ''),
     orgSlug,
     outputKind: json ? 'json' : markdown ? 'markdown' : 'print',
     page: Number(cli.flags['page'] || 1),
     per_page: Number(cli.flags['perPage'] || 30),
+    repo: repo ? String(repo) : '',
     sort: String(cli.flags['sort'] || '')
   })
 }

--- a/src/commands/scan/fetch-list-scans.ts
+++ b/src/commands/scan/fetch-list-scans.ts
@@ -5,18 +5,22 @@ import { setupSdk } from '../../utils/sdk'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function fetchListScans({
+  branch,
   direction,
   from_time,
   orgSlug,
   page,
   per_page,
+  repo,
   sort
 }: {
+  branch: string
   direction: string
   from_time: string
   orgSlug: string
   page: number
   per_page: number
+  repo: string
   sort: string
 }): Promise<SocketSdkReturnType<'getOrgFullScanList'>['data'] | void> {
   const sockSdk = await setupSdk()
@@ -28,6 +32,8 @@ export async function fetchListScans({
 
   const result = await handleApiCall(
     sockSdk.getOrgFullScanList(orgSlug, {
+      ...(branch ? { branch } : {}),
+      ...(repo ? { repo } : {}),
       sort,
       direction,
       per_page: String(per_page),

--- a/src/commands/scan/handle-list-scans.ts
+++ b/src/commands/scan/handle-list-scans.ts
@@ -2,28 +2,34 @@ import { fetchListScans } from './fetch-list-scans'
 import { outputListScans } from './output-list-scans'
 
 export async function handleListScans({
+  branch,
   direction,
   from_time,
   orgSlug,
   outputKind,
   page,
   per_page,
+  repo,
   sort
 }: {
+  branch: string
   direction: string
   from_time: string
   orgSlug: string
   outputKind: 'json' | 'markdown' | 'print'
   page: number
   per_page: number
+  repo: string
   sort: string
 }): Promise<void> {
   const data = await fetchListScans({
+    branch,
     direction,
     from_time,
     orgSlug,
     page,
     per_page,
+    repo,
     sort
   })
   if (!data) {


### PR DESCRIPTION
This way you can filter the `socket scan list` to look only for scans in certain repos or with certain branch names (or both). Probably handy ;)