### PR TITLE
Add `socket manifest conda` to convert to requirements.txt

### DIFF
--- a/src/commands/manifest/README.md
+++ b/src/commands/manifest/README.md
@@ -4,19 +4,13 @@
 
 ## Dev
 
-First build the bundle:
-
-```
-npm run build:dist
-```
-
-Then run it like these examples:
+Run it like these examples:
 
 ```
 # Scala:
-npm exec socket manifest scala -- --bin ~/apps/sbt/bin/sbt ~/socket/repos/scala/akka
+npm run bs manifest scala -- --bin ~/apps/sbt/bin/sbt ~/socket/repos/scala/akka
 # Gradle/Kotlin
-npm exec socket manifest yolo -- --cwd  ~/socket/repos/kotlin/kotlinx.coroutines
+npm run bs manifest yolo -- --cwd  ~/socket/repos/kotlin/kotlinx.coroutines
 ```
 
 And upload with this:

--- a/src/commands/manifest/cmd-manifest-auto.ts
+++ b/src/commands/manifest/cmd-manifest-auto.ts
@@ -5,6 +5,7 @@ import meow from 'meow'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import { cmdManifestConda } from './cmd-manifest-conda'
 import { cmdManifestGradle } from './cmd-manifest-gradle'
 import { cmdManifestScala } from './cmd-manifest-scala'
 import constants from '../../constants'
@@ -107,6 +108,22 @@ async function run(
       return
     }
     await cmdManifestGradle.run(subArgs, importMeta, { parentName })
+    return
+  }
+
+  if (existsSync(path.join(dir, 'environment.yml'))) {
+    logger.log(
+      'Detected an environment.yml file, running default Conda generator...'
+    )
+    if (cwd) {
+      // This command takes the cwd as first arg.
+      subArgs.push(cwd)
+    }
+    if (cli.flags['dryRun']) {
+      logger.log(DRY_RUN_BAIL_TEXT)
+      return
+    }
+    await cmdManifestConda.run(subArgs, importMeta, { parentName })
     return
   }
 

--- a/src/commands/manifest/cmd-manifest-conda.test.ts
+++ b/src/commands/manifest/cmd-manifest-conda.test.ts
@@ -1,0 +1,197 @@
+import path from 'node:path'
+
+import { describe, expect } from 'vitest'
+
+import constants from '../../../dist/constants.js'
+import { cmdit, invokeNpm } from '../../../test/utils'
+
+const { CLI } = constants
+
+describe('socket manifest conda', async () => {
+  // Lazily access constants.rootBinPath.
+  const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
+
+  cmdit(
+    ['manifest', 'conda', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
+        "[beta] Convert a Conda environment.yml file to a python requirements.txt
+
+          Usage
+            $ socket manifest conda FILE
+
+          Note: FILE can be a dash (-) to indicate stdin. This way you can pipe the
+                contents of a file to have it processed.
+
+          Options
+            --cwd             Set the cwd, defaults to process.cwd()
+            --dryRun          Do input validation for a command and exit 0 when input is ok
+            --help            Print this help
+            --json            Output result as json
+            --markdown        Output result as markdown
+            --out             Output target (use \`-\` or omit to print to stdout)
+            --verbose         Print debug messages
+
+          Examples
+
+            $ socket manifest conda ./environment.yml"
+      `
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest conda\`, cwd: <redacted>"
+      `)
+
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket manifest conda`'
+      )
+    }
+  )
+
+  cmdit(
+    ['manifest', 'conda', '--dry-run', '--config', '{}'],
+    'should require args with just dry-run',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest conda\`, cwd: <redacted>
+
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+
+          - The FILE arg is required (\\x1b[31mmissing\\x1b[39m)"
+      `)
+
+      expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
+    }
+  )
+
+  cmdit(
+    [
+      'manifest',
+      'conda',
+      'mootools',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}'
+    ],
+    'should require args with just dry-run',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest conda\`, cwd: <redacted>"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
+
+  describe('output flags', () => {
+    cmdit(
+      [
+        'manifest',
+        'conda',
+        './manifest-conda/environment.yml',
+        '--config',
+        '{}'
+      ],
+      'should print raw text without flags',
+      async cmd => {
+        const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+        expect(stdout).toMatchInlineSnapshot(`
+          "qgrid==1.3.0
+          mplstereonet
+          pyqt5
+          gempy==2.1.0"
+        `)
+        expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+          "
+             _____         _       _        /---------------
+            |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+            |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+            |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest conda\`, cwd: <redacted>"
+        `)
+      }
+    )
+
+    cmdit(
+      [
+        'manifest',
+        'conda',
+        './manifest-conda/environment.yml',
+        '--json',
+        '--config',
+        '{}'
+      ],
+      'should print a json blurb with --json flag',
+      async cmd => {
+        const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+        expect(stdout).toMatchInlineSnapshot(`
+          "{
+            "ok": true,
+            "data": {
+              "pip": "qgrid==1.3.0\\nmplstereonet\\npyqt5\\ngempy==2.1.0"
+            }
+          }"
+        `)
+        expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+          "
+             _____         _       _        /---------------
+            |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+            |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+            |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest conda\`, cwd: <redacted>"
+        `)
+      }
+    )
+
+    cmdit(
+      [
+        'manifest',
+        'conda',
+        './manifest-conda/environment.yml',
+        '--markdown',
+        '--config',
+        '{}'
+      ],
+      'should print a markdown blurb with --markdown flag',
+      async cmd => {
+        const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+        expect(stdout).toMatchInlineSnapshot(`
+          "# Converted Conda file
+
+          This is the Conda \`environment.yml\` file converted to python \`requirements.txt\`:
+
+          \`\`\`file=requirements.txt
+          qgrid==1.3.0
+          mplstereonet
+          pyqt5
+          gempy==2.1.0
+          \`\`\`"
+        `)
+        expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+          "
+             _____         _       _        /---------------
+            |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+            |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+            |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest conda\`, cwd: <redacted>"
+        `)
+      }
+    )
+  })
+})

--- a/src/commands/manifest/cmd-manifest-conda.ts
+++ b/src/commands/manifest/cmd-manifest-conda.ts
@@ -1,0 +1,127 @@
+import { logger } from '@socketsecurity/registry/lib/logger'
+
+import { handleManifestConda } from './handle-manifest-conda'
+import constants from '../../constants'
+import { commonFlags, outputFlags } from '../../flags'
+import { handleBadInput } from '../../utils/handle-bad-input'
+import { meowOrExit } from '../../utils/meow-with-subcommands'
+import { getFlagListOutput } from '../../utils/output-formatting'
+
+import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
+
+const { DRY_RUN_BAIL_TEXT } = constants
+
+const config: CliCommandConfig = {
+  commandName: 'conda',
+  description:
+    '[beta] Convert a Conda environment.yml file to a python requirements.txt',
+  hidden: false,
+  flags: {
+    ...commonFlags,
+    ...outputFlags,
+    cwd: {
+      type: 'string',
+      description: 'Set the cwd, defaults to process.cwd()'
+    },
+    out: {
+      type: 'string',
+      default: '-',
+      description: 'Output target (use `-` or omit to print to stdout)'
+    },
+    verbose: {
+      type: 'boolean',
+      description: 'Print debug messages'
+    }
+  },
+  help: (command, config) => `
+    Usage
+      $ ${command} FILE
+
+    Note: FILE can be a dash (-) to indicate stdin. This way you can pipe the
+          contents of a file to have it processed.
+
+    Options
+      ${getFlagListOutput(config.flags, 6)}
+
+    Examples
+
+      $ ${command} ./environment.yml
+  `
+}
+
+export const cmdManifestConda = {
+  description: config.description,
+  hidden: config.hidden,
+  run
+}
+
+async function run(
+  argv: string[] | readonly string[],
+  importMeta: ImportMeta,
+  { parentName }: { parentName: string }
+): Promise<void> {
+  const cli = meowOrExit({
+    argv,
+    config,
+    importMeta,
+    parentName
+  })
+
+  const {
+    cwd = process.cwd(),
+    json = false,
+    markdown = false,
+    out = '-',
+    verbose = false
+  } = cli.flags
+  const [target = ''] = cli.input
+
+  if (verbose) {
+    logger.group('- ', parentName, config.commandName, ':')
+    logger.group('- flags:', cli.flags)
+    logger.groupEnd()
+    logger.log('- target:', target)
+    logger.log('- output:', out)
+    logger.groupEnd()
+  }
+
+  const wasBadInput = handleBadInput(
+    {
+      test: !!target && target !== '-',
+      message: 'The FILE arg is required',
+      pass: 'ok',
+      fail: target === '-' ? 'stdin is not supported' : 'missing'
+    },
+    {
+      nook: true,
+      test: cli.input.length <= 1,
+      message: 'Can only accept one DIR (make sure to escape spaces!)',
+      pass: 'ok',
+      fail: 'received ' + cli.input.length
+    },
+    {
+      nook: true,
+      test: !json || !markdown,
+      message:
+        'The `--json` and `--markdown` flags can not be used at the same time',
+      pass: 'ok',
+      fail: 'bad'
+    }
+  )
+  if (wasBadInput) {
+    return
+  }
+
+  if (cli.flags['dryRun']) {
+    logger.log(DRY_RUN_BAIL_TEXT)
+    return
+  }
+
+  await handleManifestConda(
+    target,
+    String(out || ''),
+    json ? 'json' : markdown ? 'markdown' : 'text',
+    String(cwd),
+    Boolean(verbose)
+  )
+}

--- a/src/commands/manifest/cmd-manifest-conda.ts
+++ b/src/commands/manifest/cmd-manifest-conda.ts
@@ -87,10 +87,10 @@ async function run(
 
   const wasBadInput = handleBadInput(
     {
-      test: !!target && target !== '-',
+      test: !!target,
       message: 'The FILE arg is required',
       pass: 'ok',
-      fail: target === '-' ? 'stdin is not supported' : 'missing'
+      fail: 'missing'
     },
     {
       nook: true,

--- a/src/commands/manifest/cmd-manifest.test.ts
+++ b/src/commands/manifest/cmd-manifest.test.ts
@@ -25,6 +25,7 @@ describe('socket manifest', async () => {
 
           Commands
             auto              Auto-detect build and attempt to generate manifest file
+            conda             [beta] Convert a Conda environment.yml file to a python requirements.txt
             gradle            [beta] Use Gradle to generate a manifest file (\`pom.xml\`) for a Gradle/Java/Kotlin/etc project
             kotlin            [beta] Use Gradle to generate a manifest file (\`pom.xml\`) for a Kotlin project
             scala             [beta] Generate a manifest file (\`pom.xml\`) from Scala's \`build.sbt\` file

--- a/src/commands/manifest/cmd-manifest.ts
+++ b/src/commands/manifest/cmd-manifest.ts
@@ -1,4 +1,5 @@
 import { cmdManifestAuto } from './cmd-manifest-auto'
+import { cmdManifestConda } from './cmd-manifest-conda'
 import { cmdManifestGradle } from './cmd-manifest-gradle'
 import { cmdManifestKotlin } from './cmd-manifest-kotlin'
 import { cmdManifestScala } from './cmd-manifest-scala'
@@ -57,6 +58,7 @@ async function run(
   await meowWithSubcommands(
     {
       auto: cmdManifestAuto,
+      conda: cmdManifestConda,
       scala: cmdManifestScala,
       gradle: cmdManifestGradle,
       kotlin: cmdManifestKotlin

--- a/src/commands/manifest/convert-conda-to-requirements.test.ts
+++ b/src/commands/manifest/convert-conda-to-requirements.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  convertCondaToRequirements,
+  convertCondaToRequirementsFromInput
+} from './convert-conda-to-requirements'
+
+describe('convert-conda-to-requirements', () => {
+  it('should convert a simple example', () => {
+    const output = convertCondaToRequirementsFromInput(`
+name: myenv
+channels:
+  - defaults
+dependencies:
+  - python=3.8
+  - pip
+  - pip:
+    - pandas
+    - numpy==1.21.0
+    - requests>=2.26.0
+`)
+
+    expect(output).toMatchInlineSnapshot(`
+      "pandas
+      numpy==1.21.0
+      requests>=2.26.0"
+    `)
+  })
+
+  it('should support arbitrary indent block', () => {
+    const output = convertCondaToRequirementsFromInput(`
+name: myenv
+channels:
+  - defaults
+dependencies:
+  - python=3.8
+  - pip
+  - pip:
+            - pandas
+            - numpy==1.21.0
+            - requests>=2.26.0
+`)
+
+    expect(output).toMatchInlineSnapshot(`
+      "pandas
+      numpy==1.21.0
+      requests>=2.26.0"
+    `)
+  })
+
+  it('should support single space indented block', () => {
+    const output = convertCondaToRequirementsFromInput(`
+name: myenv
+channels:
+  - defaults
+dependencies:
+  - python=3.8
+  - pip
+  - pip:
+   - pandas
+   - numpy==1.21.0
+   - requests>=2.26.0
+`)
+
+    expect(output).toMatchInlineSnapshot(`
+      "pandas
+      numpy==1.21.0
+      requests>=2.26.0"
+    `)
+  })
+
+  it('should support comment and empty lines inside pip block', () => {
+    const output = convertCondaToRequirementsFromInput(`
+name: myenv
+channels:
+  - defaults
+dependencies:
+  - python=3.8
+  - pip
+  - pip:
+            - pandas
+            - numpy==1.21.0
+            - requests>=2.26.0
+`)
+
+    expect(output).toMatchInlineSnapshot(`
+      "pandas
+      numpy==1.21.0
+      requests>=2.26.0"
+    `)
+  })
+
+  it('should support block closing on further indent than start', () => {
+    const output = convertCondaToRequirementsFromInput(`
+name: myenv
+channels:
+  - defaults
+dependencies:
+  - python=3.8
+  - pip
+  - pip:
+            - pandas
+            - numpy==1.21.0
+            - requests>=2.26.0
+        - the end
+`)
+
+    expect(output).toMatchInlineSnapshot(`
+      "pandas
+      numpy==1.21.0
+      requests>=2.26.0"
+    `)
+  })
+
+  it('should support block closing on closer indent than start', () => {
+    const output = convertCondaToRequirementsFromInput(`
+name: myenv
+channels:
+  - defaults
+dependencies:
+  - python=3.8
+  - pip
+  - pip:
+            - pandas
+            - numpy==1.21.0
+            - requests>=2.26.0
+- the end
+`)
+
+    expect(output).toMatchInlineSnapshot(`
+      "pandas
+      numpy==1.21.0
+      requests>=2.26.0"
+    `)
+  })
+
+  it('should convert an example with stuff after the pip block', () => {
+    const output = convertCondaToRequirementsFromInput(`
+channels:
+- defaults
+- conda-forge
+- conda
+- pytorch
+- nvidia
+- anaconda
+- https://repo.continuum.io/pkgs/main
+- conda-forge
+- Gurobi
+dependencies:
+- python=3.9
+- gurobi>=12.0.0
+- ordered-set
+- pygraphviz=1.9
+- pydot=1.4.2
+- pympler
+- dill
+- pytest
+- pip:
+  - aiohttp==3.8.4
+  - requests==2.30.0
+  - networkx==3.1
+  - numpy==1.24.3
+  - scipy==1.10.1
+  - pandas==2.0.1
+  - dotwiz==0.4.0
+  - pydantic==2.7.1
+  - pyyaml==6.0.1
+  - psutil==5.9.0
+  - memray==1.14.0
+  - optuna>=4.1.0
+name: py-optim
+    `)
+
+    expect(output).toMatchInlineSnapshot(`
+      "aiohttp==3.8.4
+      requests==2.30.0
+      networkx==3.1
+      numpy==1.24.3
+      scipy==1.10.1
+      pandas==2.0.1
+      dotwiz==0.4.0
+      pydantic==2.7.1
+      pyyaml==6.0.1
+      psutil==5.9.0
+      memray==1.14.0
+      optuna>=4.1.0"
+    `)
+  })
+
+  it('should convert an more complex example', () => {
+    const output = convertCondaToRequirementsFromInput(`
+name: myenv                     # Environment name (optional but recommended)
+
+channels:                       # Package sources/repositories
+  - conda-forge                 # Higher priority channel
+  - defaults                    # Lower priority channel
+
+dependencies:                   # List of packages to install
+  # Conda packages (direct dependencies)
+  - python=3.9                  # Major.Minor version
+  - pandas>=1.3.0               # Greater than or equal to version
+  - numpy~=1.21.0               # Compatible release (same as >=1.21.0,<1.22.0)
+  - scipy==1.7.0                # Exact version
+  - matplotlib<3.5.0            # Less than version
+
+  # Optional: specify build number
+  - package=1.0.0=h123456_0     # package=version=build_string
+
+  # Pip packages (installed via pip)
+  - pip                         # Include pip itself
+  - pip:                        # Packages to be installed via pip
+    - tensorflow>=2.0.0
+    - torch==1.9.0
+    - transformers
+    - -r requirements.txt       # Can include requirements.txt file
+    - git+https://github.com/user/repo.git    # Install from git
+
+  # Platform-specific dependencies
+  - cudatoolkit=11.0            # Only for systems with NVIDIA GPU
+`)
+
+    expect(output).toMatchInlineSnapshot(`
+      "tensorflow>=2.0.0
+      torch==1.9.0
+      transformers
+      -r requirements.txt       # Can include requirements.txt file
+      git+https://github.com/user/repo.git    # Install from git"
+    `)
+  })
+})

--- a/src/commands/manifest/convert-conda-to-requirements.ts
+++ b/src/commands/manifest/convert-conda-to-requirements.ts
@@ -32,6 +32,21 @@ export async function convertCondaToRequirements(
         }
         reject(e)
       })
+      process.stdin.on('close', () => {
+        if (buf.length === 0) {
+          if (verbose) {
+            logger.error('stdin closed explicitly without data received')
+          }
+          reject(new Error('No data received from stdin'))
+        } else {
+          if (verbose) {
+            logger.error(
+              'warning: stdin closed explicitly with some data received'
+            )
+          }
+          resolve(buf.join(''))
+        }
+      })
     })
 
     if (!contents) {

--- a/src/commands/manifest/convert-conda-to-requirements.ts
+++ b/src/commands/manifest/convert-conda-to-requirements.ts
@@ -1,0 +1,125 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { logger } from '@socketsecurity/registry/lib/logger'
+
+export async function convertCondaToRequirements(
+  target: string,
+  cwd: string,
+  verbose: boolean
+): Promise<
+  | { ok: true; message: string; data: { contents: string; pip: string } }
+  | { ok: false; message: string; data: undefined }
+> {
+  let contents: string
+  if (target === '-') {
+    if (verbose) {
+      logger.error(`[VERBOSE] reading input from stdin`)
+    }
+
+    const buf: string[] = []
+    contents = await new Promise((resolve, reject) => {
+      process.stdin.on('data', chunk => {
+        const input = chunk.toString()
+        buf.push(input)
+      })
+      process.stdin.on('end', () => {
+        resolve(buf.join(''))
+      })
+      process.stdin.on('error', e => {
+        if (verbose) {
+          logger.error('Unexpected error while reading from stdin:', e)
+        }
+        reject(e)
+      })
+    })
+
+    if (!contents) {
+      return {
+        ok: false,
+        message: 'No data received from stdin',
+        data: undefined
+      }
+    }
+  } else {
+    const f = path.resolve(cwd, target)
+
+    if (verbose) {
+      logger.error(`[VERBOSE] target file: ${f}`)
+    }
+
+    if (!fs.existsSync(f)) {
+      return {
+        ok: false,
+        message: `Input file not found at ${f}`,
+        data: undefined
+      }
+    }
+
+    contents = fs.readFileSync(target, 'utf8')
+
+    if (!contents) {
+      return { ok: false, message: 'File is empty', data: undefined }
+    }
+  }
+
+  return {
+    ok: true,
+    message: '',
+    data: {
+      contents,
+      pip: convertCondaToRequirementsFromInput(contents)
+    }
+  }
+}
+
+// Just extract the first pip block, if one exists at all.
+export function convertCondaToRequirementsFromInput(input: string): string {
+  const keeping: string[] = []
+  let collecting = false
+  let delim = '-'
+  let indent = ''
+  input.split('\n').some(line => {
+    if (!line) {
+      // Ignore empty lines
+      return
+    }
+    if (collecting) {
+      if (line.startsWith('#')) {
+        // Ignore comment lines (keep?)
+        return
+      }
+      if (line.startsWith(delim)) {
+        // In this case we have a line with the same indentation as the
+        // `- pip:` line, so we have reached the end of the pip block.
+        return true // the end
+      } else {
+        if (!indent) {
+          // Store the indentation of the block
+          if (line.trim().startsWith('-')) {
+            indent = line.split('-')[0] + '-'
+            if (indent.length <= delim.length) {
+              // The first line after the `pip:` line does not indent further
+              // than that so the block is empty?
+              return true
+            }
+          }
+        }
+        if (line.startsWith(indent)) {
+          keeping.push(line.slice(indent.length).trim())
+        } else {
+          // Unexpected input. bail.
+          return true
+        }
+      }
+    } else {
+      // Note: the line may end with a line comment so don't === it.
+      if (line.trim().startsWith('- pip:')) {
+        delim = line.split('-')[0] + '-'
+        collecting = true
+      }
+    }
+  })
+
+  return keeping.join('\n')
+}

--- a/src/commands/manifest/handle-manifest-conda.ts
+++ b/src/commands/manifest/handle-manifest-conda.ts
@@ -1,0 +1,23 @@
+import { logger } from '@socketsecurity/registry/lib/logger'
+
+import { convertCondaToRequirements } from './convert-conda-to-requirements'
+import { outputRequirements } from './output-requirements'
+
+export async function handleManifestConda(
+  target: string,
+  out: string,
+  outputKind: 'json' | 'markdown' | 'text',
+  cwd: string,
+  verbose: boolean
+): Promise<void> {
+  const data = await convertCondaToRequirements(target, cwd, verbose)
+  if (!data) {
+    return
+  }
+  if (!data.ok) {
+    logger.fail(data.message)
+    return
+  }
+
+  await outputRequirements(data.data, outputKind, out)
+}

--- a/src/commands/manifest/output-requirements.ts
+++ b/src/commands/manifest/output-requirements.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs'
+
+import { logger } from '@socketsecurity/registry/lib/logger'
+
+export async function outputRequirements(
+  data: { contents: string; pip: string },
+  outputKind: 'json' | 'markdown' | 'text',
+  out: string
+) {
+  if (outputKind === 'json') {
+    const json = JSON.stringify(
+      {
+        ok: true,
+        data: {
+          pip: data.pip
+        }
+      },
+      undefined,
+      2
+    )
+
+    if (out === '-') {
+      logger.log(json)
+    } else {
+      fs.writeFileSync(out, json, 'utf8')
+    }
+
+    return
+  }
+
+  if (outputKind === 'markdown') {
+    const arr = []
+    arr.push('# Converted Conda file')
+    arr.push('')
+    arr.push(
+      'This is the Conda `environment.yml` file converted to python `requirements.txt`:'
+    )
+    arr.push('')
+    arr.push('```file=requirements.txt')
+    arr.push(data.pip)
+    arr.push('```')
+    arr.push('')
+    const md = arr.join('\n')
+
+    if (out === '-') {
+      logger.log(md)
+    } else {
+      fs.writeFileSync(out, md, 'utf8')
+    }
+    return
+  }
+
+  if (out === '-') {
+    logger.log(data.pip)
+    logger.log('')
+  } else {
+    fs.writeFileSync(out, data.pip, 'utf8')
+  }
+}

--- a/test/socket-npm-fixtures/manifest-conda/environment.yml
+++ b/test/socket-npm-fixtures/manifest-conda/environment.yml
@@ -1,0 +1,21 @@
+name: my_stuff
+
+channels:
+  - conda-thing
+  - defaults
+dependencies:
+  - python=3.8
+  - pandas=1.3.4
+  - numpy=1.19.0
+  - scipy
+  - mkl-service
+  - libpython
+  - m2w64-toolchain
+  - pytest
+  - requests
+  - pip
+  - pip:
+      - qgrid==1.3.0
+      - mplstereonet
+      - pyqt5
+      - gempy==2.1.0


### PR DESCRIPTION
The `socket manifest conda` will try to extract the pip block from a Conda environment.yml file and return it as a python requirements.txt file.
