### PR TITLE
Hide --dry-run from sub commands

### DIFF
--- a/src/commands/analytics/cmd-analytics.test.ts
+++ b/src/commands/analytics/cmd-analytics.test.ts
@@ -31,7 +31,6 @@ describe('socket analytics', async () => {
           last 7 days.
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --file            Filepath to save output. Only valid with --json/--markdown. Defaults to stdout.
             --help            Print this help
             --json            Output result as json

--- a/src/commands/audit-log/cmd-audit-log.test.ts
+++ b/src/commands/audit-log/cmd-audit-log.test.ts
@@ -31,7 +31,6 @@ describe('socket audit-log', async () => {
           to this feature and many more, please visit https://socket.dev/pricing
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/config/cmd-config-get.test.ts
+++ b/src/commands/config/cmd-config-get.test.ts
@@ -24,7 +24,6 @@ describe('socket config get', async () => {
             $ socket config get <org slug>
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/config/cmd-config-list.test.ts
+++ b/src/commands/config/cmd-config-list.test.ts
@@ -24,7 +24,6 @@ describe('socket config get', async () => {
             $ socket config list <org slug>
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --full            Show full tokens in plaintext (unsafe)
             --help            Print this help
             --json            Output result as json

--- a/src/commands/config/cmd-config-set.test.ts
+++ b/src/commands/config/cmd-config-set.test.ts
@@ -24,7 +24,6 @@ describe('socket config get', async () => {
             $ socket config set <key> <value>
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/config/cmd-config-unset.test.ts
+++ b/src/commands/config/cmd-config-unset.test.ts
@@ -24,7 +24,6 @@ describe('socket config unset', async () => {
             $ socket config unset <org slug>
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/config/cmd-config.test.ts
+++ b/src/commands/config/cmd-config.test.ts
@@ -31,7 +31,6 @@ describe('socket config', async () => {
             unset             Clear the value of a local CLI config item
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
 
           Examples

--- a/src/commands/dependencies/cmd-dependencies.test.ts
+++ b/src/commands/dependencies/cmd-dependencies.test.ts
@@ -28,7 +28,6 @@ describe('socket dependencies', async () => {
             - Permissions: none (does need token with access to target org)
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --limit           Maximum number of dependencies returned

--- a/src/commands/diff-scan/cmd-diff-scan-get.test.ts
+++ b/src/commands/diff-scan/cmd-diff-scan-get.test.ts
@@ -35,7 +35,6 @@ describe('socket diff-scan get', async () => {
             --after           The scan ID of the head scan
             --before          The scan ID of the base scan
             --depth           Max depth of JSON to display before truncating, use zero for no limit (without --json/--file)
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --file            Path to a local file where the output should be saved. Use \`-\` to force stdout.
             --help            Print this help
             --json            Output result as json. This can be big. Use --file to store it to disk without truncation.

--- a/src/commands/diff-scan/cmd-diff-scan.test.ts
+++ b/src/commands/diff-scan/cmd-diff-scan.test.ts
@@ -27,7 +27,6 @@ describe('socket diff-scan', async () => {
             get               Get a diff scan for an organization
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
 
           Examples

--- a/src/commands/fix/cmd-fix.test.ts
+++ b/src/commands/fix/cmd-fix.test.ts
@@ -27,7 +27,6 @@ describe('socket fix', async () => {
                 --autoMerge       Enable auto-merge for pull requests that Socket opens.
                                   See GitHub documentation (\\u200bhttps://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository\\u200b) for managing auto-merge for pull requests in your repository.
                 --autoPilot       Shorthand for --autoMerge --test
-                --dryRun          Do input validation for a command and exit 0 when input is ok
                 --help            Print this help
                 --purl            User provided PURL to fix
                 --rangeStyle      Define how updated dependency versions should be written in package.json.

--- a/src/commands/info/cmd-info.test.ts
+++ b/src/commands/info/cmd-info.test.ts
@@ -27,7 +27,6 @@ describe('socket info', async () => {
 
           Options
             --all             Include all issues
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/login/cmd-login.test.ts
+++ b/src/commands/login/cmd-login.test.ts
@@ -31,7 +31,6 @@ describe('socket login', async () => {
           Options
             --apiBaseUrl      API server to connect to for login
             --apiProxy        Proxy to use when making connection to API server
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
 
           Examples

--- a/src/commands/manifest/cmd-manifest-auto.test.ts
+++ b/src/commands/manifest/cmd-manifest-auto.test.ts
@@ -25,7 +25,6 @@ describe('socket manifest auto', async () => {
 
           Options
             --cwd             Set the cwd, defaults to process.cwd()
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --verbose         Enable debug output, may help when running into errors
 

--- a/src/commands/manifest/cmd-manifest-conda.test.ts
+++ b/src/commands/manifest/cmd-manifest-conda.test.ts
@@ -28,7 +28,6 @@ describe('socket manifest conda', async () => {
 
           Options
             --cwd             Set the cwd, defaults to process.cwd()
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/manifest/cmd-manifest-gradle.test.ts
+++ b/src/commands/manifest/cmd-manifest-gradle.test.ts
@@ -26,7 +26,6 @@ describe('socket manifest gradle', async () => {
           Options
             --bin             Location of gradlew binary to use, default: CWD/gradlew
             --cwd             Set the cwd, defaults to process.cwd()
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --gradleOpts      Additional options to pass on to ./gradlew, see \`./gradlew --help\`
             --help            Print this help
             --task            Task to target. By default targets all

--- a/src/commands/manifest/cmd-manifest-kotlin.test.ts
+++ b/src/commands/manifest/cmd-manifest-kotlin.test.ts
@@ -26,7 +26,6 @@ describe('socket manifest kotlin', async () => {
           Options
             --bin             Location of gradlew binary to use, default: CWD/gradlew
             --cwd             Set the cwd, defaults to process.cwd()
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --gradleOpts      Additional options to pass on to ./gradlew, see \`./gradlew --help\`
             --help            Print this help
             --task            Task to target. By default targets all

--- a/src/commands/manifest/cmd-manifest-scala.test.ts
+++ b/src/commands/manifest/cmd-manifest-scala.test.ts
@@ -26,7 +26,6 @@ describe('socket manifest scala', async () => {
           Options
             --bin             Location of sbt binary to use
             --cwd             Set the cwd, defaults to process.cwd()
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --out             Path of output file; where to store the resulting manifest, see also --stdout
             --sbtOpts         Additional options to pass on to sbt, as per \`sbt --help\`

--- a/src/commands/manifest/cmd-manifest.test.ts
+++ b/src/commands/manifest/cmd-manifest.test.ts
@@ -31,7 +31,6 @@ describe('socket manifest', async () => {
             scala             [beta] Generate a manifest file (\`pom.xml\`) from Scala's \`build.sbt\` file
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
 
           Examples

--- a/src/commands/optimize/cmd-optimize.test.ts
+++ b/src/commands/optimize/cmd-optimize.test.ts
@@ -24,7 +24,6 @@ describe('socket optimize', async () => {
             $ socket optimize
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --pin             Pin overrides to their latest version
             --prod            Only add overrides for production dependencies

--- a/src/commands/organization/cmd-organization-list.test.ts
+++ b/src/commands/organization/cmd-organization-list.test.ts
@@ -28,7 +28,6 @@ describe('socket organization list', async () => {
             - Permissions: none (does need a token)
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown"

--- a/src/commands/organization/cmd-organization-policy-license.test.ts
+++ b/src/commands/organization/cmd-organization-policy-license.test.ts
@@ -28,7 +28,6 @@ describe('socket organization policy license', async () => {
             - Permissions: license-policy:read
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/organization/cmd-organization-policy-security.test.ts
+++ b/src/commands/organization/cmd-organization-policy-security.test.ts
@@ -28,7 +28,6 @@ describe('socket organization policy security', async () => {
             - Permissions: security-policy:read
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/organization/cmd-organization-policy.test.ts
+++ b/src/commands/organization/cmd-organization-policy.test.ts
@@ -27,7 +27,6 @@ describe('socket organization list', async () => {
             (none)
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
 
           Examples

--- a/src/commands/organization/cmd-organization-quota.test.ts
+++ b/src/commands/organization/cmd-organization-quota.test.ts
@@ -24,7 +24,6 @@ describe('socket organization quota', async () => {
             $ socket organization quota
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown"

--- a/src/commands/organization/cmd-organization.test.ts
+++ b/src/commands/organization/cmd-organization.test.ts
@@ -27,7 +27,6 @@ describe('socket organization', async () => {
             list              List organizations associated with the API key used
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
 
           Examples

--- a/src/commands/package/cmd-package-score.test.ts
+++ b/src/commands/package/cmd-package-score.test.ts
@@ -28,7 +28,6 @@ describe('socket package score', async () => {
             - Permissions: packages:list
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/package/cmd-package-shallow.test.ts
+++ b/src/commands/package/cmd-package-shallow.test.ts
@@ -28,7 +28,6 @@ describe('socket package shallow', async () => {
             - Permissions: packages:list
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/package/cmd-package.test.ts
+++ b/src/commands/package/cmd-package.test.ts
@@ -28,7 +28,6 @@ describe('socket package', async () => {
             shallow           [beta] Look up info regarding one or more packages but not their transitives
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
 
           Examples

--- a/src/commands/report/cmd-report.test.ts
+++ b/src/commands/report/cmd-report.test.ts
@@ -28,7 +28,6 @@ describe('socket report', async () => {
             view              [Deprecated] View a project report
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
 
           Examples

--- a/src/commands/repos/cmd-repos-create.test.ts
+++ b/src/commands/repos/cmd-repos-create.test.ts
@@ -29,7 +29,6 @@ describe('socket repos create', async () => {
 
           Options
             --defaultBranch   Repository default branch
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --homepage        Repository url
             --repoDescription Repository description

--- a/src/commands/repos/cmd-repos-del.test.ts
+++ b/src/commands/repos/cmd-repos-del.test.ts
@@ -28,7 +28,6 @@ describe('socket repos del', async () => {
             - Permissions: repo:delete
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
 
           Examples

--- a/src/commands/repos/cmd-repos-list.test.ts
+++ b/src/commands/repos/cmd-repos-list.test.ts
@@ -29,7 +29,6 @@ describe('socket repos list', async () => {
 
           Options
             --direction       Direction option
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/repos/cmd-repos-update.test.ts
+++ b/src/commands/repos/cmd-repos-update.test.ts
@@ -29,7 +29,6 @@ describe('socket repos update', async () => {
 
           Options
             --defaultBranch   Repository default branch
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --homepage        Repository url
             --repoDescription Repository description

--- a/src/commands/repos/cmd-repos-view.test.ts
+++ b/src/commands/repos/cmd-repos-view.test.ts
@@ -28,7 +28,6 @@ describe('socket repos view', async () => {
             - Permissions: repo:list
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/repos/cmd-repos.test.ts
+++ b/src/commands/repos/cmd-repos.test.ts
@@ -31,7 +31,6 @@ describe('socket repos', async () => {
             view              View repositories in an organization
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
 
           Examples

--- a/src/commands/scan/cmd-scan-create.test.ts
+++ b/src/commands/scan/cmd-scan-create.test.ts
@@ -56,7 +56,6 @@ describe('socket scan create', async () => {
             --committers      Committers
             --cwd             working directory, defaults to process.cwd()
             --defaultBranch   Set the default branch of the repository to the branch of this full-scan. Should only need to be done once, for example for the "main" or "master" branch.
-            --dryRun          Run input validation part of command without any concrete side effects
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/scan/cmd-scan-create.ts
+++ b/src/commands/scan/cmd-scan-create.ts
@@ -56,11 +56,6 @@ const config: CliCommandConfig = {
       description:
         'Set the default branch of the repository to the branch of this full-scan. Should only need to be done once, for example for the "main" or "master" branch.'
     },
-    dryRun: {
-      type: 'boolean',
-      description:
-        'Run input validation part of command without any concrete side effects'
-    },
     pendingHead: {
       type: 'boolean',
       default: true,

--- a/src/commands/scan/cmd-scan-del.test.ts
+++ b/src/commands/scan/cmd-scan-del.test.ts
@@ -28,7 +28,6 @@ describe('socket scan del', async () => {
             - Permissions: full-scans:delete
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/scan/cmd-scan-diff.test.ts
+++ b/src/commands/scan/cmd-scan-diff.test.ts
@@ -36,7 +36,6 @@ describe('socket scan diff', async () => {
 
           Options
             --depth           Max depth of JSON to display before truncating, use zero for no limit (without --json/--file)
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --file            Path to a local file where the output should be saved. Use \`-\` to force stdout.
             --help            Print this help
             --json            Output result as json

--- a/src/commands/scan/cmd-scan-list.test.ts
+++ b/src/commands/scan/cmd-scan-list.test.ts
@@ -30,7 +30,6 @@ describe('socket scan list', async () => {
           Options
             --branch          Filter to show only scans with this branch name
             --direction       Direction option (\`desc\` or \`asc\`) - Default is \`desc\`
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --fromTime        From time - as a unix timestamp
             --help            Print this help
             --json            Output result as json

--- a/src/commands/scan/cmd-scan-metadata.test.ts
+++ b/src/commands/scan/cmd-scan-metadata.test.ts
@@ -28,7 +28,6 @@ describe('socket scan metadata', async () => {
             - Permissions: full-scans:list
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/scan/cmd-scan-report.test.ts
+++ b/src/commands/scan/cmd-scan-report.test.ts
@@ -28,7 +28,6 @@ describe('socket scan report', async () => {
             - Permissions: full-scans:list security-policy:read
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --fold            Fold reported alerts to some degree
             --help            Print this help
             --json            Output result as json

--- a/src/commands/scan/cmd-scan-view.test.ts
+++ b/src/commands/scan/cmd-scan-view.test.ts
@@ -30,7 +30,6 @@ describe('socket scan view', async () => {
           When no output path is given the contents is sent to stdout.
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/scan/cmd-scan.test.ts
+++ b/src/commands/scan/cmd-scan.test.ts
@@ -33,7 +33,6 @@ describe('socket scan', async () => {
             view              View the raw results of a scan
 
           Options
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --help            Print this help
 
           Examples

--- a/src/commands/threat-feed/cmd-threat-feed.test.ts
+++ b/src/commands/threat-feed/cmd-threat-feed.test.ts
@@ -33,7 +33,6 @@ describe('socket threat-feed', async () => {
 
           Options
             --direction       Order asc or desc by the createdAt attribute
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --eco             Only show threats for a particular ecosystem
             --filter          Filter what type of threats to return
             --help            Print this help

--- a/src/commands/wrapper/cmd-wrapper.test.ts
+++ b/src/commands/wrapper/cmd-wrapper.test.ts
@@ -25,7 +25,6 @@ describe('socket wrapper', async () => {
 
           Options
             --disable         Disables the Socket npm/npx wrapper
-            --dryRun          Do input validation for a command and exit 0 when input is ok
             --enable          Enables the Socket npm/npx wrapper
             --help            Print this help
 

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -22,6 +22,7 @@ export const commonFlags: MeowFlags = {
   dryRun: {
     type: 'boolean',
     default: false,
+    hidden: true, // Only show in root command
     description: 'Do input validation for a command and exit 0 when input is ok'
   },
   help: {

--- a/src/utils/meow-with-subcommands.ts
+++ b/src/utils/meow-with-subcommands.ts
@@ -89,7 +89,7 @@ export async function meowWithSubcommands(
     ...additionalOptions.flags
   }
 
-  // No further args or first arg is a flag (shrug)z
+  // No further args or first arg is a flag (shrug)
   if (
     name === 'socket' &&
     (!commandOrAliasName || commandOrAliasName?.startsWith('-'))

--- a/src/utils/meow-with-subcommands.ts
+++ b/src/utils/meow-with-subcommands.ts
@@ -89,6 +89,20 @@ export async function meowWithSubcommands(
     ...additionalOptions.flags
   }
 
+  // No further args or first arg is a flag (shrug)z
+  if (
+    name === 'socket' &&
+    (!commandOrAliasName || commandOrAliasName?.startsWith('-'))
+  ) {
+    flags['dryRun'] = {
+      type: 'boolean',
+      default: false,
+      hidden: false, // Only show on root
+      description:
+        'Do input validation for a command and exit 0 when input is ok. Every command should support this flag (not shown on help screens)'
+    }
+  }
+
   const cli = meow(
     `
     Usage


### PR DESCRIPTION
This hides the `--dry-run` flag from all sub-commands.

It's more noise than useful. The root command will show the flag and a note that all sub-commands have it. Not even sure if it's actually useful for anyone other than our tests.