### PR TITLE
Add --interactive flag to scan create

### DIFF
--- a/src/commands/ci/handle-ci.ts
+++ b/src/commands/ci/handle-ci.ts
@@ -20,6 +20,7 @@ export async function handleCI(): Promise<void> {
     committers: '',
     cwd: process.cwd(),
     defaultBranch: false,
+    interactive: false,
     orgSlug,
     outputKind: 'json',
     pendingHead: true, // when true, requires branch name set, tmp false

--- a/src/commands/scan/cmd-scan-create.test.ts
+++ b/src/commands/scan/cmd-scan-create.test.ts
@@ -57,6 +57,7 @@ describe('socket scan create', async () => {
             --cwd             working directory, defaults to process.cwd()
             --defaultBranch   Set the default branch of the repository to the branch of this full-scan. Should only need to be done once, for example for the "main" or "master" branch.
             --help            Print this help
+            --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown
             --pendingHead     Designate this full-scan as the latest scan of a given branch. This must be set to have it show up in the dashboard.

--- a/src/commands/scan/cmd-scan-create.ts
+++ b/src/commands/scan/cmd-scan-create.ts
@@ -56,6 +56,12 @@ const config: CliCommandConfig = {
       description:
         'Set the default branch of the repository to the branch of this full-scan. Should only need to be done once, for example for the "main" or "master" branch.'
     },
+    interactive: {
+      type: 'boolean',
+      default: true,
+      description:
+        'Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.'
+    },
     pendingHead: {
       type: 'boolean',
       default: true,
@@ -159,6 +165,7 @@ async function run(
     cwd: cwdOverride,
     defaultBranch,
     dryRun,
+    interactive = true,
     json,
     markdown,
     pendingHead,
@@ -175,6 +182,7 @@ async function run(
     committers: string
     defaultBranch: boolean
     dryRun: boolean
+    interactive: boolean
     json: boolean
     markdown: boolean
     pendingHead: boolean
@@ -202,7 +210,7 @@ async function run(
   // the command without requiring user input, as a suggestion.
   let updatedInput = false
 
-  if (!targets.length && !dryRun) {
+  if (!targets.length && !dryRun && interactive) {
     const received = await suggestTarget()
     targets = received ?? []
     updatedInput = true
@@ -211,7 +219,7 @@ async function run(
   // If the current cwd is unknown and is used as a repo slug anyways, we will
   // first need to register the slug before we can use it.
   // Only do suggestions with an apiToken and when not in dryRun mode
-  if (apiToken && !dryRun) {
+  if (apiToken && !dryRun && interactive) {
     if (!orgSlug) {
       const suggestion = await suggestOrgSlug()
       if (suggestion) {
@@ -302,6 +310,7 @@ async function run(
     committers: (committers && String(committers)) || '',
     cwd,
     defaultBranch: Boolean(defaultBranch),
+    interactive: Boolean(interactive),
     orgSlug,
     outputKind: json ? 'json' : markdown ? 'markdown' : 'text',
     pendingHead: Boolean(pendingHead),

--- a/src/commands/scan/handle-create-new-scan.ts
+++ b/src/commands/scan/handle-create-new-scan.ts
@@ -14,6 +14,7 @@ export async function handleCreateNewScan({
   committers,
   cwd,
   defaultBranch,
+  interactive,
   orgSlug,
   outputKind,
   pendingHead,
@@ -30,6 +31,7 @@ export async function handleCreateNewScan({
   committers: string
   cwd: string
   defaultBranch: boolean
+  interactive: boolean
   orgSlug: string
   pendingHead: boolean
   pullRequest: number
@@ -106,6 +108,6 @@ export async function handleCreateNewScan({
       process.exitCode = 1
     }
   } else {
-    await outputCreateNewScan(data, outputKind)
+    await outputCreateNewScan(data, outputKind, interactive)
   }
 }

--- a/src/commands/scan/output-create-new-scan.ts
+++ b/src/commands/scan/output-create-new-scan.ts
@@ -8,7 +8,8 @@ import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function outputCreateNewScan(
   data: SocketSdkReturnType<'CreateOrgFullScan'>['data'],
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: 'json' | 'markdown' | 'text',
+  interactive: boolean
 ) {
   if (!data.id) {
     logger.fail('Did not receive a scan ID from the API...')
@@ -47,10 +48,11 @@ export async function outputCreateNewScan(
   logger.log(`Available at: ${link}`)
 
   if (
-    await confirm({
+    interactive &&
+    (await confirm({
       message: 'Would you like to open it in your browser?',
       default: false
-    })
+    }))
   ) {
     await open(`${data.html_report_url}`)
   }


### PR DESCRIPTION
This adds a flag to `socket scan create` that will suppress any interactive asks for input.

This includes the auto-suggestion for missing input, as well as the final "do you want to view in browser" question.

There used to be a `--view` option but that was removed a while back. This would basically replace that in lieu of a more generic approach (pending).