### PR TITLE
Add v1 org discovery to all commands that need it

### DIFF
--- a/src/commands/analytics/cmd-analytics.test.ts
+++ b/src/commands/analytics/cmd-analytics.test.ts
@@ -240,7 +240,7 @@ describe('socket analytics', async () => {
 
           - Scope must be "repo" or "org" (\\x1b[32mok\\x1b[39m)
 
-          - When scope=repo, repo name should the second argument (\\x1b[31mmissing\\x1b[39m)
+          - When scope=repo, repo name should be the second argument (\\x1b[31mmissing\\x1b[39m)
 
           - The time filter must either be 7, 30 or 90 (\\x1b[32mok\\x1b[39m)"
       `)

--- a/src/commands/analytics/cmd-analytics.test.ts
+++ b/src/commands/analytics/cmd-analytics.test.ts
@@ -75,8 +75,6 @@ describe('socket analytics', async () => {
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
-          - Scope must be "repo" or "org" (\\x1b[32mok\\x1b[39m)
-
           - The time filter must either be 7, 30 or 90 (\\x1b[32mok\\x1b[39m)
 
           - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
@@ -89,7 +87,6 @@ describe('socket analytics', async () => {
   cmdit(
     [
       'analytics',
-      'boo',
       '--scope',
       'org',
       '--repo',
@@ -108,6 +105,304 @@ describe('socket analytics', async () => {
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket analytics\`, cwd: <redacted>"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
+
+  cmdit(
+    ['analytics', '--help', '--config', '{"isTestingV1": true}'],
+    'should support --help in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
+        "Look up analytics data
+
+          Usage
+            $ socket analytics [ org | repo <reponame>] [time]
+
+          API Token Requirements
+            - Quota: 1 unit
+            - Permissions: report:write
+
+          The scope is either org or repo level, defaults to org.
+
+          When scope is repo, a repo slug must be given as well.
+
+          The time argument must be number 7, 30, or 90 and defaults to 7.
+
+          Options
+            --file            Filepath to save output. Only valid with --json/--markdown. Defaults to stdout.
+            --help            Print this help
+            --json            Output result as json
+            --markdown        Output result as markdown
+            --repo            Name of the repository. Only valid when scope=repo
+            --scope           Scope of the analytics data - either 'org' or 'repo', default: org
+            --time            Time filter - either 7, 30 or 90, default: 7
+
+          Examples
+            $ socket analytics org 7
+            $ socket analytics repo test-repo 30
+            $ socket analytics 90"
+      `
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket analytics\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
+      `)
+
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket analytics`'
+      )
+    }
+  )
+
+  cmdit(
+    [
+      'analytics',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything"}'
+    ],
+    'should run to dryrun without args in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket analytics\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
+
+  cmdit(
+    [
+      'analytics',
+      'org',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything"}'
+    ],
+    'should accept org arg in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket analytics\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
+
+  cmdit(
+    [
+      'analytics',
+      'repo',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything"}'
+    ],
+    'should ask for repo name with repo arg in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket analytics\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+
+          - Scope must be "repo" or "org" (\\x1b[32mok\\x1b[39m)
+
+          - When scope=repo, repo name should the second argument (\\x1b[31mmissing\\x1b[39m)
+
+          - The time filter must either be 7, 30 or 90 (\\x1b[32mok\\x1b[39m)"
+      `)
+
+      expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
+    }
+  )
+
+  cmdit(
+    [
+      'analytics',
+      'repo',
+      'daname',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything"}'
+    ],
+    'should accept repo with arg in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket analytics\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
+
+  cmdit(
+    [
+      'analytics',
+      '7',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything"}'
+    ],
+    'should accept time 7 arg in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket analytics\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
+
+  cmdit(
+    [
+      'analytics',
+      '30',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything"}'
+    ],
+    'should accept time 30 arg in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket analytics\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
+
+  cmdit(
+    [
+      'analytics',
+      '90',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything"}'
+    ],
+    'should accept time 90 arg in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket analytics\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
+
+  cmdit(
+    [
+      'analytics',
+      'org',
+      '7',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything"}'
+    ],
+    'should accept org and time arg in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket analytics\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
+
+  cmdit(
+    [
+      'analytics',
+      'repo',
+      'slowpo',
+      '30',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything"}'
+    ],
+    'should accept repo and time arg in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket analytics\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
       `)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)

--- a/src/commands/analytics/cmd-analytics.ts
+++ b/src/commands/analytics/cmd-analytics.ts
@@ -1,5 +1,3 @@
-import assert from 'node:assert'
-
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { displayAnalytics } from './display-analytics'
@@ -128,13 +126,13 @@ async function run(
     }
   } else {
     if (cli.flags['scope']) {
-      scope = cli.flags['scope']
+      scope = String(cli.flags['scope'] || '')
     }
     if (scope === 'repo') {
-      repoName = cli.flags['repoName'] || ''
+      repoName = String(cli.flags['repoName'] || '')
     }
     if (cli.flags['time']) {
-      time = cli.flags['time']
+      time = Number(cli.flags['time'] || 7)
     }
   }
 

--- a/src/commands/analytics/cmd-analytics.ts
+++ b/src/commands/analytics/cmd-analytics.ts
@@ -153,7 +153,7 @@ async function run(
       nook: true,
       test: scope === 'org' || !!repoName,
       message: isTestingV1()
-        ? 'When scope=repo, repo name should the second argument'
+        ? 'When scope=repo, repo name should be the second argument'
         : 'When scope=repo, repo name should be set through --repo',
       pass: 'ok',
       fail: 'missing'

--- a/src/commands/audit-log/cmd-audit-log.test.ts
+++ b/src/commands/audit-log/cmd-audit-log.test.ts
@@ -32,8 +32,10 @@ describe('socket audit-log', async () => {
 
           Options
             --help            Print this help
+            --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown
+            --org             Force override the organization slug, overrides the default org from config
             --page            Page number - default is 1
             --perPage         Results per page - default is 30
             --type            Type of log event
@@ -72,7 +74,7 @@ describe('socket audit-log', async () => {
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
-          - Org name should be the first arg (\\x1b[31mmissing\\x1b[39m)
+          - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
           - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)
@@ -99,6 +101,89 @@ describe('socket audit-log', async () => {
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket audit-log\`, cwd: <redacted>"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
+
+  cmdit(
+    [
+      'audit-log',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything"}'
+    ],
+    'should report missing org name in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket audit-log\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m
+        Missing the org slug and no --org flag set. Trying to auto-discover the org now...
+        Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
+        \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+
+          - Org name by default setting, --org, or auto-discovered (\\x1b[31mmissing\\x1b[39m)"
+      `)
+
+      expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
+    }
+  )
+
+  cmdit(
+    [
+      'audit-log',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything", "defaultOrg": "fakeorg"}'
+    ],
+    'should accept default org in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>, default org: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket audit-log\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
+
+  cmdit(
+    [
+      'audit-log',
+      '--org',
+      'forcedorg',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything"}'
+    ],
+    'should accept --org flag in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket audit-log\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
       `)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)

--- a/src/commands/audit-log/cmd-audit-log.ts
+++ b/src/commands/audit-log/cmd-audit-log.ts
@@ -3,7 +3,8 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { handleAuditLog } from './handle-audit-log'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
-import { getConfigValue } from '../../utils/config'
+import { isTestingV1 } from '../../utils/config'
+import { determineOrgSlug } from '../../utils/determine-org-slug'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
@@ -18,6 +19,19 @@ const config: CliCommandConfig = {
   description: 'Look up the audit log for an organization',
   hidden: false,
   flags: {
+    ...commonFlags,
+    ...outputFlags,
+    interactive: {
+      type: 'boolean',
+      default: true,
+      description:
+        'Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.'
+    },
+    org: {
+      type: 'string',
+      description:
+        'Force override the organization slug, overrides the default org from config'
+    },
     type: {
       type: 'string',
       shortFlag: 't',
@@ -35,13 +49,11 @@ const config: CliCommandConfig = {
       shortFlag: 'p',
       default: 1,
       description: 'Page number - default is 1'
-    },
-    ...commonFlags,
-    ...outputFlags
+    }
   },
   help: (command, config) => `
     Usage
-      $ ${command} <org slug>
+      $ ${command} ${isTestingV1() ? '<repo>' : '<org slug>'}
 
     API Token Requirements
       - Quota: 1 unit
@@ -54,7 +66,7 @@ const config: CliCommandConfig = {
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${command} FakeOrg
+      $ ${command} ${isTestingV1() ? '' : 'FakeOrg'}
   `
 }
 
@@ -76,18 +88,34 @@ async function run(
     parentName
   })
 
-  const { json, markdown, page, perPage, type } = cli.flags
+  const {
+    dryRun,
+    interactive,
+    json,
+    markdown,
+    org: orgFlag,
+    page,
+    perPage,
+    type
+  } = cli.flags
   const logType = String(type || '')
 
-  const defaultOrgSlug = getConfigValue('defaultOrg')
-  const orgSlug = defaultOrgSlug || cli.input[0] || ''
+  const [orgSlug] = await determineOrgSlug(
+    String(orgFlag || ''),
+    cli.input[0] || '',
+    !!interactive,
+    !!dryRun
+  )
 
   const apiToken = getDefaultToken()
 
   const wasBadInput = handleBadInput(
     {
+      nook: true,
       test: !!orgSlug,
-      message: 'Org name should be the first arg',
+      message: isTestingV1()
+        ? 'Org name by default setting, --org, or auto-discovered'
+        : 'Org name must be the first argument',
       pass: 'ok',
       fail: 'missing'
     },

--- a/src/commands/cdxgen/cmd-cdxgen.test.ts
+++ b/src/commands/cdxgen/cmd-cdxgen.test.ts
@@ -75,9 +75,11 @@ describe('socket cdxgen', async () => {
     expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
-        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
         |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket cdxgen\`, cwd: <redacted>"
+        |_____|___|___|_,_|___|_|.dev   | Command: \`socket cdxgen\`, cwd: <redacted>
+      \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+      \\x1b[39m"
     `)
 
     // expect(code, 'help should exit with code 2').toBe(2)

--- a/src/commands/config/cmd-config.test.ts
+++ b/src/commands/config/cmd-config.test.ts
@@ -82,10 +82,11 @@ describe('socket config', async () => {
         expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
           "
              _____         _       _        /---------------
-            |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+            |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
             |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
             |_____|___|___|_,_|___|_|.dev   | Command: \`socket\`, cwd: <redacted>
-
+          \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+          \\x1b[39m
           \\x1b[31m\\xd7\\x1b[39m Could not JSON parse the config override. Make sure it's a proper JSON object (double-quoted keys and strings, no unquoted \`undefined\`) and try again."
         `)
 

--- a/src/commands/diff-scan/cmd-diff-scan-get.test.ts
+++ b/src/commands/diff-scan/cmd-diff-scan-get.test.ts
@@ -20,6 +20,9 @@ describe('socket diff-scan get', async () => {
         `
         "Get a diff scan for an organization
 
+          Note: This command is deprecated, to be dropped in the next major bump.
+                Please see \`socket scan diff\`
+
           Usage
             $ socket diff-scan get <org slug> --before=<before> --after=<after>
 

--- a/src/commands/diff-scan/cmd-diff-scan-get.ts
+++ b/src/commands/diff-scan/cmd-diff-scan-get.ts
@@ -3,7 +3,7 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { handleDiffScan } from './handle-diff-scan'
 import constants from '../../constants'
 import { commonFlags } from '../../flags'
-import { getConfigValue } from '../../utils/config'
+import { getConfigValue, isTestingV1 } from '../../utils/config'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
@@ -52,7 +52,13 @@ const config: CliCommandConfig = {
         'Path to a local file where the output should be saved. Use `-` to force stdout.'
     }
   },
-  help: (command, config) => `
+  help: (command, config) =>
+    isTestingV1()
+      ? 'This command will be removed in v1'
+      : `
+    Note: This command is deprecated, to be dropped in the next major bump.
+          Please see \`socket scan diff\`
+
     Usage
       $ ${command} <org slug> --before=<before> --after=<after>
 

--- a/src/commands/fix/cmd-fix.test.ts
+++ b/src/commands/fix/cmd-fix.test.ts
@@ -42,12 +42,14 @@ describe('socket fix', async () => {
     `
     )
     expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
-        "
-           _____         _       _        /---------------
-          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
-          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-          |_____|___|___|_,_|___|_|.dev   | Command: \`socket fix\`, cwd: <redacted>"
-      `)
+      "
+         _____         _       _        /---------------
+        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+        |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+        |_____|___|___|_,_|___|_|.dev   | Command: \`socket fix\`, cwd: <redacted>
+      \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+      \\x1b[39m"
+    `)
 
     expect(code, 'help should exit with code 2').toBe(2)
     expect(stderr, 'banner includes base command').toContain('`socket fix`')

--- a/src/commands/info/cmd-info.ts
+++ b/src/commands/info/cmd-info.ts
@@ -3,6 +3,7 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { handlePackageInfo } from './handle-package-info'
 import constants from '../../constants'
 import { commonFlags, outputFlags, validationFlags } from '../../flags'
+import { isTestingV1 } from '../../utils/config'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
@@ -20,7 +21,10 @@ const config: CliCommandConfig = {
     ...outputFlags,
     ...validationFlags
   },
-  help: (command, config) => `
+  help: (command, config) =>
+    isTestingV1()
+      ? 'This command will be removed in v1'
+      : `
     Usage
       $ ${command} <name>
 

--- a/src/commands/organization/cmd-organization-policy-license.test.ts
+++ b/src/commands/organization/cmd-organization-policy-license.test.ts
@@ -29,8 +29,10 @@ describe('socket organization policy license', async () => {
 
           Options
             --help            Print this help
+            --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown
+            --org             Force override the organization slug, overrides the default org from config
 
           Your API token will need the \`license-policy:read\` permission otherwise
           the request will fail with an authentication error.
@@ -70,7 +72,7 @@ describe('socket organization policy license', async () => {
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
-          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
+          - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
           - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)
@@ -99,6 +101,95 @@ describe('socket organization policy license', async () => {
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy license\`, cwd: <redacted>"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
+
+  cmdit(
+    [
+      'organization',
+      'policy',
+      'license',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything"}'
+    ],
+    'should report missing org name in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy license\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m
+        Missing the org slug and no --org flag set. Trying to auto-discover the org now...
+        Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
+        \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+
+          - Org name by default setting, --org, or auto-discovered (\\x1b[31mmissing\\x1b[39m)"
+      `)
+
+      expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
+    }
+  )
+
+  cmdit(
+    [
+      'organization',
+      'policy',
+      'license',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything", "defaultOrg": "fakeorg"}'
+    ],
+    'should accept default org in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>, default org: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy license\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
+
+  cmdit(
+    [
+      'organization',
+      'policy',
+      'license',
+      '--org',
+      'forcedorg',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything"}'
+    ],
+    'should accept --org flag in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy license\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
       `)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)

--- a/src/commands/organization/cmd-organization-policy-security.test.ts
+++ b/src/commands/organization/cmd-organization-policy-security.test.ts
@@ -29,8 +29,10 @@ describe('socket organization policy security', async () => {
 
           Options
             --help            Print this help
+            --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown
+            --org             Force override the organization slug, overrides the default org from config
 
           Your API token will need the \`security-policy:read\` permission otherwise
           the request will fail with an authentication error.
@@ -99,6 +101,95 @@ describe('socket organization policy security', async () => {
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy security\`, cwd: <redacted>"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
+
+  cmdit(
+    [
+      'organization',
+      'policy',
+      'security',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything"}'
+    ],
+    'should report missing org name in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy security\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m
+        Missing the org slug and no --org flag set. Trying to auto-discover the org now...
+        Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
+        \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)"
+      `)
+
+      expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
+    }
+  )
+
+  cmdit(
+    [
+      'organization',
+      'policy',
+      'security',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything", "defaultOrg": "fakeorg"}'
+    ],
+    'should accept default org in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>, default org: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy security\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
+
+  cmdit(
+    [
+      'organization',
+      'policy',
+      'security',
+      '--org',
+      'forcedorg',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything"}'
+    ],
+    'should accept --org flag in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy security\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
       `)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)

--- a/src/commands/organization/cmd-organization-policy-security.ts
+++ b/src/commands/organization/cmd-organization-policy-security.ts
@@ -3,7 +3,8 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { handleSecurityPolicy } from './handle-security-policy'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
-import { getConfigValue } from '../../utils/config'
+import { isTestingV1 } from '../../utils/config'
+import { determineOrgSlug } from '../../utils/determine-org-slug'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
@@ -20,11 +21,22 @@ const config: CliCommandConfig = {
   hidden: true,
   flags: {
     ...commonFlags,
-    ...outputFlags
+    ...outputFlags,
+    interactive: {
+      type: 'boolean',
+      default: true,
+      description:
+        'Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.'
+    },
+    org: {
+      type: 'string',
+      description:
+        'Force override the organization slug, overrides the default org from config'
+    }
   },
   help: (command, _config) => `
     Usage
-      $ ${command} <org slug>
+      $ ${command}${isTestingV1() ? '' : ' <org slug>'}
 
     API Token Requirements
       - Quota: 1 unit
@@ -37,8 +49,8 @@ const config: CliCommandConfig = {
     the request will fail with an authentication error.
 
     Examples
-      $ ${command} mycorp
-      $ ${command} mycorp --json
+      $ ${command}${isTestingV1() ? '' : ' mycorp'}
+      $ ${command}${isTestingV1() ? '' : ' mycorp'} --json
   `
 }
 
@@ -60,11 +72,15 @@ async function run(
     parentName
   })
 
-  const json = Boolean(cli.flags['json'])
-  const markdown = Boolean(cli.flags['markdown'])
+  const { dryRun, interactive, json, markdown, org: orgFlag } = cli.flags
 
-  const defaultOrgSlug = getConfigValue('defaultOrg')
-  const orgSlug = defaultOrgSlug || cli.input[0] || ''
+  const [orgSlug] = await determineOrgSlug(
+    String(orgFlag || ''),
+    cli.input[0] || '',
+    !!interactive,
+    !!dryRun
+  )
+
   const apiToken = getDefaultToken()
 
   const wasBadInput = handleBadInput(

--- a/src/commands/repos/cmd-repos-create.ts
+++ b/src/commands/repos/cmd-repos-create.ts
@@ -3,12 +3,12 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { handleCreateRepo } from './handle-create-repo'
 import constants from '../../constants'
 import { commonFlags } from '../../flags'
-import { getConfigValue, isTestingV1 } from '../../utils/config'
+import { isTestingV1 } from '../../utils/config'
+import { determineOrgSlug } from '../../utils/determine-org-slug'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
-import { suggestOrgSlug } from '../scan/suggest-org-slug'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -96,34 +96,20 @@ async function run(
     parentName
   })
 
-  const defaultOrgSlug = getConfigValue('defaultOrg')
+  const {
+    dryRun,
+    interactive,
+    org: orgFlag,
+    repoName: repoNameFlag
+  } = cli.flags
 
-  const interactive = cli.flags['interactive']
-  const dryRun = cli.flags['dryRun']
+  const [orgSlug] = await determineOrgSlug(
+    String(orgFlag || ''),
+    cli.input[0] || '',
+    !!interactive,
+    !!dryRun
+  )
 
-  let orgSlug = String(cli.flags['org'] || defaultOrgSlug || '')
-  if (!orgSlug) {
-    if (isTestingV1()) {
-      // ask from server
-      logger.error(
-        'Missing the org slug and no --org flag set. Trying to auto-discover the org now...'
-      )
-      logger.error(
-        'Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.'
-      )
-      if (dryRun) {
-        logger.fail('Skipping auto-discovery of org in dry-run mode')
-      } else if (!interactive) {
-        logger.fail('Skipping auto-discovery of org when interactive = false')
-      } else {
-        orgSlug = (await suggestOrgSlug()) || ''
-      }
-    } else {
-      orgSlug = cli.input[0] || ''
-    }
-  }
-
-  const repoNameFlag = cli.flags['repoName']
   const repoName = (isTestingV1() ? cli.input[0] : repoNameFlag) || ''
 
   const apiToken = getDefaultToken()

--- a/src/commands/repos/cmd-repos-del.ts
+++ b/src/commands/repos/cmd-repos-del.ts
@@ -3,12 +3,12 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { handleDeleteRepo } from './handle-delete-repo'
 import constants from '../../constants'
 import { commonFlags } from '../../flags'
-import { getConfigValue, isTestingV1 } from '../../utils/config'
+import { isTestingV1 } from '../../utils/config'
+import { determineOrgSlug } from '../../utils/determine-org-slug'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
-import { suggestOrgSlug } from '../scan/suggest-org-slug'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -66,35 +66,18 @@ async function run(
     parentName
   })
 
-  const defaultOrgSlug = getConfigValue('defaultOrg')
+  const { dryRun, interactive, org: orgFlag } = cli.flags
 
-  const interactive = cli.flags['interactive']
-  const dryRun = cli.flags['dryRun']
-
-  let orgSlug = String(cli.flags['org'] || defaultOrgSlug || '')
-  if (!orgSlug) {
-    if (isTestingV1()) {
-      // ask from server
-      logger.error(
-        'Missing the org slug and no --org flag set. Trying to auto-discover the org now...'
-      )
-      logger.error(
-        'Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.'
-      )
-      if (dryRun) {
-        logger.fail('Skipping auto-discovery of org in dry-run mode')
-      } else if (!interactive) {
-        logger.fail('Skipping auto-discovery of org when interactive = false')
-      } else {
-        orgSlug = (await suggestOrgSlug()) || ''
-      }
-    } else {
-      orgSlug = cli.input[0] || ''
-    }
-  }
+  const [orgSlug, defaultOrgSlug] = await determineOrgSlug(
+    String(orgFlag || ''),
+    cli.input[0] || '',
+    !!interactive,
+    !!dryRun
+  )
 
   const repoName =
     (defaultOrgSlug || isTestingV1() ? cli.input[0] : cli.input[1]) || ''
+
   const apiToken = getDefaultToken()
 
   const wasBadInput = handleBadInput(

--- a/src/commands/repos/cmd-repos-list.ts
+++ b/src/commands/repos/cmd-repos-list.ts
@@ -3,12 +3,12 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { handleListRepos } from './handle-list-repos'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
-import { getConfigValue, isTestingV1 } from '../../utils/config'
+import { isTestingV1 } from '../../utils/config'
+import { determineOrgSlug } from '../../utils/determine-org-slug'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
-import { suggestOrgSlug } from '../scan/suggest-org-slug'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -92,32 +92,14 @@ async function run(
 
   const { json, markdown } = cli.flags
 
-  const defaultOrgSlug = getConfigValue('defaultOrg')
+  const { dryRun, interactive, org: orgFlag } = cli.flags
 
-  const interactive = cli.flags['interactive']
-  const dryRun = cli.flags['dryRun']
-
-  let orgSlug = String(cli.flags['org'] || defaultOrgSlug || '')
-  if (!orgSlug) {
-    if (isTestingV1()) {
-      // ask from server
-      logger.error(
-        'Missing the org slug and no --org flag set. Trying to auto-discover the org now...'
-      )
-      logger.error(
-        'Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.'
-      )
-      if (dryRun) {
-        logger.fail('Skipping auto-discovery of org in dry-run mode')
-      } else if (!interactive) {
-        logger.fail('Skipping auto-discovery of org when interactive = false')
-      } else {
-        orgSlug = (await suggestOrgSlug()) || ''
-      }
-    } else {
-      orgSlug = cli.input[0] || ''
-    }
-  }
+  const [orgSlug] = await determineOrgSlug(
+    String(orgFlag || ''),
+    cli.input[0] || '',
+    !!interactive,
+    !!dryRun
+  )
 
   const apiToken = getDefaultToken()
 

--- a/src/commands/repos/cmd-repos-update.ts
+++ b/src/commands/repos/cmd-repos-update.ts
@@ -3,12 +3,12 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { handleUpdateRepo } from './handle-update-repo'
 import constants from '../../constants'
 import { commonFlags } from '../../flags'
-import { getConfigValue, isTestingV1 } from '../../utils/config'
+import { isTestingV1 } from '../../utils/config'
+import { determineOrgSlug } from '../../utils/determine-org-slug'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
-import { suggestOrgSlug } from '../scan/suggest-org-slug'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -96,32 +96,14 @@ async function run(
     parentName
   })
 
-  const defaultOrgSlug = getConfigValue('defaultOrg')
+  const { dryRun, interactive, org: orgFlag } = cli.flags
 
-  const interactive = cli.flags['interactive']
-  const dryRun = cli.flags['dryRun']
-
-  let orgSlug = String(cli.flags['org'] || defaultOrgSlug || '')
-  if (!orgSlug) {
-    if (isTestingV1()) {
-      // ask from server
-      logger.error(
-        'Missing the org slug and no --org flag set. Trying to auto-discover the org now...'
-      )
-      logger.error(
-        'Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.'
-      )
-      if (dryRun) {
-        logger.fail('Skipping auto-discovery of org in dry-run mode')
-      } else if (!interactive) {
-        logger.fail('Skipping auto-discovery of org when interactive = false')
-      } else {
-        orgSlug = (await suggestOrgSlug()) || ''
-      }
-    } else {
-      orgSlug = cli.input[0] || ''
-    }
-  }
+  const [orgSlug] = await determineOrgSlug(
+    String(orgFlag || ''),
+    cli.input[0] || '',
+    !!interactive,
+    !!dryRun
+  )
 
   const repoNameFlag = cli.flags['repoName']
   const repoName = (isTestingV1() ? cli.input[0] : repoNameFlag) || ''

--- a/src/commands/scan/cmd-scan-create.test.ts
+++ b/src/commands/scan/cmd-scan-create.test.ts
@@ -60,6 +60,7 @@ describe('socket scan create', async () => {
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown
+            --org             Force override the organization slug, overrides the default org from config
             --pendingHead     Designate this full-scan as the latest scan of a given branch. This must be set to have it show up in the dashboard.
             --pullRequest     Commit hash
             --readOnly        Similar to --dry-run except it can read from remote, stops before it would create an actual report
@@ -68,6 +69,7 @@ describe('socket scan create', async () => {
             --tmp             Set the visibility (true/false) of the scan in your dashboard. Can not be used when --pendingHead is set.
 
           Examples
+            $ socket scan create FakeOrg .
             $ socket scan create --repo=test-repo --branch=main FakeOrg ./package.json"
       `)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`

--- a/src/commands/scan/cmd-scan-del.test.ts
+++ b/src/commands/scan/cmd-scan-del.test.ts
@@ -29,8 +29,10 @@ describe('socket scan del', async () => {
 
           Options
             --help            Print this help
+            --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown
+            --org             Force override the organization slug, overrides the default org from config
 
           Examples
             $ socket scan del FakeOrg 000aaaa1-0000-0a0a-00a0-00a0000000a0"
@@ -66,7 +68,7 @@ describe('socket scan del', async () => {
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
-          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
+          - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
           - Scan ID to delete (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/scan/cmd-scan-diff.test.ts
+++ b/src/commands/scan/cmd-scan-diff.test.ts
@@ -38,12 +38,14 @@ describe('socket scan diff', async () => {
             --depth           Max depth of JSON to display before truncating, use zero for no limit (without --json/--file)
             --file            Path to a local file where the output should be saved. Use \`-\` to force stdout.
             --help            Print this help
+            --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown
+            --org             Force override the organization slug, overrides the default org from config
 
           Examples
-            $ socket scan diff FakeCorp aaa0aa0a-aaaa-0000-0a0a-0000000a00a0 aaa1aa1a-aaaa-1111-1a1a-1111111a11a1
-            $ socket scan diff FakeCorp aaa0aa0a-aaaa-0000-0a0a-0000000a00a0 aaa1aa1a-aaaa-1111-1a1a-1111111a11a1 --json"
+            $ socket scan diff FakeOrg aaa0aa0a-aaaa-0000-0a0a-0000000a00a0 aaa1aa1a-aaaa-1111-1a1a-1111111a11a1
+            $ socket scan diff FakeOrg aaa0aa0a-aaaa-0000-0a0a-0000000a00a0 aaa1aa1a-aaaa-1111-1a1a-1111111a11a1 --json"
       `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
@@ -79,7 +81,7 @@ describe('socket scan diff', async () => {
           - Specify two Scan IDs. (\\x1b[31mmissing both Scan IDs\\x1b[39m)
             A Scan ID looks like \`aaa0aa0a-aaaa-0000-0a0a-0000000a00a0\`.
 
-          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
+          - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
           - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)

--- a/src/commands/scan/cmd-scan-list.test.ts
+++ b/src/commands/scan/cmd-scan-list.test.ts
@@ -32,8 +32,10 @@ describe('socket scan list', async () => {
             --direction       Direction option (\`desc\` or \`asc\`) - Default is \`desc\`
             --fromTime        From time - as a unix timestamp
             --help            Print this help
+            --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown
+            --org             Force override the organization slug, overrides the default org from config
             --page            Page number - Default is 1
             --perPage         Results per page - Default is 30
             --repo            Filter to show only scans with this repository name
@@ -74,7 +76,7 @@ describe('socket scan list', async () => {
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
-          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
+          - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
           - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
       `)

--- a/src/commands/scan/cmd-scan-metadata.test.ts
+++ b/src/commands/scan/cmd-scan-metadata.test.ts
@@ -29,8 +29,10 @@ describe('socket scan metadata', async () => {
 
           Options
             --help            Print this help
+            --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown
+            --org             Force override the organization slug, overrides the default org from config
 
           Examples
             $ socket scan metadata FakeOrg 000aaaa1-0000-0a0a-00a0-00a0000000a0"
@@ -66,7 +68,7 @@ describe('socket scan metadata', async () => {
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
-          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
+          - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
           - Scan ID to inspect as argument (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/scan/cmd-scan-metadata.ts
+++ b/src/commands/scan/cmd-scan-metadata.ts
@@ -3,7 +3,8 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { handleOrgScanMetadata } from './handle-scan-metadata'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
-import { getConfigValue } from '../../utils/config'
+import { isTestingV1 } from '../../utils/config'
+import { determineOrgSlug } from '../../utils/determine-org-slug'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
@@ -22,11 +23,22 @@ const config: CliCommandConfig = {
   hidden: false,
   flags: {
     ...commonFlags,
-    ...outputFlags
+    ...outputFlags,
+    interactive: {
+      type: 'boolean',
+      default: true,
+      description:
+        'Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.'
+    },
+    org: {
+      type: 'string',
+      description:
+        'Force override the organization slug, overrides the default org from config'
+    }
   },
   help: (command, config) => `
     Usage
-      $ ${command} <org slug> <scan ID>
+      $ ${command}${isTestingV1() ? '' : ' <org slug>'} <scan ID>
 
     API Token Requirements
       - Quota: 1 unit
@@ -36,7 +48,7 @@ const config: CliCommandConfig = {
       ${getFlagListOutput(config.flags, 6)}
 
     Examples
-      $ ${command} FakeOrg 000aaaa1-0000-0a0a-00a0-00a0000000a0
+      $ ${command}${isTestingV1() ? '' : ' FakeOrg'} 000aaaa1-0000-0a0a-00a0-00a0000000a0
   `
 }
 
@@ -58,17 +70,26 @@ async function run(
     parentName
   })
 
-  const { json, markdown } = cli.flags
-  const defaultOrgSlug = getConfigValue('defaultOrg')
-  const orgSlug = defaultOrgSlug || cli.input[0] || ''
-  const scanId = (defaultOrgSlug ? cli.input[0] : cli.input[1]) || ''
+  const { dryRun, interactive, json, markdown, org: orgFlag } = cli.flags
+
+  const [orgSlug, defaultOrgSlug] = await determineOrgSlug(
+    String(orgFlag || ''),
+    cli.input[0] || '',
+    !!interactive,
+    !!dryRun
+  )
+
+  const scanId =
+    (isTestingV1() || defaultOrgSlug ? cli.input[0] : cli.input[1]) || ''
   const apiToken = getDefaultToken()
 
   const wasBadInput = handleBadInput(
     {
       nook: !!defaultOrgSlug,
       test: !!orgSlug && orgSlug !== '.',
-      message: 'Org name as the first argument',
+      message: isTestingV1()
+        ? 'Org name by default setting, --org, or auto-discovered'
+        : 'Org name must be the first argument',
       pass: 'ok',
       fail:
         orgSlug === '.'

--- a/src/commands/scan/cmd-scan-report.test.ts
+++ b/src/commands/scan/cmd-scan-report.test.ts
@@ -30,9 +30,11 @@ describe('socket scan report', async () => {
           Options
             --fold            Fold reported alerts to some degree
             --help            Print this help
+            --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --license         Also report the license policy status. Default: false
             --markdown        Output result as markdown
+            --org             Force override the organization slug, overrides the default org from config
             --reportLevel     Which policy level alerts should be reported
             --short           Report only the healthy status
 
@@ -80,7 +82,7 @@ describe('socket scan report', async () => {
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
-          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
+          - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
           - Scan ID to fetch (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/scan/cmd-scan-view.test.ts
+++ b/src/commands/scan/cmd-scan-view.test.ts
@@ -31,8 +31,10 @@ describe('socket scan view', async () => {
 
           Options
             --help            Print this help
+            --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown
+            --org             Force override the organization slug, overrides the default org from config
 
           Examples
             $ socket scan view FakeOrg 000aaaa1-0000-0a0a-00a0-00a0000000a0 ./stream.txt"
@@ -68,7 +70,7 @@ describe('socket scan view', async () => {
 
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
 
-          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
+          - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
           - Scan ID to delete (\\x1b[31mmissing\\x1b[39m)
 

--- a/src/commands/threat-feed/cmd-threat-feed.test.ts
+++ b/src/commands/threat-feed/cmd-threat-feed.test.ts
@@ -21,7 +21,7 @@ describe('socket threat-feed', async () => {
         "[beta] View the threat feed
 
           Usage
-            $ socket threat-feed
+            $ socket threat-feed <org slug>
 
           API Token Requirements
             - Quota: 1 unit
@@ -36,8 +36,10 @@ describe('socket threat-feed', async () => {
             --eco             Only show threats for a particular ecosystem
             --filter          Filter what type of threats to return
             --help            Print this help
+            --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown
+            --org             Force override the organization slug, overrides the default org from config
             --page            Page token
             --perPage         Number of items per page
 
@@ -65,8 +67,8 @@ describe('socket threat-feed', async () => {
             - pypi
 
           Examples
-            $ socket threat-feed
-            $ socket threat-feed --perPage=5 --page=2 --direction=asc --filter=joke"
+            $ socket threat-feed FakeOrg
+            $ socket threat-feed FakeOrg --perPage=5 --page=2 --direction=asc --filter=joke"
       `
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
@@ -120,6 +122,89 @@ describe('socket threat-feed', async () => {
           |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket threat-feed\`, cwd: <redacted>"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
+
+  cmdit(
+    [
+      'threat-feed',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything"}'
+    ],
+    'should report missing org name in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket threat-feed\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m
+        Missing the org slug and no --org flag set. Trying to auto-discover the org now...
+        Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
+        \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)"
+      `)
+
+      expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
+    }
+  )
+
+  cmdit(
+    [
+      'threat-feed',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything", "defaultOrg": "fakeorg"}'
+    ],
+    'should accept default org in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>, default org: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket threat-feed\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    }
+  )
+
+  cmdit(
+    [
+      'threat-feed',
+      '--org',
+      'forcedorg',
+      '--dry-run',
+      '--config',
+      '{"isTestingV1": true, "apiToken":"anything"}'
+    ],
+    'should accept --org flag in v1',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket threat-feed\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
       `)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)

--- a/src/utils/determine-org-slug.ts
+++ b/src/utils/determine-org-slug.ts
@@ -1,0 +1,36 @@
+import { logger } from '@socketsecurity/registry/lib/logger'
+
+import { getConfigValue, isTestingV1 } from './config'
+import { suggestOrgSlug } from '../commands/scan/suggest-org-slug'
+
+export async function determineOrgSlug(
+  orgFlag: string,
+  firstArg: string,
+  interactive: boolean,
+  dryRun: boolean
+): Promise<[string, string]> {
+  const defaultOrgSlug = getConfigValue('defaultOrg') || ''
+  let orgSlug = String(orgFlag || defaultOrgSlug || '')
+  if (!orgSlug) {
+    if (isTestingV1()) {
+      // ask from server
+      logger.error(
+        'Missing the org slug and no --org flag set. Trying to auto-discover the org now...'
+      )
+      logger.error(
+        'Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.'
+      )
+      if (dryRun) {
+        logger.fail('Skipping auto-discovery of org in dry-run mode')
+      } else if (!interactive) {
+        logger.fail('Skipping auto-discovery of org when interactive = false')
+      } else {
+        orgSlug = (await suggestOrgSlug()) || ''
+      }
+    } else {
+      orgSlug = firstArg || ''
+    }
+  }
+
+  return [orgSlug, defaultOrgSlug]
+}


### PR DESCRIPTION
This will make all commands that currently require an orgslug as first argument, not require that in favor of either
- default org setting
- `--org` flag override
- auto-discovery by asking API

Help pages were updated to conditionally say the right thing if you optin to the new flow.