### PR TITLE
Add the `cause` field to the API error message

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -18,8 +18,10 @@ export function handleUnsuccessfulApiResponse<T extends SocketSdkOperations>(
   _name: T,
   sockSdkError: SocketSdkErrorType<T>
 ): never {
-  const message = sockSdkError.error || 'No error message returned'
-  const { status } = sockSdkError
+  const { cause, error, status } = sockSdkError
+  const message =
+    (error || 'No error message returned') +
+    (cause ? ' (reason: ' + cause + ')' : '')
   if (status === 401 || status === 403) {
     // Lazily access constants.spinner.
     const { spinner } = constants


### PR DESCRIPTION
We recently changed the SDK to no longer drop these causes but we weren't surfacing them to the user yet.

These causes are super informational when it comes to input problems.

![image](https://github.com/user-attachments/assets/d856aabb-38f4-4cc2-b4dc-143bff3930d4)

So now:

![image](https://github.com/user-attachments/assets/76a6531f-8189-4641-ad37-af933ff57f10)

Not as useful for auth errors but can't hurt either

![image](https://github.com/user-attachments/assets/73b1b380-c9e1-4143-ba53-b4b6291dbc8b)
