### PR TITLE
Fix config override in two tests, default to empty

### DIFF
--- a/src/commands/cdxgen/cmd-cdxgen.test.ts
+++ b/src/commands/cdxgen/cmd-cdxgen.test.ts
@@ -12,7 +12,10 @@ describe('socket cdxgen', async () => {
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
   cmdit(['cdxgen', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd, {
+      // Need to pass it on as env because --config will break cdxgen
+      SOCKET_CLI_CONFIG: '{}'
+    })
     expect(stdout).toMatchInlineSnapshot(
       `
       "cdxgen [command]
@@ -76,7 +79,7 @@ describe('socket cdxgen', async () => {
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
-        |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+        |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket cdxgen\`, cwd: <redacted>
       \\x1b[1m   \\x1b[31mWarning:\\x1b[39m NodeJS version 19 and lower will be \\x1b[31munsupported\\x1b[39m after April 30th, 2025.\\x1b[22m
                   Soon after the Socket CLI will require NodeJS version 20 or higher."

--- a/src/commands/config/cmd-config.test.ts
+++ b/src/commands/config/cmd-config.test.ts
@@ -78,16 +78,42 @@ describe('socket config', async () => {
 
   describe('config override', () => {
     cmdit(
-      ['config', 'get', 'apiToken', '--config', '{apiToken:invalidjson}'],
-      'should print nice error when config override cannot be parsed',
+      ['config', 'get', 'apiToken'],
+      'should print nice error when env config override cannot be parsed',
       async cmd => {
-        const { code, stderr, stdout } = await invokeNpm(entryPath, cmd, {})
+        const { code, stderr, stdout } = await invokeNpm(entryPath, cmd, {
+          // This will be parsed first. If it fails it should fallback to flag or empty.
+          SOCKET_CLI_CONFIG: '{apiToken:invalidjson}'
+        })
         expect(stdout).toMatchInlineSnapshot(`""`)
         expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
           "
              _____         _       _        /---------------
             |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
-            |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+            |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+            |_____|___|___|_,_|___|_|.dev   | Command: \`socket\`, cwd: <redacted>
+          \\x1b[1m   \\x1b[31mWarning:\\x1b[39m NodeJS version 19 and lower will be \\x1b[31munsupported\\x1b[39m after April 30th, 2025.\\x1b[22m
+                      Soon after the Socket CLI will require NodeJS version 20 or higher.
+
+          \\x1b[31m\\xd7\\x1b[39m Could not JSON parse the config override. Make sure it's a proper JSON object (double-quoted keys and strings, no unquoted \`undefined\`) and try again."
+        `)
+
+        expect(stderr.includes('Could not JSON parse')).toBe(true)
+        expect(code, 'bad config input should exit with code 2 ').toBe(2)
+      }
+    )
+
+    cmdit(
+      ['config', 'get', 'apiToken', '--config', '{apiToken:invalidjson}'],
+      'should print nice error when flag config override cannot be parsed',
+      async cmd => {
+        const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+        expect(stdout).toMatchInlineSnapshot(`""`)
+        expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+          "
+             _____         _       _        /---------------
+            |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+            |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
             |_____|___|___|_,_|___|_|.dev   | Command: \`socket\`, cwd: <redacted>
           \\x1b[1m   \\x1b[31mWarning:\\x1b[39m NodeJS version 19 and lower will be \\x1b[31munsupported\\x1b[39m after April 30th, 2025.\\x1b[22m
                       Soon after the Socket CLI will require NodeJS version 20 or higher.

--- a/src/commands/fix/cmd-fix.test.ts
+++ b/src/commands/fix/cmd-fix.test.ts
@@ -11,10 +11,13 @@ describe('socket fix', async () => {
   // Lazily access constants.rootBinPath.
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
-  cmdit(['fix', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-    expect(stdout).toMatchInlineSnapshot(
-      `
+  cmdit(
+    ['fix', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
       "Update dependencies with "fixable" Socket alerts
 
         Usage
@@ -40,20 +43,21 @@ describe('socket fix', async () => {
           --test            Verify the fix by running unit tests
           --testScript      The test script to run for each fix attempt"
     `
-    )
-    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
       "
          _____         _       _        /---------------
         |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
-        |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+        |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket fix\`, cwd: <redacted>
       \\x1b[1m   \\x1b[31mWarning:\\x1b[39m NodeJS version 19 and lower will be \\x1b[31munsupported\\x1b[39m after April 30th, 2025.\\x1b[22m
                   Soon after the Socket CLI will require NodeJS version 20 or higher."
     `)
 
-    expect(code, 'help should exit with code 2').toBe(2)
-    expect(stderr, 'banner includes base command').toContain('`socket fix`')
-  })
+      expect(code, 'help should exit with code 2').toBe(2)
+      expect(stderr, 'banner includes base command').toContain('`socket fix`')
+    }
+  )
 
   cmdit(
     ['fix', '--dry-run', '--config', '{"apiToken":"anything"}'],

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -61,6 +61,10 @@ export function overrideCachedConfig(
       throw new Error()
     }
   } catch {
+    // Force set an empty config to prevent accidentally using system settings
+    _cachedConfig = {} as LocalConfig
+    _readOnlyConfig = true
+
     return {
       ok: false,
       message:


### PR DESCRIPTION
There were two tests that were not using a config override.

The "bad config" test made me realize that the CLI should fallback to an empty config when it can't parse the config override. Otherwise it may accidentally use settings it's not supposed to use. (Admittedly that's mostly useful for tests since all it should do is print the error and exit, but...)