### PR TITLE
First step in --json hardening the failure paths

### DIFF
--- a/src/commands/analytics/cmd-analytics.test.ts
+++ b/src/commands/analytics/cmd-analytics.test.ts
@@ -73,11 +73,12 @@ describe('socket analytics', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket analytics\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - The time filter must either be 7, 30 or 90 (\\x1b[32mok\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -236,13 +237,14 @@ describe('socket analytics', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket analytics\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Scope must be "repo" or "org" (\\x1b[32mok\\x1b[39m)
 
           - When scope=repo, repo name should be the second argument (\\x1b[31mmissing\\x1b[39m)
 
-          - The time filter must either be 7, 30 or 90 (\\x1b[32mok\\x1b[39m)"
+          - The time filter must either be 7, 30 or 90 (\\x1b[32mok\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/analytics/cmd-analytics.ts
+++ b/src/commands/analytics/cmd-analytics.ts
@@ -4,7 +4,8 @@ import { displayAnalytics } from './display-analytics'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -96,6 +97,7 @@ async function run(
   })
 
   const { file, json, markdown } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
 
   // In v1 mode support:
   // - []        (no args)
@@ -138,7 +140,8 @@ async function run(
 
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       // In v1 this can't go wrong anymore since the unknown value goes to time
       nook: !isTestingV1(),
@@ -216,7 +219,7 @@ async function run(
     scope,
     time: time === '90' ? 90 : time === '30' ? 30 : 7,
     repo: repoName,
-    outputKind: json ? 'json' : markdown ? 'markdown' : 'print',
+    outputKind,
     filePath: String(file || '')
   })
 }

--- a/src/commands/analytics/fetch-org-analytics.ts
+++ b/src/commands/analytics/fetch-org-analytics.ts
@@ -1,31 +1,41 @@
-import { logger } from '@socketsecurity/registry/lib/logger'
-
-import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
+import constants from '../../constants'
+import { handleApiCall, handleFailedApiResponse } from '../../utils/api'
 import { setupSdk } from '../../utils/sdk'
 
-import type { Spinner } from '@socketsecurity/registry/lib/spinner'
+import type { CliJsonResult } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function fetchOrgAnalyticsData(
-  time: number,
-  spinner: Spinner
-): Promise<SocketSdkReturnType<'getOrgAnalytics'>['data'] | undefined> {
+  time: number
+): Promise<CliJsonResult<SocketSdkReturnType<'getOrgAnalytics'>['data']>> {
   const sockSdk = await setupSdk()
+
+  // Lazily access constants.spinner.
+  const { spinner } = constants
+
+  spinner.start(`Requesting analytics data from API...`)
+
   const result = await handleApiCall(
     sockSdk.getOrgAnalytics(time.toString()),
     'fetching analytics data'
   )
 
-  if (result.success === false) {
-    handleUnsuccessfulApiResponse('getOrgAnalytics', result)
-  }
+  spinner.successAndStop(`Received API response.`)
 
-  spinner.stop()
+  if (result.success === false) {
+    return handleFailedApiResponse('getOrgAnalytics', result)
+  }
 
   if (!result.data.length) {
-    logger.log('No analytics data is available for this organization yet.')
-    return
+    return {
+      ok: true,
+      message: 'No analytics data is available for this organization yet.',
+      data: []
+    }
   }
 
-  return result.data
+  return {
+    ok: true,
+    data: result.data
+  }
 }

--- a/src/commands/analytics/fetch-repo-analytics.ts
+++ b/src/commands/analytics/fetch-repo-analytics.ts
@@ -1,16 +1,13 @@
-import { logger } from '@socketsecurity/registry/lib/logger'
-
-import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
+import { handleApiCall, handleFailedApiResponse } from '../../utils/api'
 import { setupSdk } from '../../utils/sdk'
 
-import type { Spinner } from '@socketsecurity/registry/lib/spinner'
+import type { CliJsonResult } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function fetchRepoAnalyticsData(
   repo: string,
-  time: number,
-  spinner: Spinner
-): Promise<SocketSdkReturnType<'getRepoAnalytics'>['data'] | undefined> {
+  time: number
+): Promise<CliJsonResult<SocketSdkReturnType<'getRepoAnalytics'>['data']>> {
   const sockSdk = await setupSdk()
   const result = await handleApiCall(
     sockSdk.getRepoAnalytics(repo, time.toString()),
@@ -18,15 +15,19 @@ export async function fetchRepoAnalyticsData(
   )
 
   if (result.success === false) {
-    handleUnsuccessfulApiResponse('getRepoAnalytics', result)
+    return handleFailedApiResponse('getRepoAnalytics', result)
   }
-
-  spinner.stop()
 
   if (!result.data.length) {
-    logger.log('No analytics data is available for this organization yet.')
-    return
+    return {
+      ok: true,
+      message: 'No analytics data is available for this repository yet.',
+      data: []
+    }
   }
 
-  return result.data
+  return {
+    ok: true,
+    data: result.data
+  }
 }

--- a/src/commands/audit-log/cmd-audit-log.test.ts
+++ b/src/commands/audit-log/cmd-audit-log.test.ts
@@ -72,11 +72,12 @@ describe('socket audit-log', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket audit-log\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -129,9 +130,10 @@ describe('socket audit-log', async () => {
         Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - Org name by default setting, --org, or auto-discovered (\\x1b[31mmissing\\x1b[39m)"
+          - Org name by default setting, --org, or auto-discovered (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/audit-log/cmd-audit-log.ts
+++ b/src/commands/audit-log/cmd-audit-log.ts
@@ -5,7 +5,8 @@ import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
 import { determineOrgSlug } from '../../utils/determine-org-slug'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -98,6 +99,7 @@ async function run(
     perPage,
     type
   } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
   const logType = String(type || '')
 
   const [orgSlug] = await determineOrgSlug(
@@ -109,7 +111,8 @@ async function run(
 
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: true,
       test: !!orgSlug,
@@ -147,7 +150,7 @@ async function run(
 
   await handleAuditLog({
     orgSlug,
-    outputKind: json ? 'json' : markdown ? 'markdown' : 'print',
+    outputKind,
     page: Number(page || 0),
     perPage: Number(perPage || 0),
     logType: logType.charAt(0).toUpperCase() + logType.slice(1)

--- a/src/commands/audit-log/fetch-audit-log.ts
+++ b/src/commands/audit-log/fetch-audit-log.ts
@@ -1,7 +1,8 @@
 import constants from '../../constants'
-import { handleApiCall, handleUnsuccessfulApiResponse } from '../../utils/api'
+import { handleApiCall, handleFailedApiResponse } from '../../utils/api'
 import { setupSdk } from '../../utils/sdk'
 
+import type { CliJsonResult, OutputKind } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function fetchAuditLog({
@@ -11,12 +12,12 @@ export async function fetchAuditLog({
   page,
   perPage
 }: {
-  outputKind: 'json' | 'markdown' | 'print'
+  outputKind: OutputKind
   orgSlug: string
   page: number
   perPage: number
   logType: string
-}): Promise<SocketSdkReturnType<'getAuditLogEvents'>['data'] | void> {
+}): Promise<CliJsonResult<SocketSdkReturnType<'getAuditLogEvents'>['data']>> {
   const sockSdk = await setupSdk()
 
   // Lazily access constants.spinner.
@@ -38,11 +39,14 @@ export async function fetchAuditLog({
     `Looking up audit log for ${orgSlug}\n`
   )
 
+  spinner.successAndStop(`Received API response.`)
+
   if (!result.success) {
-    handleUnsuccessfulApiResponse('getAuditLogEvents', result)
+    return handleFailedApiResponse('getAuditLogEvents', result)
   }
 
-  spinner.stop()
-
-  return result.data
+  return {
+    ok: true,
+    data: result.data
+  }
 }

--- a/src/commands/audit-log/handle-audit-log.ts
+++ b/src/commands/audit-log/handle-audit-log.ts
@@ -1,6 +1,8 @@
 import { fetchAuditLog } from './fetch-audit-log'
 import { outputAuditLog } from './output-audit-log'
 
+import type { OutputKind } from '../../types'
+
 export async function handleAuditLog({
   logType,
   orgSlug,
@@ -8,7 +10,7 @@ export async function handleAuditLog({
   page,
   perPage
 }: {
-  outputKind: 'json' | 'markdown' | 'print'
+  outputKind: OutputKind
   orgSlug: string
   page: number
   perPage: number
@@ -21,9 +23,6 @@ export async function handleAuditLog({
     perPage,
     logType
   })
-  if (!auditLogs) {
-    return
-  }
 
   await outputAuditLog(auditLogs, {
     logType,

--- a/src/commands/audit-log/output-audit-log.test.ts
+++ b/src/commands/audit-log/output-audit-log.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import FIXTURE from './audit-fixture.json' with { type: 'json' }
 import { outputAsJson, outputAsMarkdown } from './output-audit-log'
+import { CliJsonResult } from '../../types'
 
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
@@ -11,7 +12,7 @@ describe('output-audit-log', () => {
   describe('json', () => {
     it('should return formatted json string', async () => {
       const r = await outputAsJson(
-        JSON.parse(JSON.stringify(FIXTURE.results)),
+        { ok: true, data: JSON.parse(JSON.stringify(FIXTURE)) },
         {
           logType: '',
           orgSlug: 'noorgslug',
@@ -21,70 +22,74 @@ describe('output-audit-log', () => {
       )
       expect(r).toMatchInlineSnapshot(`
         "{
-          "desc": "Audit logs for given query",
-          "generated": "<redacted>",
-          "org": "noorgslug",
-          "logType": "",
-          "page": 1,
-          "perPage": 10,
-          "logs": [
-            {
-              "event_id": "123112",
-              "created_at": "2025-04-02T01:47:26.914Z",
-              "ip_address": "",
-              "type": "updateOrganizationSetting",
-              "user_agent": "",
-              "user_email": "person@socket.dev"
-            },
-            {
-              "event_id": "122421",
-              "created_at": "2025-03-31T15:19:55.299Z",
-              "ip_address": "123.123.321.213",
-              "type": "createApiToken",
-              "user_agent": "",
-              "user_email": "person@socket.dev"
-            },
-            {
-              "event_id": "121392",
-              "created_at": "2025-03-27T16:24:36.344Z",
-              "ip_address": "",
-              "type": "updateOrganizationSetting",
-              "user_agent": "super ai .com",
-              "user_email": "person@socket.dev"
-            },
-            {
-              "event_id": "121391",
-              "created_at": "2025-03-27T16:24:33.912Z",
-              "ip_address": "",
-              "type": "updateOrganizationSetting",
-              "user_agent": "",
-              "user_email": "person@socket.dev"
-            },
-            {
-              "event_id": "120287",
-              "created_at": "2025-03-24T21:52:12.879Z",
-              "ip_address": "",
-              "type": "updateAlertTriage",
-              "user_agent": "",
-              "user_email": "person@socket.dev"
-            },
-            {
-              "event_id": "118431",
-              "created_at": "2025-03-17T15:57:29.885Z",
-              "ip_address": "",
-              "type": "updateOrganizationSetting",
-              "user_agent": "",
-              "user_email": "person@socket.dev"
-            },
-            {
-              "event_id": "116928",
-              "created_at": "2025-03-10T22:53:35.734Z",
-              "ip_address": "",
-              "type": "updateApiTokenScopes",
-              "user_agent": "",
-              "user_email": "person@socket.dev"
-            }
-          ]
+          "ok": true,
+          "data": {
+            "desc": "Audit logs for given query",
+            "generated": "<redacted>",
+            "org": "noorgslug",
+            "logType": "",
+            "page": 1,
+            "nextPage": "2",
+            "perPage": 10,
+            "logs": [
+              {
+                "event_id": "123112",
+                "created_at": "2025-04-02T01:47:26.914Z",
+                "ip_address": "",
+                "type": "updateOrganizationSetting",
+                "user_agent": "",
+                "user_email": "person@socket.dev"
+              },
+              {
+                "event_id": "122421",
+                "created_at": "2025-03-31T15:19:55.299Z",
+                "ip_address": "123.123.321.213",
+                "type": "createApiToken",
+                "user_agent": "",
+                "user_email": "person@socket.dev"
+              },
+              {
+                "event_id": "121392",
+                "created_at": "2025-03-27T16:24:36.344Z",
+                "ip_address": "",
+                "type": "updateOrganizationSetting",
+                "user_agent": "super ai .com",
+                "user_email": "person@socket.dev"
+              },
+              {
+                "event_id": "121391",
+                "created_at": "2025-03-27T16:24:33.912Z",
+                "ip_address": "",
+                "type": "updateOrganizationSetting",
+                "user_agent": "",
+                "user_email": "person@socket.dev"
+              },
+              {
+                "event_id": "120287",
+                "created_at": "2025-03-24T21:52:12.879Z",
+                "ip_address": "",
+                "type": "updateAlertTriage",
+                "user_agent": "",
+                "user_email": "person@socket.dev"
+              },
+              {
+                "event_id": "118431",
+                "created_at": "2025-03-17T15:57:29.885Z",
+                "ip_address": "",
+                "type": "updateOrganizationSetting",
+                "user_agent": "",
+                "user_email": "person@socket.dev"
+              },
+              {
+                "event_id": "116928",
+                "created_at": "2025-03-10T22:53:35.734Z",
+                "ip_address": "",
+                "type": "updateApiTokenScopes",
+                "user_agent": "",
+                "user_email": "person@socket.dev"
+              }
+            ]
+          }
         }"
       `)
     })
@@ -103,7 +108,7 @@ describe('output-audit-log', () => {
   describe('markdown', () => {
     it('should return markdown report', async () => {
       const r = await outputAsMarkdown(
-        JSON.parse(JSON.stringify(FIXTURE.results)),
+        { ok: true, data: JSON.parse(JSON.stringify(FIXTURE)) },
         {
           logType: '',
           orgSlug: 'noorgslug',
@@ -119,6 +124,7 @@ describe('output-audit-log', () => {
         - org: noorgslug
         - type filter: (none)
         - page: 1
+        - next page: 2
         - per page: 10
         - generated: <redacted>
 
@@ -137,14 +143,32 @@ describe('output-audit-log', () => {
       `)
     })
 
-    it('should return empty string on error', async () => {
-      const r = await outputAsMarkdown({} as AuditLogs, {
-        logType: '',
-        orgSlug: 'noorgslug',
-        page: 1,
-        perPage: 10
-      })
-      expect(r).toMatchInlineSnapshot(`""`)
+    it('should return error report on error', async () => {
+      const r = await outputAsMarkdown(
+        { ok: false, message: '(test) failed to get report', data: undefined },
+        {
+          logType: '',
+          orgSlug: 'noorgslug',
+          page: 1,
+          perPage: 10
+        }
+      )
+      expect(r).toMatchInlineSnapshot(`
+        "
+        # Socket Audit Logs
+
+        There was a problem fetching the audit logs:
+
+        > (test) failed to get report
+
+        Parameters:
+
+        - org: noorgslug
+        - type filter: (none)
+        - page: 1
+        - per page: 10
+        "
+      `)
     })
   })
 })

--- a/src/commands/audit-log/output-audit-log.ts
+++ b/src/commands/audit-log/output-audit-log.ts
@@ -4,14 +4,17 @@ import { debugLog, isDebug } from '@socketsecurity/registry/lib/debug'
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import constants from '../../constants'
+import { failMsgWithBadge } from '../../utils/fail-msg-with-badge'
 import { mdTable } from '../../utils/markdown'
+import { serializeResultJson } from '../../utils/serialize-result-json'
 
+import type { CliJsonResult, OutputKind } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 const { REDACTED } = constants
 
 export async function outputAuditLog(
-  auditLogs: SocketSdkReturnType<'getAuditLogEvents'>['data'],
+  auditLogs: CliJsonResult<SocketSdkReturnType<'getAuditLogEvents'>['data']>,
   {
     logType,
     orgSlug,
@@ -19,7 +22,7 @@ export async function outputAuditLog(
     page,
     perPage
   }: {
-    outputKind: 'json' | 'markdown' | 'print'
+    outputKind: OutputKind
     orgSlug: string
     page: number
     perPage: number
@@ -28,16 +31,18 @@ export async function outputAuditLog(
 ): Promise<void> {
   if (outputKind === 'json') {
     logger.log(
-      await outputAsJson(auditLogs.results, {
+      await outputAsJson(auditLogs, {
         logType,
         orgSlug,
         page,
         perPage
       })
     )
+  } else if (outputKind !== 'markdown' && !auditLogs.ok) {
+    logger.fail(failMsgWithBadge(auditLogs.message, auditLogs.data))
   } else {
     logger.log(
-      await outputAsMarkdown(auditLogs.results, {
+      await outputAsMarkdown(auditLogs, {
         logType,
         orgSlug,
         page,
@@ -48,7 +53,7 @@ export async function outputAuditLog(
 }
 
 export async function outputAsJson(
-  auditLogs: SocketSdkReturnType<'getAuditLogEvents'>['data']['results'],
+  auditLogs: CliJsonResult<SocketSdkReturnType<'getAuditLogEvents'>['data']>,
   {
     logType,
     orgSlug,
@@ -61,55 +66,45 @@ export async function outputAsJson(
     logType: string
   }
 ): Promise<string> {
-  let json
-  try {
-    json = JSON.stringify(
-      {
-        desc: 'Audit logs for given query',
-        generated: process.env['VITEST'] ? REDACTED : new Date().toISOString(),
-        org: orgSlug,
-        logType,
-        page,
-        perPage,
-        logs: auditLogs.map(log => {
-          // Note: The subset is pretty arbitrary
-          const {
-            created_at,
-            event_id,
-            ip_address,
-            type,
-            user_agent,
-            user_email
-          } = log
-          return {
-            event_id,
-            created_at,
-            ip_address,
-            type,
-            user_agent,
-            user_email
-          }
-        })
-      },
-      null,
-      2
-    )
-  } catch (e) {
-    process.exitCode = 1
-    logger.fail(
-      'There was a problem converting the logs to JSON, please try without the `--json` flag'
-    )
-    if (isDebug()) {
-      debugLog('Error:\n', e)
-    }
-    return '{}'
+  if (!auditLogs.ok) {
+    return serializeResultJson(auditLogs)
   }
 
-  return json
+  return serializeResultJson({
+    ok: true,
+    data: {
+      desc: 'Audit logs for given query',
+      generated: process.env['VITEST'] ? REDACTED : new Date().toISOString(),
+      org: orgSlug,
+      logType,
+      page,
+      nextPage: auditLogs.data.nextPage,
+      perPage,
+      logs: auditLogs.data.results.map(log => {
+        // Note: The subset is pretty arbitrary
+        const {
+          created_at,
+          event_id,
+          ip_address,
+          type,
+          user_agent,
+          user_email
+        } = log
+        return {
+          event_id,
+          created_at,
+          ip_address,
+          type,
+          user_agent,
+          user_email
+        }
+      })
+    }
+  })
 }
 
 export async function outputAsMarkdown(
-  auditLogs: SocketSdkReturnType<'getAuditLogEvents'>['data']['results'],
+  auditLogs: CliJsonResult<SocketSdkReturnType<'getAuditLogEvents'>['data']>,
   {
     logType,
     orgSlug,
@@ -122,8 +117,33 @@ export async function outputAsMarkdown(
     logType: string
   }
 ): Promise<string> {
+  if (!auditLogs.ok) {
+    return `
+# Socket Audit Logs
+
+There was a problem fetching the audit logs:
+
+> ${auditLogs.message}
+${
+  auditLogs.data
+    ? '>\n' +
+      auditLogs.data
+        .split('\n')
+        .map(s => `> ${s}\n`)
+        .join('')
+    : ''
+}
+Parameters:
+
+- org: ${orgSlug}
+- type filter: ${logType || '(none)'}
+- page: ${page}
+- per page: ${perPage}
+`
+  }
+
   try {
-    const table = mdTable<any>(auditLogs, [
+    const table = mdTable<any>(auditLogs.data.results, [
       'event_id',
       'created_at',
       'type',
@@ -139,6 +159,7 @@ These are the Socket.dev audit logs as per requested query.
 - org: ${orgSlug}
 - type filter: ${logType || '(none)'}
 - page: ${page}
+- next page: ${auditLogs.data.nextPage}
 - per page: ${perPage}
 - generated: ${process.env['VITEST'] ? REDACTED : new Date().toISOString()}
 

--- a/src/commands/ci/fetch-default-org-slug.ts
+++ b/src/commands/ci/fetch-default-org-slug.ts
@@ -1,10 +1,11 @@
 import { debugLog } from '@socketsecurity/registry/lib/debug'
 import { logger } from '@socketsecurity/registry/lib/logger'
 
-import { CliJsonResult } from '../../types'
 import { handleApiCall } from '../../utils/api'
 import { getConfigValue } from '../../utils/config'
 import { setupSdk } from '../../utils/sdk'
+
+import type { CliJsonResult } from '../../types'
 
 // Use the config defaultOrg when set, otherwise discover from remote
 export async function getDefaultOrgSlug(): Promise<CliJsonResult<string>> {

--- a/src/commands/ci/fetch-default-org-slug.ts
+++ b/src/commands/ci/fetch-default-org-slug.ts
@@ -1,11 +1,13 @@
+import { debugLog } from '@socketsecurity/registry/lib/debug'
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import { CliJsonResult } from '../../types'
 import { handleApiCall } from '../../utils/api'
 import { getConfigValue } from '../../utils/config'
 import { setupSdk } from '../../utils/sdk'
 
 // Use the config defaultOrg when set, otherwise discover from remote
-export async function getDefaultOrgSlug(): Promise<string | void> {
+export async function getDefaultOrgSlug(): Promise<CliJsonResult<string>> {
   let defaultOrg = getConfigValue('defaultOrg')
   if (defaultOrg) {
     logger.info(`Using default org: ${defaultOrg}`)
@@ -18,38 +20,42 @@ export async function getDefaultOrgSlug(): Promise<string | void> {
     // Ignore a failed request here. It was not the primary goal of
     // running this command and reporting it only leads to end-user confusion.
     if (!result.success) {
-      logger.fail(
-        'Failed to fetch default organization from API. Unable to continue.'
-      )
       process.exitCode = 1
-      return
+      return {
+        ok: false,
+        message: result.error,
+        data: `Failed to fetch default organization from API. Unable to continue.${result.cause ? ` ( Reason given: ${result.cause} )` : ''}`
+      }
     }
+
     const orgs = result.data.organizations
     const keys = Object.keys(orgs)
 
     if (!keys[0]) {
-      logger.fail(
-        'Could not find default organization for the current API token. Unable to continue.'
-      )
       process.exitCode = 1
-      return
+      return {
+        ok: false,
+        message: 'Failed to establish identity',
+        data: `API did not return any organization associated with the current API token. Unable to continue.`
+      }
     }
 
     const slug = (keys[0] in orgs && orgs?.[keys[0]]?.name) ?? undefined
 
     if (slug) {
       defaultOrg = slug
-      logger.info(`Resolved org to: ${defaultOrg}`)
+      debugLog(`Resolved org to: ${defaultOrg}`)
     }
   }
 
   if (!defaultOrg) {
-    logger.fail(
-      'Could not find the default organization for the current API token. Unable to continue.'
-    )
     process.exitCode = 1
-    return
+    return {
+      ok: false,
+      message: 'Failed to establish identity',
+      data: `Was unable to determine the default organization for the current API token. Unable to continue.`
+    }
   }
 
-  return defaultOrg
+  return { ok: true, data: defaultOrg }
 }

--- a/src/commands/ci/handle-ci.ts
+++ b/src/commands/ci/handle-ci.ts
@@ -1,4 +1,7 @@
+import { logger } from '@socketsecurity/registry/lib/logger'
+
 import { getDefaultOrgSlug } from './fetch-default-org-slug'
+import { serializeResultJson } from '../../utils/serialize-result-json'
 import { handleCreateNewScan } from '../scan/handle-create-new-scan'
 
 export async function handleCI(): Promise<void> {
@@ -6,8 +9,10 @@ export async function handleCI(): Promise<void> {
   //   description: 'Alias for "report create --view --strict"',
   //     argv: ['report', 'create', '--view', '--strict']
   // }
-  const orgSlug = await getDefaultOrgSlug()
-  if (!orgSlug) {
+  const result = await getDefaultOrgSlug()
+  if (!result.ok) {
+    // Always assume json mode
+    logger.log(serializeResultJson(result))
     return
   }
 
@@ -21,7 +26,7 @@ export async function handleCI(): Promise<void> {
     cwd: process.cwd(),
     defaultBranch: false,
     interactive: false,
-    orgSlug,
+    orgSlug: result.data,
     outputKind: 'json',
     pendingHead: true, // when true, requires branch name set, tmp false
     pullRequest: 0,

--- a/src/commands/config/cmd-config-auto.ts
+++ b/src/commands/config/cmd-config-auto.ts
@@ -4,7 +4,8 @@ import { handleConfigAuto } from './handle-config-auto'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { supportedConfigKeys } from '../../utils/config'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -63,9 +64,13 @@ async function run(
   })
 
   const { json, markdown } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
+
   const [key = ''] = cli.input
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
+    outputKind,
     {
       test: supportedConfigKeys.has(key as keyof LocalConfig) && key !== 'test',
       message: 'Config key should be the first arg',
@@ -92,6 +97,6 @@ async function run(
 
   await handleConfigAuto({
     key: key as keyof LocalConfig,
-    outputKind: json ? 'json' : markdown ? 'markdown' : 'text'
+    outputKind
   })
 }

--- a/src/commands/config/cmd-config-auto.ts
+++ b/src/commands/config/cmd-config-auto.ts
@@ -70,7 +70,6 @@ async function run(
 
   const wasBadInput = checkCommandInput(
     outputKind,
-    outputKind,
     {
       test: supportedConfigKeys.has(key as keyof LocalConfig) && key !== 'test',
       message: 'Config key should be the first arg',

--- a/src/commands/config/cmd-config-get.test.ts
+++ b/src/commands/config/cmd-config-get.test.ts
@@ -69,9 +69,10 @@ describe('socket config get', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket config get\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - Config key should be the first arg (\\x1b[31mmissing\\x1b[39m)"
+          - Config key should be the first arg (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/config/cmd-config-get.ts
+++ b/src/commands/config/cmd-config-get.ts
@@ -4,7 +4,8 @@ import { handleConfigGet } from './handle-config-get'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { supportedConfigKeys } from '../../utils/config'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -58,9 +59,12 @@ async function run(
   })
 
   const { json, markdown } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
+
   const [key = ''] = cli.input
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       test: supportedConfigKeys.has(key as keyof LocalConfig) || key === 'test',
       message: 'Config key should be the first arg',
@@ -87,6 +91,6 @@ async function run(
 
   await handleConfigGet({
     key: key as keyof LocalConfig,
-    outputKind: json ? 'json' : markdown ? 'markdown' : 'text'
+    outputKind
   })
 }

--- a/src/commands/config/cmd-config-list.ts
+++ b/src/commands/config/cmd-config-list.ts
@@ -4,7 +4,8 @@ import { outputConfigList } from './output-config-list'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { supportedConfigKeys } from '../../utils/config'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -62,8 +63,9 @@ async function run(
   })
 
   const { full, json, markdown } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
 
-  const wasBadInput = handleBadInput({
+  const wasBadInput = checkCommandInput(outputKind, {
     nook: true,
     test: !json || !markdown,
     message:
@@ -82,6 +84,6 @@ async function run(
 
   await outputConfigList({
     full: !!full,
-    outputKind: json ? 'json' : markdown ? 'markdown' : 'text'
+    outputKind
   })
 }

--- a/src/commands/config/cmd-config-set.test.ts
+++ b/src/commands/config/cmd-config-set.test.ts
@@ -74,11 +74,12 @@ describe('socket config get', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket config set\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Config key should be the first arg (\\x1b[31mmissing\\x1b[39m)
 
-          - Key value should be the remaining args (use \`unset\` to unset a value) (\\x1b[31mmissing\\x1b[39m)"
+          - Key value should be the remaining args (use \`unset\` to unset a value) (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/config/cmd-config-set.ts
+++ b/src/commands/config/cmd-config-set.ts
@@ -4,7 +4,8 @@ import { handleConfigSet } from './handle-config-set'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { supportedConfigKeys } from '../../utils/config'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -63,10 +64,13 @@ async function run(
   })
 
   const { json, markdown } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
+
   const [key = '', ...rest] = cli.input
   const value = rest.join(' ')
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       test: key === 'test' || supportedConfigKeys.has(key as keyof LocalConfig),
       message: 'Config key should be the first arg',
@@ -100,7 +104,7 @@ async function run(
 
   await handleConfigSet({
     key: key as keyof LocalConfig,
-    outputKind: json ? 'json' : markdown ? 'markdown' : 'text',
+    outputKind,
     value
   })
 }

--- a/src/commands/config/cmd-config-unset.test.ts
+++ b/src/commands/config/cmd-config-unset.test.ts
@@ -69,9 +69,10 @@ describe('socket config unset', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket config unset\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - Config key should be the first arg (\\x1b[31mmissing\\x1b[39m)"
+          - Config key should be the first arg (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/config/cmd-config-unset.ts
+++ b/src/commands/config/cmd-config-unset.ts
@@ -4,7 +4,8 @@ import { handleConfigUnset } from './handle-config-unset'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { supportedConfigKeys } from '../../utils/config'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -58,9 +59,12 @@ async function run(
   })
 
   const { json, markdown } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
+
   const [key = ''] = cli.input
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       test: key === 'test' || supportedConfigKeys.has(key as keyof LocalConfig),
       message: 'Config key should be the first arg',
@@ -87,6 +91,6 @@ async function run(
 
   await handleConfigUnset({
     key: key as keyof LocalConfig,
-    outputKind: json ? 'json' : markdown ? 'markdown' : 'text'
+    outputKind
   })
 }

--- a/src/commands/config/handle-config-auto.ts
+++ b/src/commands/config/handle-config-auto.ts
@@ -1,6 +1,7 @@
 import { discoverConfigValue } from './discover-config-value'
 import { outputConfigAuto } from './output-config-auto'
 
+import type { OutputKind } from '../../types'
 import type { LocalConfig } from '../../utils/config'
 
 export async function handleConfigAuto({
@@ -8,7 +9,7 @@ export async function handleConfigAuto({
   outputKind
 }: {
   key: keyof LocalConfig
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 }) {
   const result = await discoverConfigValue(key)
 

--- a/src/commands/config/handle-config-get.ts
+++ b/src/commands/config/handle-config-get.ts
@@ -1,6 +1,7 @@
 import { outputConfigGet } from './output-config-get'
 import { getConfigValue, isReadOnlyConfig } from '../../utils/config'
 
+import type { OutputKind } from '../../types'
 import type { LocalConfig } from '../../utils/config'
 
 export async function handleConfigGet({
@@ -8,7 +9,7 @@ export async function handleConfigGet({
   outputKind
 }: {
   key: keyof LocalConfig
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 }) {
   const value = getConfigValue(key)
   const readOnly = isReadOnlyConfig()

--- a/src/commands/config/handle-config-set.ts
+++ b/src/commands/config/handle-config-set.ts
@@ -1,6 +1,7 @@
 import { outputConfigSet } from './output-config-set'
 import { isReadOnlyConfig, updateConfigValue } from '../../utils/config'
 
+import type { OutputKind } from '../../types'
 import type { LocalConfig } from '../../utils/config'
 
 export async function handleConfigSet({
@@ -9,7 +10,7 @@ export async function handleConfigSet({
   value
 }: {
   key: keyof LocalConfig
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
   value: string
 }) {
   updateConfigValue(key, value)

--- a/src/commands/config/handle-config-unset.ts
+++ b/src/commands/config/handle-config-unset.ts
@@ -1,6 +1,7 @@
 import { outputConfigUnset } from './output-config-unset'
 import { updateConfigValue } from '../../utils/config'
 
+import type { OutputKind } from '../../types'
 import type { LocalConfig } from '../../utils/config'
 
 export async function handleConfigUnset({
@@ -8,7 +9,7 @@ export async function handleConfigUnset({
   outputKind
 }: {
   key: keyof LocalConfig
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 }) {
   updateConfigValue(key, undefined)
   await outputConfigUnset(key, outputKind)

--- a/src/commands/config/output-config-auto.ts
+++ b/src/commands/config/output-config-auto.ts
@@ -3,6 +3,8 @@ import { select } from '@socketsecurity/registry/lib/prompts'
 
 import { LocalConfig, updateConfigValue } from '../../utils/config'
 
+import type { OutputKind } from '../../types'
+
 export async function outputConfigAuto(
   key: keyof LocalConfig,
   {
@@ -14,7 +16,7 @@ export async function outputConfigAuto(
     value: unknown
     message: string
   },
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 ) {
   if (outputKind === 'json') {
     logger.log(JSON.stringify({ success, message, result: { key, value } }))

--- a/src/commands/config/output-config-get.ts
+++ b/src/commands/config/output-config-get.ts
@@ -2,11 +2,13 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { LocalConfig } from '../../utils/config'
 
+import type { OutputKind } from '../../types'
+
 export async function outputConfigGet(
   key: keyof LocalConfig,
   value: unknown,
   readOnly: boolean, // Is config in read-only mode? (Overrides applied)
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 ) {
   if (outputKind === 'json') {
     logger.log(

--- a/src/commands/config/output-config-list.ts
+++ b/src/commands/config/output-config-list.ts
@@ -7,12 +7,14 @@ import {
   supportedConfigKeys
 } from '../../utils/config'
 
+import type { OutputKind } from '../../types'
+
 export async function outputConfigList({
   full,
   outputKind
 }: {
   full: boolean
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 }) {
   const readOnly = isReadOnlyConfig()
   if (outputKind === 'json') {

--- a/src/commands/config/output-config-set.ts
+++ b/src/commands/config/output-config-set.ts
@@ -1,12 +1,13 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import type { OutputKind } from '../../types'
 import type { LocalConfig } from '../../utils/config'
 
 export async function outputConfigSet(
   key: keyof LocalConfig,
   _value: string,
   readOnly: boolean,
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 ) {
   if (outputKind === 'json') {
     logger.log(

--- a/src/commands/config/output-config-unset.ts
+++ b/src/commands/config/output-config-unset.ts
@@ -1,10 +1,11 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import type { OutputKind } from '../../types'
 import type { LocalConfig } from '../../utils/config'
 
 export async function outputConfigUnset(
   key: keyof LocalConfig,
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 ) {
   if (outputKind === 'json') {
     logger.log(

--- a/src/commands/dependencies/cmd-dependencies.ts
+++ b/src/commands/dependencies/cmd-dependencies.ts
@@ -3,7 +3,8 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { handleDependencies } from './handle-dependencies'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -68,10 +69,12 @@ async function run(
   })
 
   const { json, limit, markdown, offset } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
 
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: true,
       test: !json || !markdown,
@@ -101,6 +104,6 @@ async function run(
   await handleDependencies({
     limit: Number(limit || 0) || 0,
     offset: Number(offset || 0) || 0,
-    outputKind: json ? 'json' : markdown ? 'markdown' : 'text'
+    outputKind
   })
 }

--- a/src/commands/dependencies/handle-dependencies.ts
+++ b/src/commands/dependencies/handle-dependencies.ts
@@ -1,6 +1,8 @@
 import { fetchDependencies } from './fetch-dependencies'
 import { outputDependencies } from './output-dependencies'
 
+import type { OutputKind } from '../../types'
+
 export async function handleDependencies({
   limit,
   offset,
@@ -8,7 +10,7 @@ export async function handleDependencies({
 }: {
   limit: number
   offset: number
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 }): Promise<void> {
   const data = await fetchDependencies({ limit, offset })
   if (!data) {

--- a/src/commands/dependencies/output-dependencies.ts
+++ b/src/commands/dependencies/output-dependencies.ts
@@ -4,6 +4,7 @@ import colors from 'yoctocolors-cjs'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import type { OutputKind } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function outputDependencies(
@@ -15,7 +16,7 @@ export async function outputDependencies(
   }: {
     limit: number
     offset: number
-    outputKind: 'json' | 'markdown' | 'text'
+    outputKind: OutputKind
   }
 ): Promise<void> {
   if (outputKind === 'json') {

--- a/src/commands/diff-scan/cmd-diff-scan-get.test.ts
+++ b/src/commands/diff-scan/cmd-diff-scan-get.test.ts
@@ -74,14 +74,15 @@ describe('socket diff-scan get', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Specify a before and after scan ID. (\\x1b[31mmissing before and after\\x1b[39m)
             The args are expecting a full \`aaa0aa0a-aaaa-0000-0a0a-0000000a00a0\` scan ID.
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/diff-scan/cmd-diff-scan-get.ts
+++ b/src/commands/diff-scan/cmd-diff-scan-get.ts
@@ -4,7 +4,8 @@ import { handleDiffScan } from './handle-diff-scan'
 import constants from '../../constants'
 import { commonFlags } from '../../flags'
 import { getConfigValue, isTestingV1 } from '../../utils/config'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -97,13 +98,15 @@ async function run(
   })
 
   const { after, before, depth, file, json, markdown } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
 
   const defaultOrgSlug = getConfigValue('defaultOrg')
   const orgSlug = defaultOrgSlug || cli.input[0] || ''
 
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       test: !!(before && after),
       message:
@@ -158,7 +161,7 @@ async function run(
     after: String(after || ''),
     depth: Number(depth),
     orgSlug,
-    outputKind: json ? 'json' : markdown ? 'markdown' : 'text',
+    outputKind,
     file: String(file || '')
   })
 }

--- a/src/commands/diff-scan/handle-diff-scan.ts
+++ b/src/commands/diff-scan/handle-diff-scan.ts
@@ -1,6 +1,8 @@
 import { fetchDiffScan } from './fetch-diff-scan'
 import { outputDiffScan } from './output-diff-scan'
 
+import type { OutputKind } from '../../types'
+
 export async function handleDiffScan({
   after,
   before,
@@ -14,7 +16,7 @@ export async function handleDiffScan({
   depth: number
   file: string
   orgSlug: string
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 }): Promise<void> {
   const data = await fetchDiffScan({
     after,

--- a/src/commands/diff-scan/output-diff-scan.ts
+++ b/src/commands/diff-scan/output-diff-scan.ts
@@ -5,6 +5,7 @@ import colors from 'yoctocolors-cjs'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import type { OutputKind } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function outputDiffScan(
@@ -16,7 +17,7 @@ export async function outputDiffScan(
   }: {
     depth: number
     file: string
-    outputKind: 'json' | 'markdown' | 'text'
+    outputKind: OutputKind
   }
 ): Promise<void> {
   const dashboardUrl = result.diff_report_url

--- a/src/commands/fix/cmd-fix.ts
+++ b/src/commands/fix/cmd-fix.ts
@@ -6,7 +6,8 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { runFix } from './run-fix'
 import constants from '../../constants'
 import { commonFlags } from '../../flags'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { RangeStyles } from '../../utils/semver'
@@ -99,7 +100,10 @@ async function run(
     parentName
   })
 
-  const wasBadInput = handleBadInput({
+  const { json, markdown } = cli.flags
+  const outputKind = getOutputKind(json, markdown) // TODO: impl json/md further
+
+  const wasBadInput = checkCommandInput(outputKind, {
     test: RangeStyles.includes(cli.flags['rangeStyle'] as string),
     message: `Expecting range style of ${joinOr(RangeStyles)}`,
     pass: 'ok',

--- a/src/commands/info/cmd-info.test.ts
+++ b/src/commands/info/cmd-info.test.ts
@@ -63,11 +63,12 @@ describe('socket info', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket info\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Expecting a package name (\\x1b[31mmissing\\x1b[39m)
 
-          - Can only accept one package at a time (\\x1b[31mgot 0\\x1b[39m)"
+          - Can only accept one package at a time (\\x1b[31mgot 0\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/info/cmd-info.ts
+++ b/src/commands/info/cmd-info.ts
@@ -4,7 +4,8 @@ import { handlePackageInfo } from './handle-package-info'
 import constants from '../../constants'
 import { commonFlags, outputFlags, validationFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -58,9 +59,12 @@ async function run(
   })
 
   const { all, json, markdown, strict } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
+
   const [rawPkgName = ''] = cli.input
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       test: !!rawPkgName,
       message: 'Expecting a package name',
@@ -101,7 +105,7 @@ async function run(
   await handlePackageInfo({
     commandName: `${parentName} ${config.commandName}`,
     includeAllIssues: Boolean(all),
-    outputKind: json ? 'json' : markdown ? 'markdown' : 'print',
+    outputKind,
     pkgName,
     pkgVersion,
     strict: Boolean(strict)

--- a/src/commands/info/handle-package-info.ts
+++ b/src/commands/info/handle-package-info.ts
@@ -5,6 +5,7 @@ import { hasKeys } from '@socketsecurity/registry/lib/objects'
 import { fetchPackageInfo } from './fetch-package-info'
 import { outputPackageInfo } from './output-package-info'
 
+import type { OutputKind } from '../../types'
 import type { SocketSdkAlert } from '../../utils/alert/severity'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
@@ -24,7 +25,7 @@ export async function handlePackageInfo({
 }: {
   commandName: string
   includeAllIssues: boolean
-  outputKind: 'json' | 'markdown' | 'print'
+  outputKind: OutputKind
   pkgName: string
   pkgVersion: string
   strict: boolean

--- a/src/commands/info/output-package-info.ts
+++ b/src/commands/info/output-package-info.ts
@@ -13,6 +13,7 @@ import {
 } from '../../utils/socket-url'
 
 import type { PackageData } from './handle-package-info'
+import type { OutputKind } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 const { NPM } = constants
@@ -74,7 +75,7 @@ export function outputPackageInfo(
     pkgVersion
   }: {
     commandName: string
-    outputKind: 'json' | 'markdown' | 'print'
+    outputKind: OutputKind
     pkgName: string
     pkgVersion: string
     includeAllIssues?: boolean | undefined

--- a/src/commands/manifest/cmd-manifest-auto.ts
+++ b/src/commands/manifest/cmd-manifest-auto.ts
@@ -66,6 +66,7 @@ async function run(
   })
   const verbose = !!cli.flags['verbose']
   const cwd = (cli.flags['cwd'] as string) ?? process.cwd()
+  // TODO: impl json/md
 
   if (verbose) {
     logger.group('- ', parentName, config.commandName, ':')

--- a/src/commands/manifest/cmd-manifest-conda.test.ts
+++ b/src/commands/manifest/cmd-manifest-conda.test.ts
@@ -67,9 +67,10 @@ describe('socket manifest conda', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest conda\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - The FILE arg is required (\\x1b[31mmissing\\x1b[39m)"
+          - The FILE arg is required (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/manifest/cmd-manifest-conda.ts
+++ b/src/commands/manifest/cmd-manifest-conda.ts
@@ -3,7 +3,8 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { handleManifestConda } from './handle-manifest-conda'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -74,6 +75,8 @@ async function run(
     out = '-',
     verbose = false
   } = cli.flags
+  const outputKind = getOutputKind(json, markdown) // TODO: impl json/md further
+
   const [target = ''] = cli.input
 
   if (verbose) {
@@ -85,7 +88,8 @@ async function run(
     logger.groupEnd()
   }
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       test: !!target,
       message: 'The FILE arg is required',

--- a/src/commands/manifest/cmd-manifest-gradle.test.ts
+++ b/src/commands/manifest/cmd-manifest-gradle.test.ts
@@ -85,9 +85,10 @@ describe('socket manifest gradle', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest gradle\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - The DIR arg is required (\\x1b[31mmissing\\x1b[39m)"
+          - The DIR arg is required (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/manifest/cmd-manifest-gradle.ts
+++ b/src/commands/manifest/cmd-manifest-gradle.ts
@@ -5,7 +5,8 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { convertGradleToMaven } from './convert_gradle_to_maven'
 import constants from '../../constants'
 import { commonFlags } from '../../flags'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -97,6 +98,8 @@ async function run(
   })
 
   const verbose = Boolean(cli.flags['verbose'])
+  const { json, markdown } = cli.flags
+  const outputKind = getOutputKind(json, markdown) // TODO: impl json/md further
 
   if (verbose) {
     logger.group('- ', parentName, config.commandName, ':')
@@ -112,7 +115,8 @@ async function run(
   //       try, store contents in a file in some folder, target that folder... what
   //       would the file name be?
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       test: !!target && target !== '-',
       message: 'The DIR arg is required',

--- a/src/commands/manifest/cmd-manifest-kotlin.test.ts
+++ b/src/commands/manifest/cmd-manifest-kotlin.test.ts
@@ -85,9 +85,10 @@ describe('socket manifest kotlin', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest kotlin\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - The DIR arg is required (\\x1b[31mmissing\\x1b[39m)"
+          - The DIR arg is required (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/manifest/cmd-manifest-kotlin.ts
+++ b/src/commands/manifest/cmd-manifest-kotlin.ts
@@ -5,7 +5,8 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { convertGradleToMaven } from './convert_gradle_to_maven'
 import constants from '../../constants'
 import { commonFlags } from '../../flags'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -102,6 +103,8 @@ async function run(
   })
 
   const verbose = Boolean(cli.flags['verbose'])
+  const { json, markdown } = cli.flags
+  const outputKind = getOutputKind(json, markdown) // TODO: impl json/md further
 
   if (verbose) {
     logger.group('- ', parentName, config.commandName, ':')
@@ -117,7 +120,8 @@ async function run(
   //       try, store contents in a file in some folder, target that folder... what
   //       would the file name be?
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       test: !!target && target !== '-',
       message: 'The DIR arg is required',

--- a/src/commands/manifest/cmd-manifest-scala.test.ts
+++ b/src/commands/manifest/cmd-manifest-scala.test.ts
@@ -91,9 +91,10 @@ describe('socket manifest scala', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest scala\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - The DIR arg is required (\\x1b[31mmissing\\x1b[39m)"
+          - The DIR arg is required (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/manifest/cmd-manifest-scala.ts
+++ b/src/commands/manifest/cmd-manifest-scala.ts
@@ -3,7 +3,8 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { convertSbtToMaven } from './convert_sbt_to_maven'
 import constants from '../../constants'
 import { commonFlags } from '../../flags'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -105,6 +106,8 @@ async function run(
   })
 
   const verbose = Boolean(cli.flags['verbose'])
+  const { json, markdown } = cli.flags
+  const outputKind = getOutputKind(json, markdown) // TODO: impl json/md further
 
   if (verbose) {
     logger.group('- ', parentName, config.commandName, ':')
@@ -120,7 +123,8 @@ async function run(
   //       try, store contents in a file in some folder, target that folder... what
   //       would the file name be?
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       test: !!target && target !== '-',
       message: 'The DIR arg is required',

--- a/src/commands/manifest/handle-manifest-conda.ts
+++ b/src/commands/manifest/handle-manifest-conda.ts
@@ -3,10 +3,12 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { convertCondaToRequirements } from './convert-conda-to-requirements'
 import { outputRequirements } from './output-requirements'
 
+import type { OutputKind } from '../../types'
+
 export async function handleManifestConda(
   target: string,
   out: string,
-  outputKind: 'json' | 'markdown' | 'text',
+  outputKind: OutputKind,
   cwd: string,
   verbose: boolean
 ): Promise<void> {

--- a/src/commands/manifest/output-requirements.ts
+++ b/src/commands/manifest/output-requirements.ts
@@ -2,9 +2,11 @@ import fs from 'node:fs'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import type { OutputKind } from '../../types'
+
 export async function outputRequirements(
   data: { contents: string; pip: string },
-  outputKind: 'json' | 'markdown' | 'text',
+  outputKind: OutputKind,
   out: string
 ) {
   if (outputKind === 'json') {

--- a/src/commands/oops/cmd-oops.ts
+++ b/src/commands/oops/cmd-oops.ts
@@ -41,6 +41,8 @@ async function run(
     parentName
   })
 
+  // TODO: impl json/md
+
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAIL_TEXT)
     return

--- a/src/commands/optimize/cmd-optimize.ts
+++ b/src/commands/optimize/cmd-optimize.ts
@@ -58,6 +58,8 @@ async function run(
     parentName
   })
 
+  // TODO: impl json/md
+
   const cwd = process.cwd()
 
   if (cli.flags['dryRun']) {

--- a/src/commands/organization/cmd-organization-list.ts
+++ b/src/commands/organization/cmd-organization-list.ts
@@ -3,7 +3,8 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { handleOrganizationList } from './handle-organization-list'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -52,9 +53,12 @@ async function run(
   })
 
   const { json, markdown } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
+
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: true,
       test: !json || !markdown,
@@ -81,5 +85,5 @@ async function run(
     return
   }
 
-  await handleOrganizationList(json ? 'json' : markdown ? 'markdown' : 'text')
+  await handleOrganizationList(outputKind)
 }

--- a/src/commands/organization/cmd-organization-policy-license.test.ts
+++ b/src/commands/organization/cmd-organization-policy-license.test.ts
@@ -70,11 +70,12 @@ describe('socket organization policy license', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy license\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if input bad').toBe(2)
@@ -131,9 +132,10 @@ describe('socket organization policy license', async () => {
         Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - Org name by default setting, --org, or auto-discovered (\\x1b[31mmissing\\x1b[39m)"
+          - Org name by default setting, --org, or auto-discovered (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/organization/cmd-organization-policy-license.ts
+++ b/src/commands/organization/cmd-organization-policy-license.ts
@@ -5,7 +5,8 @@ import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
 import { determineOrgSlug } from '../../utils/determine-org-slug'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -73,6 +74,7 @@ async function run(
   })
 
   const { dryRun, interactive, json, markdown, org: orgFlag } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
 
   const [orgSlug] = await determineOrgSlug(
     String(orgFlag || ''),
@@ -83,7 +85,8 @@ async function run(
 
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: true,
       test: !!orgSlug,
@@ -118,8 +121,5 @@ async function run(
     return
   }
 
-  await handleLicensePolicy(
-    orgSlug,
-    json ? 'json' : markdown ? 'markdown' : 'text'
-  )
+  await handleLicensePolicy(orgSlug, outputKind)
 }

--- a/src/commands/organization/cmd-organization-policy-security.test.ts
+++ b/src/commands/organization/cmd-organization-policy-security.test.ts
@@ -70,11 +70,12 @@ describe('socket organization policy security', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy security\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if input bad').toBe(2)
@@ -131,9 +132,10 @@ describe('socket organization policy security', async () => {
         Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)"
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/organization/cmd-organization-policy-security.ts
+++ b/src/commands/organization/cmd-organization-policy-security.ts
@@ -5,7 +5,8 @@ import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
 import { determineOrgSlug } from '../../utils/determine-org-slug'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -73,6 +74,7 @@ async function run(
   })
 
   const { dryRun, interactive, json, markdown, org: orgFlag } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
 
   const [orgSlug] = await determineOrgSlug(
     String(orgFlag || ''),
@@ -83,7 +85,8 @@ async function run(
 
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: true,
       test: !!orgSlug,
@@ -116,8 +119,5 @@ async function run(
     return
   }
 
-  await handleSecurityPolicy(
-    orgSlug,
-    json ? 'json' : markdown ? 'markdown' : 'text'
-  )
+  await handleSecurityPolicy(orgSlug, outputKind)
 }

--- a/src/commands/organization/cmd-organization-quota.ts
+++ b/src/commands/organization/cmd-organization-quota.ts
@@ -3,7 +3,8 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { handleQuota } from './handle-quota'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -49,9 +50,12 @@ async function run(
 
   const json = Boolean(cli.flags['json'])
   const markdown = Boolean(cli.flags['markdown'])
+  const outputKind = getOutputKind(json, markdown)
+
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: true,
       test: !json || !markdown,
@@ -77,5 +81,5 @@ async function run(
     return
   }
 
-  await handleQuota(json ? 'json' : markdown ? 'markdown' : 'text')
+  await handleQuota(outputKind)
 }

--- a/src/commands/organization/handle-license-policy.ts
+++ b/src/commands/organization/handle-license-policy.ts
@@ -1,9 +1,11 @@
 import { fetchLicensePolicy } from './fetch-license-policy'
 import { outputLicensePolicy } from './output-license-policy'
 
+import type { OutputKind } from '../../types'
+
 export async function handleLicensePolicy(
   orgSlug: string,
-  outputKind: 'text' | 'json' | 'markdown'
+  outputKind: OutputKind
 ): Promise<void> {
   const data = await fetchLicensePolicy(orgSlug)
   if (!data) {

--- a/src/commands/organization/handle-organization-list.ts
+++ b/src/commands/organization/handle-organization-list.ts
@@ -1,8 +1,10 @@
 import { fetchOrganization } from './fetch-organization-list'
 import { outputOrganizationList } from './output-organization-list'
 
+import type { OutputKind } from '../../types'
+
 export async function handleOrganizationList(
-  outputKind: 'text' | 'json' | 'markdown' = 'text'
+  outputKind: OutputKind = 'text'
 ): Promise<void> {
   const data = await fetchOrganization()
   if (!data) {

--- a/src/commands/organization/handle-quota.ts
+++ b/src/commands/organization/handle-quota.ts
@@ -1,8 +1,10 @@
 import { fetchQuota } from './fetch-quota'
 import { outputQuota } from './output-quota'
 
+import type { OutputKind } from '../../types'
+
 export async function handleQuota(
-  outputKind: 'text' | 'json' | 'markdown' = 'text'
+  outputKind: OutputKind = 'text'
 ): Promise<void> {
   const data = await fetchQuota()
   if (!data) {

--- a/src/commands/organization/handle-security-policy.ts
+++ b/src/commands/organization/handle-security-policy.ts
@@ -1,9 +1,11 @@
 import { fetchSecurityPolicy } from './fetch-security-policy'
 import { outputSecurityPolicy } from './output-security-policy'
 
+import type { OutputKind } from '../../types'
+
 export async function handleSecurityPolicy(
   orgSlug: string,
-  outputKind: 'text' | 'json' | 'markdown'
+  outputKind: OutputKind
 ): Promise<void> {
   const data = await fetchSecurityPolicy(orgSlug)
   if (!data) {

--- a/src/commands/organization/output-license-policy.ts
+++ b/src/commands/organization/output-license-policy.ts
@@ -2,11 +2,12 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { mdTableOfPairs } from '../../utils/markdown'
 
+import type { OutputKind } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function outputLicensePolicy(
   data: SocketSdkReturnType<'getOrgLicensePolicy'>['data'],
-  outputKind: 'text' | 'json' | 'markdown'
+  outputKind: OutputKind
 ): Promise<void> {
   if (outputKind === 'json') {
     let json

--- a/src/commands/organization/output-organization-list.ts
+++ b/src/commands/organization/output-organization-list.ts
@@ -5,11 +5,12 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { getLastFiveOfApiToken } from '../../utils/api'
 import { getDefaultToken } from '../../utils/sdk'
 
+import type { OutputKind } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function outputOrganizationList(
   data: SocketSdkReturnType<'getOrganizations'>['data'],
-  outputKind: 'text' | 'json' | 'markdown' = 'text'
+  outputKind: OutputKind = 'text'
 ): Promise<void> {
   const organizations = Object.values(data.organizations)
   const apiToken = getDefaultToken()

--- a/src/commands/organization/output-quota.ts
+++ b/src/commands/organization/output-quota.ts
@@ -1,10 +1,11 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import type { OutputKind } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function outputQuota(
   data: SocketSdkReturnType<'getQuota'>['data'],
-  outputKind: 'text' | 'json' | 'markdown' = 'text'
+  outputKind: OutputKind = 'text'
 ): Promise<void> {
   if (outputKind === 'json') {
     let json

--- a/src/commands/organization/output-security-policy.ts
+++ b/src/commands/organization/output-security-policy.ts
@@ -2,11 +2,12 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { mdTableOfPairs } from '../../utils/markdown'
 
+import type { OutputKind } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function outputSecurityPolicy(
   data: SocketSdkReturnType<'getOrgSecurityPolicy'>['data'],
-  outputKind: 'text' | 'json' | 'markdown'
+  outputKind: OutputKind
 ): Promise<void> {
   if (outputKind === 'json') {
     let json

--- a/src/commands/package/cmd-package-score.test.ts
+++ b/src/commands/package/cmd-package-score.test.ts
@@ -83,13 +83,14 @@ describe('socket package score', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket package score\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - First parameter must be an ecosystem or the whole purl (\\x1b[31mbad\\x1b[39m)
 
           - Expecting at least one package (\\x1b[31mmissing\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/package/cmd-package-score.ts
+++ b/src/commands/package/cmd-package-score.ts
@@ -4,7 +4,8 @@ import { handlePurlDeepScore } from './handle-purl-deep-score'
 import { parsePackageSpecifiers } from './parse-package-specifiers'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -75,12 +76,15 @@ async function run(
   })
 
   const { json, markdown } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
+
   const [ecosystem = '', purl] = cli.input
   const apiToken = getDefaultToken()
 
   const { purls, valid } = parsePackageSpecifiers(ecosystem, purl ? [purl] : [])
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       test: valid,
       message: 'First parameter must be an ecosystem or the whole purl',
@@ -118,8 +122,5 @@ async function run(
     return
   }
 
-  await handlePurlDeepScore(
-    purls[0] || '',
-    json ? 'json' : markdown ? 'markdown' : 'text'
-  )
+  await handlePurlDeepScore(purls[0] || '', outputKind)
 }

--- a/src/commands/package/cmd-package-shallow.test.ts
+++ b/src/commands/package/cmd-package-shallow.test.ts
@@ -82,11 +82,12 @@ describe('socket package shallow', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket package shallow\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - First parameter should be an ecosystem or all args must be purls (\\x1b[31mbad\\x1b[39m)
 
-          - Expecting at least one package (\\x1b[31mmissing\\x1b[39m)"
+          - Expecting at least one package (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/package/cmd-package-shallow.ts
+++ b/src/commands/package/cmd-package-shallow.ts
@@ -4,7 +4,8 @@ import { handlePurlsShallowScore } from './handle-purls-shallow-score'
 import { parsePackageSpecifiers } from './parse-package-specifiers'
 import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -81,11 +82,14 @@ async function run(
   })
 
   const { json, markdown } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
+
   const [ecosystem = '', ...pkgs] = cli.input
 
   const { purls, valid } = parsePackageSpecifiers(ecosystem, pkgs)
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       test: valid,
       message:
@@ -117,7 +121,7 @@ async function run(
   }
 
   await handlePurlsShallowScore({
-    outputKind: json ? 'json' : markdown ? 'markdown' : 'text',
+    outputKind,
     purls
   })
 }

--- a/src/commands/package/handle-purl-deep-score.ts
+++ b/src/commands/package/handle-purl-deep-score.ts
@@ -1,9 +1,11 @@
 import { fetchPurlDeepScore } from './fetch-purl-deep-score'
 import { outputPurlScore } from './output-purl-score'
 
+import type { OutputKind } from '../../types'
+
 export async function handlePurlDeepScore(
   purl: string,
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 ) {
   const data = await fetchPurlDeepScore(purl)
   if (!data) {

--- a/src/commands/package/handle-purls-shallow-score.ts
+++ b/src/commands/package/handle-purls-shallow-score.ts
@@ -1,13 +1,14 @@
 import { fetchPurlsShallowScore } from './fetch-purls-shallow-score'
 import { outputPurlsShallowScore } from './output-purls-shallow-score'
 
+import type { OutputKind } from '../../types'
 import type { components } from '@socketsecurity/sdk/types/api'
 
 export async function handlePurlsShallowScore({
   outputKind,
   purls
 }: {
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
   purls: string[]
 }) {
   const packageData = await fetchPurlsShallowScore(purls)

--- a/src/commands/package/output-purl-score.ts
+++ b/src/commands/package/output-purl-score.ts
@@ -2,10 +2,12 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { mdTable } from '../../utils/markdown'
 
+import type { OutputKind } from '../../types'
+
 export async function outputPurlScore(
   purl: string,
   data: unknown,
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 ) {
   if (outputKind === 'json') {
     let json

--- a/src/commands/package/output-purls-shallow-score.ts
+++ b/src/commands/package/output-purls-shallow-score.ts
@@ -3,12 +3,13 @@ import colors from 'yoctocolors-cjs'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import type { OutputKind } from '../../types'
 import type { components } from '@socketsecurity/sdk/types/api'
 
 export function outputPurlsShallowScore(
   purls: string[],
   packageData: Array<components['schemas']['SocketArtifact']>,
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 ): void {
   if (outputKind === 'json') {
     // In JSON simply return what the server responds with. Don't bother trying

--- a/src/commands/repos/cmd-repos-create.test.ts
+++ b/src/commands/repos/cmd-repos-create.test.ts
@@ -69,13 +69,14 @@ describe('socket repos create', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos create\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
           - Repository name using --repoName (\\x1b[31mmissing\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -133,11 +134,12 @@ describe('socket repos create', async () => {
         Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name by default setting, --org, or auto-discovered (\\x1b[31mmissing\\x1b[39m)
 
-          - Repository name as first argument (\\x1b[32mok\\x1b[39m)"
+          - Repository name as first argument (\\x1b[32mok\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -164,9 +166,10 @@ describe('socket repos create', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos create\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - Repository name as first argument (\\x1b[31mmissing\\x1b[39m)"
+          - Repository name as first argument (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -195,9 +198,10 @@ describe('socket repos create', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos create\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - Repository name as first argument (\\x1b[31mmissing\\x1b[39m)"
+          - Repository name as first argument (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/repos/cmd-repos-create.ts
+++ b/src/commands/repos/cmd-repos-create.ts
@@ -5,7 +5,8 @@ import constants from '../../constants'
 import { commonFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
 import { determineOrgSlug } from '../../utils/determine-org-slug'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -99,9 +100,12 @@ async function run(
   const {
     dryRun,
     interactive,
+    json,
+    markdown,
     org: orgFlag,
     repoName: repoNameFlag
   } = cli.flags
+  const outputKind = getOutputKind(json, markdown) // TODO: impl json/md further
 
   const [orgSlug] = await determineOrgSlug(
     String(orgFlag || ''),
@@ -114,7 +118,8 @@ async function run(
 
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: true,
       test: !!orgSlug,

--- a/src/commands/repos/cmd-repos-del.test.ts
+++ b/src/commands/repos/cmd-repos-del.test.ts
@@ -64,13 +64,14 @@ describe('socket repos del', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos del\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
           - Repository name using --repoName (\\x1b[31mmissing\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -127,11 +128,12 @@ describe('socket repos del', async () => {
         Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name by default setting, --org, or auto-discovered (\\x1b[31mmissing\\x1b[39m)
 
-          - Repository name as first argument (\\x1b[32mok\\x1b[39m)"
+          - Repository name as first argument (\\x1b[32mok\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -158,9 +160,10 @@ describe('socket repos del', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos del\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - Repository name as first argument (\\x1b[31mmissing\\x1b[39m)"
+          - Repository name as first argument (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -189,9 +192,10 @@ describe('socket repos del', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos del\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - Repository name as first argument (\\x1b[31mmissing\\x1b[39m)"
+          - Repository name as first argument (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/repos/cmd-repos-del.ts
+++ b/src/commands/repos/cmd-repos-del.ts
@@ -5,7 +5,8 @@ import constants from '../../constants'
 import { commonFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
 import { determineOrgSlug } from '../../utils/determine-org-slug'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -66,7 +67,8 @@ async function run(
     parentName
   })
 
-  const { dryRun, interactive, org: orgFlag } = cli.flags
+  const { dryRun, interactive, json, markdown, org: orgFlag } = cli.flags
+  const outputKind = getOutputKind(json, markdown) // TODO: impl json/md further
 
   const [orgSlug, defaultOrgSlug] = await determineOrgSlug(
     String(orgFlag || ''),
@@ -80,7 +82,8 @@ async function run(
 
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: true,
       test: !!orgSlug,

--- a/src/commands/repos/cmd-repos-list.test.ts
+++ b/src/commands/repos/cmd-repos-list.test.ts
@@ -70,11 +70,12 @@ describe('socket repos list', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos list\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -122,9 +123,10 @@ describe('socket repos list', async () => {
         Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - Org name by default setting, --org, or auto-discovered (\\x1b[31mmissing\\x1b[39m)"
+          - Org name by default setting, --org, or auto-discovered (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/repos/cmd-repos-list.ts
+++ b/src/commands/repos/cmd-repos-list.ts
@@ -5,7 +5,8 @@ import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
 import { determineOrgSlug } from '../../utils/determine-org-slug'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -91,6 +92,7 @@ async function run(
   })
 
   const { json, markdown } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
 
   const { dryRun, interactive, org: orgFlag } = cli.flags
 
@@ -103,7 +105,8 @@ async function run(
 
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: true,
       test: !!orgSlug,
@@ -142,7 +145,7 @@ async function run(
   await handleListRepos({
     direction: cli.flags['direction'] === 'asc' ? 'asc' : 'desc',
     orgSlug,
-    outputKind: json ? 'json' : markdown ? 'markdown' : 'print',
+    outputKind,
     page: Number(cli.flags['page']) || 1,
     per_page: Number(cli.flags['perPage']) || 30,
     sort: String(cli.flags['sort'] || 'created_at')

--- a/src/commands/repos/cmd-repos-update.test.ts
+++ b/src/commands/repos/cmd-repos-update.test.ts
@@ -69,13 +69,14 @@ describe('socket repos update', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos update\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
           - Repository name using --repoName (\\x1b[31mmissing\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -106,11 +107,12 @@ describe('socket repos update', async () => {
         Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name by default setting, --org, or auto-discovered (\\x1b[31mmissing\\x1b[39m)
 
-          - Repository name as first argument (\\x1b[32mok\\x1b[39m)"
+          - Repository name as first argument (\\x1b[32mok\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -137,9 +139,10 @@ describe('socket repos update', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos update\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - Repository name as first argument (\\x1b[31mmissing\\x1b[39m)"
+          - Repository name as first argument (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -168,9 +171,10 @@ describe('socket repos update', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos update\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - Repository name as first argument (\\x1b[31mmissing\\x1b[39m)"
+          - Repository name as first argument (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/repos/cmd-repos-update.ts
+++ b/src/commands/repos/cmd-repos-update.ts
@@ -5,7 +5,8 @@ import constants from '../../constants'
 import { commonFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
 import { determineOrgSlug } from '../../utils/determine-org-slug'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -96,7 +97,8 @@ async function run(
     parentName
   })
 
-  const { dryRun, interactive, org: orgFlag } = cli.flags
+  const { dryRun, interactive, json, markdown, org: orgFlag } = cli.flags
+  const outputKind = getOutputKind(json, markdown) // TODO: impl json/md further
 
   const [orgSlug] = await determineOrgSlug(
     String(orgFlag || ''),
@@ -110,7 +112,8 @@ async function run(
 
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: true,
       test: !!orgSlug,

--- a/src/commands/repos/cmd-repos-view.test.ts
+++ b/src/commands/repos/cmd-repos-view.test.ts
@@ -67,13 +67,14 @@ describe('socket repos view', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos view\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
           - Repository name using --repoName (\\x1b[31mmissing\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -131,11 +132,12 @@ describe('socket repos view', async () => {
         Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name by default setting, --org, or auto-discovered (\\x1b[31mmissing\\x1b[39m)
 
-          - Repository name as first argument (\\x1b[32mok\\x1b[39m)"
+          - Repository name as first argument (\\x1b[32mok\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -162,9 +164,10 @@ describe('socket repos view', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos view\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - Repository name as first argument (\\x1b[31mmissing\\x1b[39m)"
+          - Repository name as first argument (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -193,9 +196,10 @@ describe('socket repos view', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos view\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - Repository name as first argument (\\x1b[31mmissing\\x1b[39m)"
+          - Repository name as first argument (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/repos/cmd-repos-view.ts
+++ b/src/commands/repos/cmd-repos-view.ts
@@ -5,7 +5,8 @@ import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
 import { determineOrgSlug } from '../../utils/determine-org-slug'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -80,6 +81,7 @@ async function run(
     org: orgFlag,
     repoName: repoNameFlag
   } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
 
   const [orgSlug] = await determineOrgSlug(
     String(orgFlag || ''),
@@ -92,7 +94,8 @@ async function run(
 
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: true,
       test: !!orgSlug,
@@ -143,9 +146,5 @@ async function run(
     return
   }
 
-  await handleViewRepo(
-    orgSlug,
-    String(repoName),
-    json ? 'json' : markdown ? 'markdown' : 'text'
-  )
+  await handleViewRepo(orgSlug, String(repoName), outputKind)
 }

--- a/src/commands/repos/handle-list-repos.ts
+++ b/src/commands/repos/handle-list-repos.ts
@@ -1,6 +1,8 @@
 import { fetchListRepos } from './fetch-list-repos'
 import { outputListRepos } from './output-list-repos'
 
+import type { OutputKind } from '../../types'
+
 export async function handleListRepos({
   direction,
   orgSlug,
@@ -11,7 +13,7 @@ export async function handleListRepos({
 }: {
   direction: string
   orgSlug: string
-  outputKind: 'json' | 'markdown' | 'print'
+  outputKind: OutputKind
   page: number
   per_page: number
   sort: string

--- a/src/commands/repos/handle-view-repo.ts
+++ b/src/commands/repos/handle-view-repo.ts
@@ -1,10 +1,12 @@
 import { fetchViewRepo } from './fetch-view-repo'
 import { outputViewRepo } from './output-view-repo'
 
+import type { OutputKind } from '../../types'
+
 export async function handleViewRepo(
   orgSlug: string,
   repoName: string,
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 ): Promise<void> {
   const data = await fetchViewRepo(orgSlug, repoName)
   if (!data) {

--- a/src/commands/repos/output-list-repos.ts
+++ b/src/commands/repos/output-list-repos.ts
@@ -4,11 +4,12 @@ import colors from 'yoctocolors-cjs'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import type { OutputKind } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function outputListRepos(
   data: SocketSdkReturnType<'getOrgRepoList'>['data'],
-  outputKind: 'json' | 'markdown' | 'print'
+  outputKind: OutputKind
 ): Promise<void> {
   if (outputKind === 'json') {
     const json = data.results.map(o => ({

--- a/src/commands/repos/output-view-repo.ts
+++ b/src/commands/repos/output-view-repo.ts
@@ -4,11 +4,12 @@ import colors from 'yoctocolors-cjs'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import type { OutputKind } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function outputViewRepo(
   data: SocketSdkReturnType<'createOrgRepo'>['data'],
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 ): Promise<void> {
   if (outputKind === 'json') {
     const {

--- a/src/commands/scan/cmd-scan-create.ts
+++ b/src/commands/scan/cmd-scan-create.ts
@@ -7,7 +7,8 @@ import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
 import { determineOrgSlug } from '../../utils/determine-org-slug'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -201,6 +202,7 @@ async function run(
     report: boolean
     tmp: boolean
   }
+  const outputKind = getOutputKind(json, markdown)
 
   let [orgSlug, defaultOrgSlug] = await determineOrgSlug(
     String(orgFlag || ''),
@@ -259,7 +261,8 @@ async function run(
     logger.error('```\n')
   }
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: !isTestingV1() && !!defaultOrgSlug,
       test: !!orgSlug && orgSlug !== '.',
@@ -333,7 +336,7 @@ async function run(
     defaultBranch: Boolean(defaultBranch),
     interactive: Boolean(interactive),
     orgSlug,
-    outputKind: json ? 'json' : markdown ? 'markdown' : 'text',
+    outputKind,
     pendingHead: Boolean(pendingHead),
     pullRequest: Number(pullRequest),
     readOnly: Boolean(readOnly),

--- a/src/commands/scan/cmd-scan-del.test.ts
+++ b/src/commands/scan/cmd-scan-del.test.ts
@@ -66,13 +66,14 @@ describe('socket scan del', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan del\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
           - Scan ID to delete (\\x1b[31mmissing\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/scan/cmd-scan-del.ts
+++ b/src/commands/scan/cmd-scan-del.ts
@@ -5,7 +5,8 @@ import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
 import { determineOrgSlug } from '../../utils/determine-org-slug'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -67,7 +68,8 @@ async function run(
     parentName
   })
 
-  const { dryRun, interactive, org: orgFlag } = cli.flags
+  const { dryRun, interactive, json, markdown, org: orgFlag } = cli.flags
+  const outputKind = getOutputKind(json, markdown) // TODO: impl json/md further
 
   const [orgSlug, defaultOrgSlug] = await determineOrgSlug(
     String(orgFlag || ''),
@@ -80,7 +82,8 @@ async function run(
     (isTestingV1() || defaultOrgSlug ? cli.input[0] : cli.input[1]) || ''
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: !!defaultOrgSlug,
       test: !!orgSlug && orgSlug !== '.',

--- a/src/commands/scan/cmd-scan-diff.test.ts
+++ b/src/commands/scan/cmd-scan-diff.test.ts
@@ -76,14 +76,15 @@ describe('socket scan diff', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan diff\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Specify two Scan IDs. (\\x1b[31mmissing both Scan IDs\\x1b[39m)
             A Scan ID looks like \`aaa0aa0a-aaaa-0000-0a0a-0000000a00a0\`.
 
           - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/scan/cmd-scan-diff.ts
+++ b/src/commands/scan/cmd-scan-diff.ts
@@ -5,7 +5,8 @@ import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
 import { determineOrgSlug } from '../../utils/determine-org-slug'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -100,6 +101,7 @@ async function run(
     markdown,
     org: orgFlag
   } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
 
   const [orgSlug, defaultOrgSlug] = await determineOrgSlug(
     String(orgFlag || ''),
@@ -119,7 +121,8 @@ async function run(
 
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       test: !!(id1 && id2),
       message:
@@ -172,7 +175,7 @@ async function run(
     id2: String(id2 || ''),
     depth: Number(depth),
     orgSlug,
-    outputKind: json ? 'json' : markdown ? 'markdown' : 'text',
+    outputKind,
     file: String(file || '')
   })
 }

--- a/src/commands/scan/cmd-scan-list.test.ts
+++ b/src/commands/scan/cmd-scan-list.test.ts
@@ -74,11 +74,12 @@ describe('socket scan list', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan list\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/scan/cmd-scan-list.ts
+++ b/src/commands/scan/cmd-scan-list.ts
@@ -5,7 +5,8 @@ import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
 import { determineOrgSlug } from '../../utils/determine-org-slug'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -124,6 +125,7 @@ async function run(
     org: orgFlag,
     repo
   } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
 
   const [orgSlug, defaultOrgSlug] = await determineOrgSlug(
     String(orgFlag || ''),
@@ -134,7 +136,8 @@ async function run(
 
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: !!defaultOrgSlug,
       test: !!orgSlug && orgSlug !== '.',
@@ -177,7 +180,7 @@ async function run(
     direction: String(cli.flags['direction'] || ''),
     from_time: String(cli.flags['fromTime'] || ''),
     orgSlug,
-    outputKind: json ? 'json' : markdown ? 'markdown' : 'print',
+    outputKind,
     page: Number(cli.flags['page'] || 1),
     per_page: Number(cli.flags['perPage'] || 30),
     repo: repo ? String(repo) : '',

--- a/src/commands/scan/cmd-scan-metadata.test.ts
+++ b/src/commands/scan/cmd-scan-metadata.test.ts
@@ -66,13 +66,14 @@ describe('socket scan metadata', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan metadata\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
           - Scan ID to inspect as argument (\\x1b[31mmissing\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/scan/cmd-scan-metadata.ts
+++ b/src/commands/scan/cmd-scan-metadata.ts
@@ -5,7 +5,8 @@ import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
 import { determineOrgSlug } from '../../utils/determine-org-slug'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -71,6 +72,7 @@ async function run(
   })
 
   const { dryRun, interactive, json, markdown, org: orgFlag } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
 
   const [orgSlug, defaultOrgSlug] = await determineOrgSlug(
     String(orgFlag || ''),
@@ -83,7 +85,8 @@ async function run(
     (isTestingV1() || defaultOrgSlug ? cli.input[0] : cli.input[1]) || ''
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: !!defaultOrgSlug,
       test: !!orgSlug && orgSlug !== '.',
@@ -127,9 +130,5 @@ async function run(
     return
   }
 
-  await handleOrgScanMetadata(
-    orgSlug,
-    scanId,
-    json ? 'json' : markdown ? 'markdown' : 'text'
-  )
+  await handleOrgScanMetadata(orgSlug, scanId, outputKind)
 }

--- a/src/commands/scan/cmd-scan-report.test.ts
+++ b/src/commands/scan/cmd-scan-report.test.ts
@@ -80,13 +80,14 @@ describe('socket scan report', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan report\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
           - Scan ID to fetch (\\x1b[31mmissing\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/scan/cmd-scan-report.ts
+++ b/src/commands/scan/cmd-scan-report.ts
@@ -5,7 +5,8 @@ import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
 import { determineOrgSlug } from '../../utils/determine-org-slug'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -108,6 +109,7 @@ async function run(
     markdown,
     reportLevel = 'warn'
   } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
 
   const { dryRun, interactive, org: orgFlag } = cli.flags
 
@@ -124,7 +126,8 @@ async function run(
     (isTestingV1() || defaultOrgSlug ? cli.input[1] : cli.input[2]) || '-'
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: !!defaultOrgSlug,
       test: !!orgSlug && orgSlug !== '.',
@@ -172,7 +175,7 @@ async function run(
     orgSlug,
     scanId: scanId,
     includeLicensePolicy: !!license,
-    outputKind: json ? 'json' : markdown ? 'markdown' : 'text',
+    outputKind,
     filePath: file,
     fold: fold as 'none' | 'file' | 'pkg' | 'version',
     short: !!cli.flags['short'],

--- a/src/commands/scan/cmd-scan-view.test.ts
+++ b/src/commands/scan/cmd-scan-view.test.ts
@@ -68,13 +68,14 @@ describe('socket scan view', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan view\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
           - Scan ID to delete (\\x1b[31mmissing\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/scan/cmd-scan-view.ts
+++ b/src/commands/scan/cmd-scan-view.ts
@@ -6,7 +6,8 @@ import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
 import { determineOrgSlug } from '../../utils/determine-org-slug'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -74,6 +75,7 @@ async function run(
   })
 
   const { dryRun, interactive, json, markdown, org: orgFlag } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
 
   const [orgSlug, defaultOrgSlug] = await determineOrgSlug(
     String(orgFlag || ''),
@@ -88,7 +90,8 @@ async function run(
     (isTestingV1() || defaultOrgSlug ? cli.input[1] : cli.input[2]) || '-'
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: !!defaultOrgSlug,
       test: !!orgSlug && orgSlug !== '.',

--- a/src/commands/scan/handle-create-new-scan.ts
+++ b/src/commands/scan/handle-create-new-scan.ts
@@ -7,6 +7,8 @@ import { outputCreateNewScan } from './output-create-new-scan'
 import { handleBadInput } from '../../utils/handle-bad-input'
 import { getPackageFilesForScan } from '../../utils/path-resolve'
 
+import type { OutputKind } from '../../types'
+
 export async function handleCreateNewScan({
   branchName,
   commitHash,
@@ -35,7 +37,7 @@ export async function handleCreateNewScan({
   orgSlug: string
   pendingHead: boolean
   pullRequest: number
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
   readOnly: boolean
   repoName: string
   report: boolean

--- a/src/commands/scan/handle-diff-scan.ts
+++ b/src/commands/scan/handle-diff-scan.ts
@@ -1,6 +1,8 @@
 import { fetchDiffScan } from './fetch-diff-scan'
 import { outputDiffScan } from './output-diff-scan'
 
+import type { OutputKind } from '../../types'
+
 export async function handleDiffScan({
   depth,
   file,
@@ -14,7 +16,7 @@ export async function handleDiffScan({
   id1: string
   id2: string
   orgSlug: string
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 }): Promise<void> {
   const data = await fetchDiffScan({
     id1,

--- a/src/commands/scan/handle-list-scans.ts
+++ b/src/commands/scan/handle-list-scans.ts
@@ -1,6 +1,8 @@
 import { fetchListScans } from './fetch-list-scans'
 import { outputListScans } from './output-list-scans'
 
+import type { OutputKind } from '../../types'
+
 export async function handleListScans({
   branch,
   direction,
@@ -16,7 +18,7 @@ export async function handleListScans({
   direction: string
   from_time: string
   orgSlug: string
-  outputKind: 'json' | 'markdown' | 'print'
+  outputKind: OutputKind
   page: number
   per_page: number
   repo: string

--- a/src/commands/scan/handle-scan-metadata.ts
+++ b/src/commands/scan/handle-scan-metadata.ts
@@ -1,10 +1,12 @@
 import { fetchScanMetadata } from './fetch-scan-metadata'
 import { outputScanMetadata } from './output-scan-metadata'
 
+import type { OutputKind } from '../../types'
+
 export async function handleOrgScanMetadata(
   orgSlug: string,
   scanId: string,
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 ): Promise<void> {
   const data = await fetchScanMetadata(orgSlug, scanId)
   if (!data) {

--- a/src/commands/scan/handle-scan-report.ts
+++ b/src/commands/scan/handle-scan-report.ts
@@ -1,6 +1,8 @@
 import { fetchReportData } from './fetch-report-data'
 import { outputScanReport } from './output-scan-report'
 
+import type { OutputKind } from '../../types'
+
 export async function handleScanReport({
   filePath,
   fold,
@@ -14,7 +16,7 @@ export async function handleScanReport({
   orgSlug: string
   scanId: string
   includeLicensePolicy: boolean
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
   filePath: string
   fold: 'pkg' | 'version' | 'file' | 'none'
   reportLevel: 'defer' | 'ignore' | 'monitor' | 'warn' | 'error'

--- a/src/commands/scan/output-create-new-scan.ts
+++ b/src/commands/scan/output-create-new-scan.ts
@@ -4,11 +4,12 @@ import colors from 'yoctocolors-cjs'
 import { logger } from '@socketsecurity/registry/lib/logger'
 import { confirm } from '@socketsecurity/registry/lib/prompts'
 
+import type { OutputKind } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function outputCreateNewScan(
   data: SocketSdkReturnType<'CreateOrgFullScan'>['data'],
-  outputKind: 'json' | 'markdown' | 'text',
+  outputKind: OutputKind,
   interactive: boolean
 ) {
   if (!data.id) {

--- a/src/commands/scan/output-diff-scan.ts
+++ b/src/commands/scan/output-diff-scan.ts
@@ -5,6 +5,7 @@ import colors from 'yoctocolors-cjs'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import type { OutputKind } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 const SOCKET_SBOM_URL_PREFIX =
@@ -19,7 +20,7 @@ export async function outputDiffScan(
   }: {
     depth: number
     file: string
-    outputKind: 'json' | 'markdown' | 'text'
+    outputKind: OutputKind
   }
 ): Promise<void> {
   const dashboardUrl = result.diff_report_url

--- a/src/commands/scan/output-list-scans.ts
+++ b/src/commands/scan/output-list-scans.ts
@@ -4,11 +4,12 @@ import colors from 'yoctocolors-cjs'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import type { OutputKind } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function outputListScans(
   data: SocketSdkReturnType<'getOrgFullScanList'>['data'],
-  outputKind: 'json' | 'markdown' | 'print'
+  outputKind: OutputKind
 ): Promise<void> {
   if (outputKind === 'json') {
     logger.log(data)

--- a/src/commands/scan/output-scan-metadata.ts
+++ b/src/commands/scan/output-scan-metadata.ts
@@ -1,11 +1,12 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import type { OutputKind } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 
 export async function outputScanMetadata(
   data: SocketSdkReturnType<'getOrgFullScanMetadata'>['data'],
   scanId: string,
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
 ): Promise<void> {
   if (outputKind === 'json') {
     logger.log(data)

--- a/src/commands/scan/output-scan-report.ts
+++ b/src/commands/scan/output-scan-report.ts
@@ -9,6 +9,7 @@ import { mdTable } from '../../utils/markdown'
 import { walkNestedMap } from '../../utils/walk-nested-map'
 
 import type { ReportLeafNode, ScanReport } from './generate-report'
+import type { OutputKind } from '../../types'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 import type { components } from '@socketsecurity/sdk/types/api'
 
@@ -28,7 +29,7 @@ export async function outputScanReport(
     orgSlug: string
     scanId: string
     includeLicensePolicy: boolean
-    outputKind: 'json' | 'markdown' | 'text'
+    outputKind: OutputKind
     filePath: string
     fold: 'pkg' | 'version' | 'file' | 'none'
     reportLevel: 'defer' | 'ignore' | 'monitor' | 'warn' | 'error'

--- a/src/commands/threat-feed/cmd-threat-feed.test.ts
+++ b/src/commands/threat-feed/cmd-threat-feed.test.ts
@@ -99,11 +99,12 @@ describe('socket threat-feed', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket threat-feed\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
           - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)"
+          - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)
@@ -150,9 +151,10 @@ describe('socket threat-feed', async () => {
         Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)"
+          - Org name as the first argument (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/threat-feed/cmd-threat-feed.ts
+++ b/src/commands/threat-feed/cmd-threat-feed.ts
@@ -5,7 +5,8 @@ import constants from '../../constants'
 import { commonFlags, outputFlags } from '../../flags'
 import { isTestingV1 } from '../../utils/config'
 import { determineOrgSlug } from '../../utils/determine-org-slug'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
@@ -126,6 +127,7 @@ async function run(
   })
 
   const { dryRun, interactive, json, markdown, org: orgFlag } = cli.flags
+  const outputKind = getOutputKind(json, markdown)
 
   const [orgSlug] = await determineOrgSlug(
     String(orgFlag || ''),
@@ -136,7 +138,8 @@ async function run(
 
   const apiToken = getDefaultToken()
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       nook: true,
       test: !!orgSlug,
@@ -173,7 +176,7 @@ async function run(
     direction: String(cli.flags['direction'] || 'desc'),
     ecosystem: String(cli.flags['eco'] || ''),
     filter: String(cli.flags['filter'] || 'mal'),
-    outputKind: json ? 'json' : markdown ? 'markdown' : 'text',
+    outputKind,
     page: String(cli.flags['page'] || '1'),
     perPage: Number(cli.flags['perPage']) || 30
   })

--- a/src/commands/threat-feed/handle-threat-feed.ts
+++ b/src/commands/threat-feed/handle-threat-feed.ts
@@ -5,6 +5,7 @@ import { outputThreatFeed } from './output-threat-feed'
 import { failMsgWithBadge } from '../../utils/fail-msg-with-badge'
 
 import type { ThreadFeedResponse } from './types'
+import type { OutputKind } from '../../types'
 
 export async function handleThreatFeed({
   direction,
@@ -17,7 +18,7 @@ export async function handleThreatFeed({
   direction: string
   ecosystem: string
   filter: string
-  outputKind: 'json' | 'markdown' | 'text'
+  outputKind: OutputKind
   page: string
   perPage: number
 }): Promise<void> {

--- a/src/commands/threat-feed/output-threat-feed.ts
+++ b/src/commands/threat-feed/output-threat-feed.ts
@@ -3,6 +3,7 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import constants from '../../constants'
 
 import type { ThreadFeedResponse, ThreatResult } from './types'
+import type { OutputKind } from '../../types'
 import type { Widgets } from 'blessed'
 
 export async function outputThreatFeed(
@@ -10,7 +11,7 @@ export async function outputThreatFeed(
   {
     outputKind
   }: {
-    outputKind: 'json' | 'markdown' | 'text'
+    outputKind: OutputKind
   }
 ) {
   if (outputKind === 'json') {

--- a/src/commands/wrapper/cmd-wrapper.test.ts
+++ b/src/commands/wrapper/cmd-wrapper.test.ts
@@ -61,9 +61,10 @@ describe('socket wrapper', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket wrapper\`, cwd: <redacted>
 
-        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again\\x1b[22m
+        \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 
-          - Must use --enabled or --disable (\\x1b[31mmissing\\x1b[39m)"
+          - Must use --enabled or --disable (\\x1b[31mmissing\\x1b[39m)
+        \\x1b[22m"
       `)
 
       expect(code, 'dry-run should exit with code 2 if missing input').toBe(2)

--- a/src/commands/wrapper/cmd-wrapper.ts
+++ b/src/commands/wrapper/cmd-wrapper.ts
@@ -8,7 +8,8 @@ import { postinstallWrapper } from './postinstall-wrapper'
 import { removeSocketWrapper } from './remove-socket-wrapper'
 import constants from '../../constants'
 import { commonFlags } from '../../flags'
-import { handleBadInput } from '../../utils/handle-bad-input'
+import { getOutputKind } from '../../utils/get-output-kind'
+import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 
@@ -70,9 +71,11 @@ async function run(
     parentName
   })
 
-  const { disable, enable } = cli.flags
+  const { disable, enable, json, markdown } = cli.flags
+  const outputKind = getOutputKind(json, markdown) // TODO: impl json/md further
 
-  const wasBadInput = handleBadInput(
+  const wasBadInput = checkCommandInput(
+    outputKind,
     {
       test: !!(enable || disable),
       message: 'Must use --enabled or --disable',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,1 +1,7 @@
 export type StringKeyValueObject = { [key: string]: string }
+
+export type OutputKind = 'json' | 'markdown' | 'text'
+
+export type CliJsonResult<T = unknown> =
+  | { ok: true; message?: string; data: T }
+  | { ok: false; message: string; data: string | undefined }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -8,6 +8,7 @@ import { getConfigValue } from './config'
 import { AuthError } from './errors'
 import constants from '../constants'
 import { failMsgWithBadge } from './fail-msg-with-badge'
+import type { CliJsonResult } from '../types'
 
 import type {
   SocketSdkErrorType,
@@ -30,6 +31,20 @@ export function handleUnsuccessfulApiResponse<T extends SocketSdkOperations>(
   logger.fail(failMsgWithBadge('Socket API returned an error', message))
   // eslint-disable-next-line n/no-process-exit
   process.exit(1)
+}
+
+export function handleFailedApiResponse<T extends SocketSdkOperations>(
+  _name: T,
+  { cause, error }: SocketSdkErrorType<T>
+): CliJsonResult<any> {
+  process.exitCode = 1
+  const message = `${error || 'No error message returned'}`
+  // logger.error(failMsgWithBadge('Socket API returned an error', message))
+  return {
+    ok: false,
+    message: 'Socket API returned an error',
+    data: `${message}${cause ? ` ( Reason: ${cause} )` : ''}`
+  } satisfies CliJsonResult
 }
 
 export async function handleApiCall<T>(

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -8,8 +8,8 @@ import { getConfigValue } from './config'
 import { AuthError } from './errors'
 import constants from '../constants'
 import { failMsgWithBadge } from './fail-msg-with-badge'
-import type { CliJsonResult } from '../types'
 
+import type { CliJsonResult } from '../types'
 import type {
   SocketSdkErrorType,
   SocketSdkOperations

--- a/src/utils/fail-msg-with-badge.ts
+++ b/src/utils/fail-msg-with-badge.ts
@@ -1,5 +1,8 @@
 import colors from 'yoctocolors-cjs'
 
-export function failMsgWithBadge(badge: string, msg: string): string {
-  return `${colors.bgRed(colors.bold(colors.white(` ${badge}: `)))} ${colors.bold(msg)}`
+export function failMsgWithBadge(
+  badge: string,
+  msg: string | undefined
+): string {
+  return `${colors.bgRed(colors.bold(colors.white(` ${badge}${msg ? ': ' : ''}`)))}${msg ? ' ' + colors.bold(msg) : ''}`
 }

--- a/src/utils/get-output-kind.ts
+++ b/src/utils/get-output-kind.ts
@@ -1,0 +1,11 @@
+import { OutputKind } from '../types'
+
+export function getOutputKind(json: unknown, markdown: unknown): OutputKind {
+  if (json) {
+    return 'json'
+  }
+  if (markdown) {
+    return 'markdown'
+  }
+  return 'text'
+}

--- a/src/utils/handle-bad-input.ts
+++ b/src/utils/handle-bad-input.ts
@@ -3,8 +3,12 @@ import colors from 'yoctocolors-cjs'
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { failMsgWithBadge } from './fail-msg-with-badge'
+import { serializeResultJson } from './serialize-result-json'
 
-export function handleBadInput(
+import type { OutputKind } from '../types'
+
+export function checkCommandInput(
+  outputKind: OutputKind,
   ...checks: Array<{
     fail: string
     message: string
@@ -12,18 +16,12 @@ export function handleBadInput(
     test: boolean
     nook?: boolean | undefined
   }>
-) {
+): boolean {
   if (checks.every(d => d.test)) {
     return false
   }
 
-  const msg = [
-    failMsgWithBadge(
-      'Input error',
-      'Please review the input requirements and try again'
-    ),
-    ''
-  ]
+  const msg = ['Please review the input requirements and try again', '']
   for (const d of checks) {
     // If nook, then ignore when test is ok
     if (d.nook && d.test) {
@@ -42,12 +40,34 @@ export function handleBadInput(
     msg.push('')
   }
 
-  logger.fail(msg.join('\n'))
-
   // Use exit status of 2 to indicate incorrect usage, generally invalid
   // options or missing arguments.
   // https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
   process.exitCode = 2
 
+  if (outputKind === 'json') {
+    logger.log(
+      serializeResultJson({
+        ok: false,
+        message: 'Input error',
+        data: msg.join('\n')
+      })
+    )
+  } else {
+    logger.fail(failMsgWithBadge('Input error', msg.join('\n')))
+  }
+
   return true
+}
+
+export function handleBadInput(
+  ...checks: Array<{
+    fail: string
+    message: string
+    pass: string
+    test: boolean
+    nook?: boolean | undefined
+  }>
+): boolean {
+  return checkCommandInput('text', ...checks)
 }

--- a/src/utils/serialize-result-json.ts
+++ b/src/utils/serialize-result-json.ts
@@ -1,0 +1,41 @@
+import { debugLog } from '@socketsecurity/registry/lib/debug'
+import { logger } from '@socketsecurity/registry/lib/logger'
+
+import { CliJsonResult } from '../types'
+
+// Serialize the final result object before printing it
+// All commands that support the --json flag should call this before printing
+export function serializeResultJson(data: CliJsonResult): string {
+  if (typeof data !== 'object' || !data) {
+    process.exitCode = 1
+    // We should not allow to expect the json value to be "null", or a boolean/number/string, even if they are valid "json".
+    const msg =
+      'There was a problem converting the data set to JSON. The JSON was not an object. Please try again without --json'
+    debugLog('typeof data=', typeof data)
+    if (typeof data !== 'object' && data) {
+      debugLog('data:', data)
+    }
+    return JSON.stringify({
+      ok: false,
+      message: 'Unable to serialize JSON',
+      data: msg
+    })
+  }
+
+  try {
+    return JSON.stringify(data, null, 2)
+  } catch (e) {
+    debugLog('Error:')
+    logger.log('wtf?', e)
+    process.exitCode = 1
+    // This could be caused by circular references, which is an "us" problem
+    const msg =
+      'There was a problem converting the data set to JSON. Please try again without --json'
+    logger.error(msg)
+    return JSON.stringify({
+      ok: false,
+      message: 'Unable to serialize JSON',
+      data: msg
+    })
+  }
+}

--- a/src/utils/serialize-result-json.ts
+++ b/src/utils/serialize-result-json.ts
@@ -1,7 +1,7 @@
 import { debugLog } from '@socketsecurity/registry/lib/debug'
 import { logger } from '@socketsecurity/registry/lib/logger'
 
-import { CliJsonResult } from '../types'
+import type { CliJsonResult } from '../types'
 
 // Serialize the final result object before printing it
 // All commands that support the --json flag should call this before printing


### PR DESCRIPTION
This PR improves error reporting to be `--json` aware.

- Input validation now expects the output kind and will emit a JSON payload when `--json` is used
- The `analytics` and `audit-logs` commands have been made fully `--json` friendly.