### PR TITLE
Make config related ops more --json friendly

### DIFF
--- a/src/commands/analytics/handle-analytics.ts
+++ b/src/commands/analytics/handle-analytics.ts
@@ -27,6 +27,7 @@ export async function handleAnalytics({
   } else if (repo) {
     result = await fetchRepoAnalyticsData(repo, time)
   } else {
+    process.exitCode = 1
     result = {
       ok: false,
       message: 'Missing repository name in command',

--- a/src/commands/ci/fetch-default-org-slug.ts
+++ b/src/commands/ci/fetch-default-org-slug.ts
@@ -1,5 +1,4 @@
 import { debugLog } from '@socketsecurity/registry/lib/debug'
-import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleApiCall } from '../../utils/api'
 import { getConfigValue } from '../../utils/config'
@@ -9,47 +8,47 @@ import type { CliJsonResult } from '../../types'
 
 // Use the config defaultOrg when set, otherwise discover from remote
 export async function getDefaultOrgSlug(): Promise<CliJsonResult<string>> {
-  let defaultOrg = getConfigValue('defaultOrg')
-  if (defaultOrg) {
-    logger.info(`Using default org: ${defaultOrg}`)
-  } else {
-    const sockSdk = await setupSdk()
-    const result = await handleApiCall(
-      sockSdk.getOrganizations(),
-      'looking up organizations'
-    )
-    // Ignore a failed request here. It was not the primary goal of
-    // running this command and reporting it only leads to end-user confusion.
-    if (!result.success) {
-      process.exitCode = 1
-      return {
-        ok: false,
-        message: result.error,
-        data: `Failed to fetch default organization from API. Unable to continue.${result.cause ? ` ( Reason given: ${result.cause} )` : ''}`
-      }
-    }
+  const defaultOrgResult = getConfigValue('defaultOrg')
+  if (!defaultOrgResult.ok) {
+    return defaultOrgResult
+  }
 
-    const orgs = result.data.organizations
-    const keys = Object.keys(orgs)
+  if (defaultOrgResult.data) {
+    debugLog(`Using default org: ${defaultOrgResult.data}`)
+    return { ok: true, data: defaultOrgResult.data }
+  }
 
-    if (!keys[0]) {
-      process.exitCode = 1
-      return {
-        ok: false,
-        message: 'Failed to establish identity',
-        data: `API did not return any organization associated with the current API token. Unable to continue.`
-      }
-    }
+  const sockSdk = await setupSdk()
 
-    const slug = (keys[0] in orgs && orgs?.[keys[0]]?.name) ?? undefined
+  const result = await handleApiCall(
+    sockSdk.getOrganizations(),
+    'looking up organizations'
+  )
 
-    if (slug) {
-      defaultOrg = slug
-      debugLog(`Resolved org to: ${defaultOrg}`)
+  if (!result.success) {
+    process.exitCode = 1
+    return {
+      ok: false,
+      message: result.error,
+      data: `Failed to fetch default organization from API. Unable to continue.${result.cause ? ` ( Reason given: ${result.cause} )` : ''}`
     }
   }
 
-  if (!defaultOrg) {
+  const orgs = result.data.organizations
+  const keys = Object.keys(orgs)
+
+  if (!keys[0]) {
+    process.exitCode = 1
+    return {
+      ok: false,
+      message: 'Failed to establish identity',
+      data: `API did not return any organization associated with the current API token. Unable to continue.`
+    }
+  }
+
+  const slug = (keys[0] in orgs && orgs?.[keys[0]]?.name) ?? undefined
+
+  if (!slug) {
     process.exitCode = 1
     return {
       ok: false,
@@ -58,5 +57,10 @@ export async function getDefaultOrgSlug(): Promise<CliJsonResult<string>> {
     }
   }
 
-  return { ok: true, data: defaultOrg }
+  debugLog(`Resolved org to: ${slug}`)
+  return {
+    ok: true,
+    message: 'Retrieved default org from server',
+    data: slug
+  }
 }

--- a/src/commands/config/handle-config-get.ts
+++ b/src/commands/config/handle-config-get.ts
@@ -1,5 +1,5 @@
 import { outputConfigGet } from './output-config-get'
-import { getConfigValue, isReadOnlyConfig } from '../../utils/config'
+import { getConfigValue } from '../../utils/config'
 
 import type { OutputKind } from '../../types'
 import type { LocalConfig } from '../../utils/config'
@@ -11,8 +11,7 @@ export async function handleConfigGet({
   key: keyof LocalConfig
   outputKind: OutputKind
 }) {
-  const value = getConfigValue(key)
-  const readOnly = isReadOnlyConfig()
+  const result = getConfigValue(key)
 
-  await outputConfigGet(key, value, readOnly, outputKind)
+  await outputConfigGet(key, result, outputKind)
 }

--- a/src/commands/config/handle-config-set.ts
+++ b/src/commands/config/handle-config-set.ts
@@ -1,5 +1,5 @@
 import { outputConfigSet } from './output-config-set'
-import { isReadOnlyConfig, updateConfigValue } from '../../utils/config'
+import { updateConfigValue } from '../../utils/config'
 
 import type { OutputKind } from '../../types'
 import type { LocalConfig } from '../../utils/config'
@@ -13,8 +13,7 @@ export async function handleConfigSet({
   outputKind: OutputKind
   value: string
 }) {
-  updateConfigValue(key, value)
-  const readOnly = isReadOnlyConfig()
+  const result = updateConfigValue(key, value)
 
-  await outputConfigSet(key, value, readOnly, outputKind)
+  await outputConfigSet(result, outputKind)
 }

--- a/src/commands/config/handle-config-unset.ts
+++ b/src/commands/config/handle-config-unset.ts
@@ -11,6 +11,6 @@ export async function handleConfigUnset({
   key: keyof LocalConfig
   outputKind: OutputKind
 }) {
-  updateConfigValue(key, undefined)
-  await outputConfigUnset(key, outputKind)
+  const updateResult = updateConfigValue(key, undefined)
+  await outputConfigUnset(updateResult, outputKind)
 }

--- a/src/commands/config/output-config-get.ts
+++ b/src/commands/config/output-config-get.ts
@@ -1,23 +1,38 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 
-import { LocalConfig } from '../../utils/config'
+import { LocalConfig, isReadOnlyConfig } from '../../utils/config'
+import { failMsgWithBadge } from '../../utils/fail-msg-with-badge'
+import { serializeResultJson } from '../../utils/serialize-result-json'
 
-import type { OutputKind } from '../../types'
+import type { CliJsonResult, OutputKind } from '../../types'
 
 export async function outputConfigGet(
   key: keyof LocalConfig,
-  value: unknown,
-  readOnly: boolean, // Is config in read-only mode? (Overrides applied)
+  result: CliJsonResult<LocalConfig[keyof LocalConfig]>,
   outputKind: OutputKind
 ) {
+  const readOnly = isReadOnlyConfig()
   if (outputKind === 'json') {
-    logger.log(
-      JSON.stringify({ success: true, result: { key, value }, readOnly })
-    )
+    if (result.ok) {
+      logger.log(
+        serializeResultJson({
+          ok: true,
+          data: {
+            key,
+            value: result.data,
+            readOnly
+          }
+        })
+      )
+    } else {
+      logger.log(serializeResultJson(result))
+    }
+  } else if (!result.ok) {
+    logger.fail(failMsgWithBadge(result.message, result.data))
   } else if (outputKind === 'markdown') {
     logger.log(`# Config Value`)
     logger.log('')
-    logger.log(`Config key '${key}' has value '${value}`)
+    logger.log(`Config key '${key}' has value '${result.data}`)
     if (readOnly) {
       logger.log('')
       logger.log(
@@ -25,7 +40,7 @@ export async function outputConfigGet(
       )
     }
   } else {
-    logger.log(`${key}: ${value}`)
+    logger.log(`${key}: ${result.data}`)
     if (readOnly) {
       logger.log('')
       logger.log(

--- a/src/commands/config/output-config-list.ts
+++ b/src/commands/config/output-config-list.ts
@@ -6,6 +6,7 @@ import {
   sensitiveConfigKeys,
   supportedConfigKeys
 } from '../../utils/config'
+import { serializeResultJson } from '../../utils/serialize-result-json'
 
 import type { OutputKind } from '../../types'
 
@@ -18,26 +19,44 @@ export async function outputConfigList({
 }) {
   const readOnly = isReadOnlyConfig()
   if (outputKind === 'json') {
+    let failed = false
     const obj: Record<string, unknown> = {}
     for (const key of supportedConfigKeys.keys()) {
-      let value = getConfigValue(key)
-      if (!full && sensitiveConfigKeys.has(key)) {
+      const result = getConfigValue(key)
+      let value = result.data
+      if (!result.ok) {
+        value = `Failed to retrieve: ${result.message}`
+        failed = true
+      } else if (!full && sensitiveConfigKeys.has(key)) {
         value = '********'
       }
       if (full || value !== undefined) {
         obj[key as any] = value ?? '<none>'
       }
     }
+    if (failed) {
+      process.exitCode = 1
+    }
     logger.log(
-      JSON.stringify(
-        {
-          success: true,
-          full,
-          config: obj,
-          readOnly
-        },
-        null,
-        2
+      serializeResultJson(
+        failed
+          ? {
+              ok: false,
+              message: 'At least one config key failed to be fetched...',
+              data: JSON.stringify({
+                full,
+                config: obj,
+                readOnly
+              })
+            }
+          : {
+              ok: true,
+              data: {
+                full,
+                config: obj,
+                readOnly
+              }
+            }
       )
     )
   } else {
@@ -51,14 +70,19 @@ export async function outputConfigList({
     logger.log(`This is the local CLI config (full=${!!full}):`)
     logger.log('')
     for (const key of supportedConfigKeys.keys()) {
-      let value = getConfigValue(key)
-      if (!full && sensitiveConfigKeys.has(key)) {
-        value = '********'
-      }
-      if (full || value !== undefined) {
-        logger.log(
-          `- ${key}:${' '.repeat(Math.max(0, maxWidth - key.length + 3))} ${Array.isArray(value) ? value.join(', ') || '<none>' : (value ?? '<none>')}`
-        )
+      const result = getConfigValue(key)
+      if (!result.ok) {
+        logger.log(`- ${key}: failed to read: ${result.message}`)
+      } else {
+        let value = result.data
+        if (!full && sensitiveConfigKeys.has(key)) {
+          value = '********'
+        }
+        if (full || value !== undefined) {
+          logger.log(
+            `- ${key}:${' '.repeat(Math.max(0, maxWidth - key.length + 3))} ${Array.isArray(value) ? value.join(', ') || '<none>' : (value ?? '<none>')}`
+          )
+        }
       }
     }
     if (readOnly) {

--- a/src/commands/config/output-config-set.ts
+++ b/src/commands/config/output-config-set.ts
@@ -1,39 +1,27 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 
-import type { OutputKind } from '../../types'
-import type { LocalConfig } from '../../utils/config'
+import { CliJsonResult, OutputKind } from '../../types'
+import { serializeResultJson } from '../../utils/serialize-result-json'
 
 export async function outputConfigSet(
-  key: keyof LocalConfig,
-  _value: string,
-  readOnly: boolean,
+  result: CliJsonResult<undefined | string>,
   outputKind: OutputKind
 ) {
   if (outputKind === 'json') {
-    logger.log(
-      JSON.stringify({
-        success: true,
-        message: `Config key '${key}' was updated${readOnly ? ' (Note: since at least one value was overridden from flag/env, the config was not persisted)' : ''}`,
-        readOnly
-      })
-    )
+    logger.log(serializeResultJson(result))
   } else if (outputKind === 'markdown') {
     logger.log(`# Update config`)
     logger.log('')
-    logger.log(`Config key '${key}' was updated`)
-    if (readOnly) {
+    logger.log(result.message)
+    if (result.data) {
       logger.log('')
-      logger.log(
-        'Note: The change was not persisted because the config is in read-only mode,\n      meaning at least one key was temporarily overridden from an env var or\n      command flag.'
-      )
+      logger.log(result.data)
     }
   } else {
     logger.log(`OK`)
-    if (readOnly) {
+    if (result.data) {
       logger.log('')
-      logger.log(
-        'Note: The change was not persisted because the config is in read-only mode, meaning at least one key was temporarily overridden from an env var or command flag.'
-      )
+      logger.log(result.data)
     }
   }
 }

--- a/src/commands/config/output-config-unset.ts
+++ b/src/commands/config/output-config-unset.ts
@@ -1,24 +1,27 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 
-import type { OutputKind } from '../../types'
-import type { LocalConfig } from '../../utils/config'
+import { failMsgWithBadge } from '../../utils/fail-msg-with-badge'
+import { serializeResultJson } from '../../utils/serialize-result-json'
+
+import type { CliJsonResult, OutputKind } from '../../types'
 
 export async function outputConfigUnset(
-  key: keyof LocalConfig,
+  updateResult: CliJsonResult<undefined | string>,
   outputKind: OutputKind
 ) {
   if (outputKind === 'json') {
-    logger.log(
-      JSON.stringify({
-        success: true,
-        message: `Config key '${key}' was unset`
-      })
-    )
+    logger.log(JSON.stringify(serializeResultJson(updateResult)))
   } else if (outputKind === 'markdown') {
     logger.log(`# Update config`)
     logger.log('')
-    logger.log(`Config key '${key}' was unset`)
-  } else {
+    logger.log(updateResult.message)
+    if (!updateResult.ok) {
+      logger.log('')
+      logger.log(updateResult.data)
+    }
+  } else if (updateResult.ok) {
     logger.log(`OK`)
+  } else {
+    logger.log(failMsgWithBadge(updateResult.message, updateResult.data))
   }
 }

--- a/src/commands/diff-scan/cmd-diff-scan-get.ts
+++ b/src/commands/diff-scan/cmd-diff-scan-get.ts
@@ -9,6 +9,7 @@ import { checkCommandInput } from '../../utils/handle-bad-input'
 import { meowOrExit } from '../../utils/meow-with-subcommands'
 import { getFlagListOutput } from '../../utils/output-formatting'
 import { getDefaultToken } from '../../utils/sdk'
+import { serializeResultJson } from '../../utils/serialize-result-json'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands'
 
@@ -100,8 +101,12 @@ async function run(
   const { after, before, depth, file, json, markdown } = cli.flags
   const outputKind = getOutputKind(json, markdown)
 
-  const defaultOrgSlug = getConfigValue('defaultOrg')
-  const orgSlug = defaultOrgSlug || cli.input[0] || ''
+  const defaultOrgSlugResult = getConfigValue('defaultOrg')
+  if (!defaultOrgSlugResult) {
+    logger.log(serializeResultJson(defaultOrgSlugResult))
+    return
+  }
+  const orgSlug = defaultOrgSlugResult.data || cli.input[0] || ''
 
   const apiToken = getDefaultToken()
 

--- a/src/commands/login/attempt-login.ts
+++ b/src/commands/login/attempt-login.ts
@@ -20,8 +20,8 @@ export async function attemptLogin(
   apiBaseUrl: string | undefined,
   apiProxy: string | undefined
 ) {
-  apiBaseUrl ??= getConfigValue('apiBaseUrl') ?? undefined
-  apiProxy ??= getConfigValue('apiProxy') ?? undefined
+  apiBaseUrl ??= getConfigValue('apiBaseUrl').data ?? undefined
+  apiProxy ??= getConfigValue('apiProxy').data ?? undefined
   const apiToken =
     (await password({
       message: `Enter your ${terminalLink(
@@ -86,7 +86,7 @@ export async function attemptLogin(
 
   spinner.stop()
 
-  const previousPersistedToken = getConfigValue('apiToken')
+  const previousPersistedToken = getConfigValue('apiToken').data
   try {
     applyLogin(apiToken, enforcedOrgs, apiBaseUrl, apiProxy)
     logger.success(

--- a/src/commands/manifest/convert-conda-to-requirements.ts
+++ b/src/commands/manifest/convert-conda-to-requirements.ts
@@ -50,6 +50,7 @@ export async function convertCondaToRequirements(
     })
 
     if (!contents) {
+      process.exitCode = 1
       return {
         ok: false,
         message: 'No data received from stdin',
@@ -64,6 +65,7 @@ export async function convertCondaToRequirements(
     }
 
     if (!fs.existsSync(f)) {
+      process.exitCode = 1
       return {
         ok: false,
         message: `Input file not found at ${f}`,
@@ -74,6 +76,7 @@ export async function convertCondaToRequirements(
     contents = fs.readFileSync(target, 'utf8')
 
     if (!contents) {
+      process.exitCode = 1
       return { ok: false, message: 'File is empty', data: undefined }
     }
   }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -82,7 +82,8 @@ export function getLastFiveOfApiToken(token: string): string {
 // The API server that should be used for operations.
 export function getDefaultApiBaseUrl(): string | undefined {
   const baseUrl =
-    process.env['SOCKET_SECURITY_API_BASE_URL'] || getConfigValue('apiBaseUrl')
+    process.env['SOCKET_SECURITY_API_BASE_URL'] ||
+    getConfigValue('apiBaseUrl').data
   if (isNonEmptyString(baseUrl)) {
     return baseUrl
   }

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { overrideCachedConfig, updateConfigValue } from './config'
+
+describe('utils/config', () => {
+  describe('updateConfigValue', () => {
+    beforeEach(() => {
+      overrideCachedConfig({})
+    })
+
+    it('should return object for applying a change', () => {
+      expect(
+        updateConfigValue('defaultOrg', 'fake_test_org')
+      ).toMatchInlineSnapshot(`
+        {
+          "data": "Change applied but not persisted; current config is overridden through env var or flag",
+          "message": "Config key 'defaultOrg' was updated",
+          "ok": true,
+        }
+      `)
+    })
+
+    it('should warn for invalid key', () => {
+      expect(
+        updateConfigValue(
+          // @ts-ignore
+          'nawthiswontwork',
+          'fake_test_org'
+        )
+      ).toMatchInlineSnapshot(`
+        {
+          "data": undefined,
+          "message": "Invalid config key: nawthiswontwork",
+          "ok": false,
+        }
+      `)
+    })
+  })
+})

--- a/src/utils/determine-org-slug.ts
+++ b/src/utils/determine-org-slug.ts
@@ -9,7 +9,7 @@ export async function determineOrgSlug(
   interactive: boolean,
   dryRun: boolean
 ): Promise<[string, string]> {
-  const defaultOrgSlug = getConfigValue('defaultOrg') || ''
+  const defaultOrgSlug = getConfigValue('defaultOrg').data || ''
   let orgSlug = String(orgFlag || defaultOrgSlug || '')
   if (!orgSlug) {
     if (isTestingV1()) {

--- a/src/utils/handle-bad-input.ts
+++ b/src/utils/handle-bad-input.ts
@@ -46,6 +46,7 @@ export function checkCommandInput(
   process.exitCode = 2
 
   if (outputKind === 'json') {
+    process.exitCode = 1
     logger.log(
       serializeResultJson({
         ok: false,

--- a/src/utils/meow-with-subcommands.ts
+++ b/src/utils/meow-with-subcommands.ts
@@ -292,7 +292,7 @@ function getAsciiHeader(command: string) {
       process.env['INLINED_SOCKET_CLI_VERSION_HASH']
   const nodeVersion = redacting ? REDACTED : process.version
   const apiToken = getDefaultToken()
-  const defaultOrg = getConfigValue('defaultOrg')
+  const defaultOrg = getConfigValue('defaultOrg').data
   const readOnlyConfig = isReadOnlyConfig() ? '*' : '.'
   const v1test = isTestingV1() ? ' (is testing v1)' : ''
   const feedback = isTestingV1()

--- a/src/utils/sdk.ts
+++ b/src/utils/sdk.ts
@@ -23,7 +23,8 @@ const {
 function getDefaultApiBaseUrl(): string | undefined {
   const baseUrl =
     // Lazily access constants.ENV[SOCKET_SECURITY_API_BASE_URL].
-    constants.ENV[SOCKET_SECURITY_API_BASE_URL] || getConfigValue('apiBaseUrl')
+    constants.ENV[SOCKET_SECURITY_API_BASE_URL] ||
+    getConfigValue('apiBaseUrl').data
   return isNonEmptyString(baseUrl) ? baseUrl : undefined
 }
 
@@ -31,7 +32,7 @@ function getDefaultApiBaseUrl(): string | undefined {
 function getDefaultHttpProxy(): string | undefined {
   const apiProxy =
     // Lazily access constants.ENV[SOCKET_SECURITY_API_PROXY].
-    constants.ENV[SOCKET_SECURITY_API_PROXY] || getConfigValue('apiProxy')
+    constants.ENV[SOCKET_SECURITY_API_PROXY] || getConfigValue('apiProxy').data
   return isNonEmptyString(apiProxy) ? apiProxy : undefined
 }
 
@@ -45,7 +46,7 @@ export function getDefaultToken(): string | undefined {
     const key =
       // Lazily access constants.ENV[SOCKET_SECURITY_API_TOKEN].
       constants.ENV[SOCKET_SECURITY_API_TOKEN] ||
-      getConfigValue('apiToken') ||
+      getConfigValue('apiToken').data ||
       _defaultToken
     _defaultToken = isNonEmptyString(key) ? key : undefined
   }


### PR DESCRIPTION
This tackles the `getConfigValue` and `updateConfigValue` functions.

Made me realize the exit code story is messy because what happens when an error is ignored (due to an optional step failing, for example). We shouldn't set the exitCode. Anyways, that'll be the next PR.

This one just tries to implement the Result type to these two functions and anything that it taints.