### PR TITLE
Fix package shallow command due to type mismatch

### DIFF
--- a/src/commands/package/fetch-purls-shallow-score.mts
+++ b/src/commands/package/fetch-purls-shallow-score.mts
@@ -41,5 +41,9 @@ export async function fetchPurlsShallowScore(
     return handleFailedApiResponse('batchPackageFetch', result)
   }
 
-  return { ok: true, data: result }
+  // TODO: seems like there's a bug in the typing since we absolutely have to return the .data here
+  return {
+    ok: true,
+    data: result.data as SocketSdkReturnType<'batchPackageFetch'>
+  }
 }


### PR DESCRIPTION
This fixes `socket package shallow npm babel` which currently breaks due to bad API typing in SDK in OpenAI.