### PR TITLE
Fix output; some was breaking --json, some typos

### DIFF
--- a/src/commands/package/fetch-purl-deep-score.mts
+++ b/src/commands/package/fetch-purl-deep-score.mts
@@ -58,7 +58,7 @@ export interface PurlDataResponse {
 export async function fetchPurlDeepScore(
   purl: string
 ): Promise<CResult<PurlDataResponse>> {
-  logger.info(`Requesting deep score data for this purl: ${purl}`)
+  logger.error(`Requesting deep score data for this purl: ${purl}`)
 
   const apiToken = getDefaultToken()
   if (!apiToken) {
@@ -96,7 +96,7 @@ export async function fetchPurlDeepScore(
     return {
       ok: false,
       message: 'Socket API returned an error',
-      cause: `${result.statusText}${err ? ` (cause: ${err}` : ''}`
+      cause: `${result.statusText}${err ? ` (cause: ${err})` : ''}`
     }
   }
 

--- a/src/commands/package/fetch-purls-shallow-score.mts
+++ b/src/commands/package/fetch-purls-shallow-score.mts
@@ -13,7 +13,7 @@ import type {
 export async function fetchPurlsShallowScore(
   purls: string[]
 ): Promise<CResult<SocketSdkReturnType<'batchPackageFetch'>>> {
-  logger.info(
+  logger.error(
     `Requesting shallow score data for ${purls.length} package urls (purl): ${purls.join(', ')}`
   )
 

--- a/src/commands/scan/cmd-scan-report.mts
+++ b/src/commands/scan/cmd-scan-report.mts
@@ -142,7 +142,7 @@ async function run(
     },
     {
       test: !!scanId,
-      message: 'Scan ID to fetch',
+      message: 'Scan ID to report on',
       pass: 'ok',
       fail: 'missing'
     },

--- a/src/commands/scan/cmd-scan-report.test.mts
+++ b/src/commands/scan/cmd-scan-report.test.mts
@@ -84,7 +84,7 @@ describe('socket scan report', async () => {
 
           - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - Scan ID to fetch (\\x1b[31mmissing\\x1b[39m)
+          - Scan ID to report on (\\x1b[31mmissing\\x1b[39m)
 
           - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
         \\x1b[22m"

--- a/src/commands/scan/cmd-scan-view.mts
+++ b/src/commands/scan/cmd-scan-view.mts
@@ -119,7 +119,7 @@ async function run(
     },
     {
       test: !!scanId,
-      message: 'Scan ID to delete',
+      message: 'Scan ID to view',
       pass: 'ok',
       fail: 'missing'
     },

--- a/src/commands/scan/cmd-scan-view.test.mts
+++ b/src/commands/scan/cmd-scan-view.test.mts
@@ -73,7 +73,7 @@ describe('socket scan view', async () => {
 
           - Org name must be the first argument (\\x1b[31mmissing\\x1b[39m)
 
-          - Scan ID to delete (\\x1b[31mmissing\\x1b[39m)
+          - Scan ID to view (\\x1b[31mmissing\\x1b[39m)
 
           - You need to be logged in to use this command. See \`socket login\`. (\\x1b[31mmissing API token\\x1b[39m)
         \\x1b[22m"

--- a/src/commands/scan/fetch-diff-scan.mts
+++ b/src/commands/scan/fetch-diff-scan.mts
@@ -38,7 +38,7 @@ export async function fetchDiffScan({
     return {
       ok: false,
       message: 'Socket API returned an error',
-      cause: `${response.statusText}${err ? ` (cause: ${err}` : ''}`
+      cause: `${response.statusText}${err ? ` (cause: ${err})` : ''}`
     }
   }
 

--- a/src/commands/scan/fetch-report-data.mts
+++ b/src/commands/scan/fetch-report-data.mts
@@ -60,7 +60,7 @@ export async function fetchReportData(
   function updateProgress() {
     if (finishedFetching) {
       spinner.stop()
-      logger.info(
+      logger.error(
         `Scan result: ${scanStatus}. Security policy: ${policyStatus}.`
       )
     } else {
@@ -85,7 +85,7 @@ export async function fetchReportData(
       return {
         ok: false,
         message: 'Socket API returned an error',
-        cause: `${response.statusText}${err ? ` (cause: ${err}` : ''}`
+        cause: `${response.statusText}${err ? ` (cause: ${err})` : ''}`
       }
     }
 

--- a/src/commands/scan/fetch-scan.mts
+++ b/src/commands/scan/fetch-scan.mts
@@ -36,7 +36,7 @@ export async function fetchScan(
     return {
       ok: false,
       message: 'Socket API returned an error',
-      cause: `${response.statusText}${err ? ` (cause: ${err}` : ''}`
+      cause: `${response.statusText}${err ? ` (cause: ${err})` : ''}`
     }
   }
 

--- a/src/commands/scan/fetch-supported-scan-file-names.mts
+++ b/src/commands/scan/fetch-supported-scan-file-names.mts
@@ -23,7 +23,7 @@ export async function fetchSupportedScanFileNames(): Promise<
   )
 
   spinner.stop()
-  logger.success('Received response while fetched supported scan file types.')
+  logger.error('Received response while fetched supported scan file types.')
 
   if (!result.success) {
     return handleFailedApiResponse('getReportSupportedFiles', result)

--- a/src/commands/scan/fetch-supported-scan-file-names.mts
+++ b/src/commands/scan/fetch-supported-scan-file-names.mts
@@ -23,7 +23,7 @@ export async function fetchSupportedScanFileNames(): Promise<
   )
 
   spinner.stop()
-  logger.error('Received response while fetched supported scan file types.')
+  logger.error('Received response while fetching supported scan file types.')
 
   if (!result.success) {
     return handleFailedApiResponse('getReportSupportedFiles', result)


### PR DESCRIPTION
Some minor output fixes

- various cases of logging to stdout that was breaking --json, temporarily doing an .error() but we'll change the logger soon to always output non-log commands to stderr and then we can do a sweep through the .error() calls to see what needs to be different.
- Some textual changes and fixed some missing parenthesis in text (the bot caught one the other day but apparently didn't think it was important for the others)