### PR TITLE
Add root shortcut "sd" to invoke the cli

### DIFF
--- a/sd
+++ b/sd
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+node --experimental-strip-types --no-warnings src/cli.mts "$@"

--- a/sd
+++ b/sd
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 node --experimental-strip-types --no-warnings src/cli.mts "$@"


### PR DESCRIPTION
`sd` is for `socket dev`, but also for running socket in dev mode.

It will invoke the src/cli.mts script with strip types and pass on args verbatim.

Now all we need to do in dev is in the root of `socket-cli` call `./sd` (which, I assure you, you get used to quite quickly).

Instant dev gratification.