### PR TITLE
Add node20 fallback to ./sd

### DIFF
--- a/sd
+++ b/sd
@@ -1,3 +1,11 @@
 #!/usr/bin/env sh
 
-node --experimental-strip-types --no-warnings src/cli.mts "$@"
+# node 20 does not support strip types (yet) so we have go the slow path
+# Note that we don't rebuild here... this will be annoying later but I
+# think this is only for dev where we don't need to run node 20.
+# Should we emit a warning anyways? Maybe.
+if [ "$(node -v | cut -d'v' -f2 | cut -d'.' -f1)" -lt 22 ]; then
+  npm run s -- "$@"
+else
+  node --experimental-strip-types --no-warnings src/cli.mts "$@"
+fi


### PR DESCRIPTION
This allows ./sd to run in node20 too by calling npm run.

I chose to have it call `npm run s` rather than `npm run bs` because we're most likely to use it for node 22 anyways. Adding a warning would add more noise. I dunno. We can still add a warning if we want to.