### PR TITLE
Change handle API to be --json safe

### DIFF
--- a/src/commands/analytics/fetch-org-analytics.mts
+++ b/src/commands/analytics/fetch-org-analytics.mts
@@ -1,5 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -10,32 +9,11 @@ export async function fetchOrgAnalyticsData(
 ): Promise<CResult<SocketSdkReturnType<'getOrgAnalytics'>['data']>> {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start(`Requesting analytics data from API...`)
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.getOrgAnalytics(time.toString()),
-    'fetching analytics data'
+    'Requesting analytics data from API...',
+    'Received API response (requested analytics data).',
+    'Error fetching analytics data',
+    'getOrgAnalytics'
   )
-
-  spinner.successAndStop(`Received API response.`)
-
-  if (result.success === false) {
-    return handleFailedApiResponse('getOrgAnalytics', result)
-  }
-
-  if (!result.data.length) {
-    return {
-      ok: true,
-      message: 'No analytics data is available for this organization yet.',
-      data: []
-    }
-  }
-
-  return {
-    ok: true,
-    data: result.data
-  }
 }

--- a/src/commands/analytics/fetch-org-analytics.mts
+++ b/src/commands/analytics/fetch-org-analytics.mts
@@ -11,9 +11,6 @@ export async function fetchOrgAnalyticsData(
 
   return await handleApiCall(
     sockSdk.getOrgAnalytics(time.toString()),
-    'Requesting analytics data from API...',
-    'Received API response (requested analytics data).',
-    'Error fetching analytics data',
-    'getOrgAnalytics'
+    'analytics data'
   )
 }

--- a/src/commands/analytics/fetch-repo-analytics.mts
+++ b/src/commands/analytics/fetch-repo-analytics.mts
@@ -12,9 +12,6 @@ export async function fetchRepoAnalyticsData(
 
   return await handleApiCall(
     sockSdk.getRepoAnalytics(repo, time.toString()),
-    'Requesting analytics data from API...',
-    'Received API response (requested analytics data).',
-    'Error fetching analytics data',
-    'getRepoAnalytics'
+    'analytics data'
   )
 }

--- a/src/commands/analytics/fetch-repo-analytics.mts
+++ b/src/commands/analytics/fetch-repo-analytics.mts
@@ -1,5 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -11,32 +10,11 @@ export async function fetchRepoAnalyticsData(
 ): Promise<CResult<SocketSdkReturnType<'getRepoAnalytics'>['data']>> {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start(`Requesting analytics data from API...`)
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.getRepoAnalytics(repo, time.toString()),
-    'fetching analytics data'
+    'Requesting analytics data from API...',
+    'Received API response (requested analytics data).',
+    'Error fetching analytics data',
+    'getRepoAnalytics'
   )
-
-  spinner.successAndStop(`Received API response.`)
-
-  if (result.success === false) {
-    return handleFailedApiResponse('getRepoAnalytics', result)
-  }
-
-  if (!result.data.length) {
-    return {
-      ok: true,
-      message: 'No analytics data is available for this repository yet.',
-      data: []
-    }
-  }
-
-  return {
-    ok: true,
-    data: result.data
-  }
 }

--- a/src/commands/analytics/handle-analytics.mts
+++ b/src/commands/analytics/handle-analytics.mts
@@ -32,6 +32,13 @@ export async function handleAnalytics({
       message: 'Missing repository name in command'
     }
   }
+  if (result.ok && !result.data.length) {
+    result = {
+      ok: true,
+      message: `The analytics data for this ${scope === 'org' ? 'organization' : 'repository'} is not yet available.`,
+      data: []
+    }
+  }
 
   await outputAnalytics(result, {
     filePath,

--- a/src/commands/audit-log/fetch-audit-log.mts
+++ b/src/commands/audit-log/fetch-audit-log.mts
@@ -30,9 +30,6 @@ export async function fetchAuditLog({
       page: String(page),
       per_page: String(perPage)
     }),
-    `Looking up audit log for ${orgSlug}\n`,
-    'Received API response (requested audit log).',
-    'Error fetching audit log',
-    'getAuditLogEvents'
+    `audit log for ${orgSlug}`
   )
 }

--- a/src/commands/audit-log/fetch-audit-log.mts
+++ b/src/commands/audit-log/fetch-audit-log.mts
@@ -1,5 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult, OutputKind } from '../../types.mts'
@@ -20,12 +19,7 @@ export async function fetchAuditLog({
 }): Promise<CResult<SocketSdkReturnType<'getAuditLogEvents'>['data']>> {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start(`Looking up audit log for ${orgSlug}`)
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.getAuditLogEvents(orgSlug, {
       // I'm not sure this is used at all.
       outputJson: String(outputKind === 'json'),
@@ -36,17 +30,9 @@ export async function fetchAuditLog({
       page: String(page),
       per_page: String(perPage)
     }),
-    `Looking up audit log for ${orgSlug}\n`
+    `Looking up audit log for ${orgSlug}\n`,
+    'Received API response (requested audit log).',
+    'Error fetching audit log',
+    'getAuditLogEvents'
   )
-
-  spinner.successAndStop(`Received API response.`)
-
-  if (!result.success) {
-    return handleFailedApiResponse('getAuditLogEvents', result)
-  }
-
-  return {
-    ok: true,
-    data: result.data
-  }
 }

--- a/src/commands/ci/fetch-default-org-slug.mts
+++ b/src/commands/ci/fetch-default-org-slug.mts
@@ -1,36 +1,32 @@
 import { debugLog } from '@socketsecurity/registry/lib/debug'
 
 import { handleApiCall } from '../../utils/api.mts'
-import { getConfigValue } from '../../utils/config.mts'
+import { getConfigValueOrUndef } from '../../utils/config.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
 
 // Use the config defaultOrg when set, otherwise discover from remote
 export async function getDefaultOrgSlug(): Promise<CResult<string>> {
-  const defaultOrgResult = getConfigValue('defaultOrg')
-  if (!defaultOrgResult.ok) {
-    return defaultOrgResult
-  }
+  const defaultOrgResult = getConfigValueOrUndef('defaultOrg')
 
-  if (defaultOrgResult.data) {
-    debugLog(`Using default org: ${defaultOrgResult.data}`)
-    return { ok: true, data: defaultOrgResult.data }
+  if (defaultOrgResult) {
+    debugLog(`Using default org: ${defaultOrgResult}`)
+    return { ok: true, data: defaultOrgResult }
   }
 
   const sockSdk = await setupSdk()
 
   const result = await handleApiCall(
     sockSdk.getOrganizations(),
-    'looking up organizations'
+    'Requesting list of organizations...',
+    'Received API response (requested list of organizations).',
+    'Error fetching list of organizations',
+    'getOrganizations'
   )
 
-  if (!result.success) {
-    return {
-      ok: false,
-      message: result.error,
-      data: `Failed to fetch default organization from API. Unable to continue.${result.cause ? ` ( Reason given: ${result.cause} )` : ''}`
-    }
+  if (!result.ok) {
+    return result
   }
 
   const orgs = result.data.organizations

--- a/src/commands/ci/fetch-default-org-slug.mts
+++ b/src/commands/ci/fetch-default-org-slug.mts
@@ -19,10 +19,7 @@ export async function getDefaultOrgSlug(): Promise<CResult<string>> {
 
   const result = await handleApiCall(
     sockSdk.getOrganizations(),
-    'Requesting list of organizations...',
-    'Received API response (requested list of organizations).',
-    'Error fetching list of organizations',
-    'getOrganizations'
+    'list of organizations'
   )
 
   if (!result.ok) {

--- a/src/commands/config/discover-config-value.mts
+++ b/src/commands/config/discover-config-value.mts
@@ -133,10 +133,13 @@ async function getDefaultOrgFromToken(): Promise<
 
   const result = await handleApiCall(
     sockSdk.getOrganizations(),
-    'looking up organizations'
+    'Requesting list of organizations...',
+    'Received API response (requested list of organizations).',
+    'Error fetching list of organizations',
+    'getOrganizations'
   )
 
-  if (result.success) {
+  if (result.ok) {
     const arr = Array.from(Object.values(result.data.organizations)).map(
       ({ slug }) => slug
     )
@@ -157,10 +160,13 @@ async function getEnforceableOrgsFromToken(): Promise<string[] | undefined> {
 
   const result = await handleApiCall(
     sockSdk.getOrganizations(),
-    'looking up organizations'
+    'Requesting list of organizations...',
+    'Received API response (requested list of organizations).',
+    'Error fetching list of organizations',
+    'getOrganizations'
   )
 
-  if (result.success) {
+  if (result.ok) {
     const arr = Array.from(Object.values(result.data.organizations)).map(
       ({ slug }) => slug
     )

--- a/src/commands/config/discover-config-value.mts
+++ b/src/commands/config/discover-config-value.mts
@@ -133,10 +133,7 @@ async function getDefaultOrgFromToken(): Promise<
 
   const result = await handleApiCall(
     sockSdk.getOrganizations(),
-    'Requesting list of organizations...',
-    'Received API response (requested list of organizations).',
-    'Error fetching list of organizations',
-    'getOrganizations'
+    'list of organizations'
   )
 
   if (result.ok) {
@@ -160,10 +157,7 @@ async function getEnforceableOrgsFromToken(): Promise<string[] | undefined> {
 
   const result = await handleApiCall(
     sockSdk.getOrganizations(),
-    'Requesting list of organizations...',
-    'Received API response (requested list of organizations).',
-    'Error fetching list of organizations',
-    'getOrganizations'
+    'list of organizations'
   )
 
   if (result.ok) {

--- a/src/commands/dependencies/fetch-dependencies.mts
+++ b/src/commands/dependencies/fetch-dependencies.mts
@@ -15,9 +15,6 @@ export async function fetchDependencies({
 
   return await handleApiCall(
     sockSdk.searchDependencies({ limit, offset }),
-    'Requesting organization dependencies from API...',
-    'Received response from API (requested organization dependencies).',
-    'Error fetching organization dependencies',
-    'searchDependencies'
+    'organization dependencies'
   )
 }

--- a/src/commands/dependencies/fetch-dependencies.mts
+++ b/src/commands/dependencies/fetch-dependencies.mts
@@ -1,5 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -14,21 +13,11 @@ export async function fetchDependencies({
 }): Promise<CResult<SocketSdkReturnType<'searchDependencies'>['data']>> {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start('Fetching organization dependencies...')
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.searchDependencies({ limit, offset }),
-    'Searching dependencies'
+    'Requesting organization dependencies from API...',
+    'Received response from API (requested organization dependencies).',
+    'Error fetching organization dependencies',
+    'searchDependencies'
   )
-
-  spinner.successAndStop('Received organization dependencies response.')
-
-  if (!result.success) {
-    return handleFailedApiResponse('searchDependencies', result)
-  }
-
-  return { ok: true, data: result.data }
 }

--- a/src/commands/diff-scan/fetch-diff-scan.mts
+++ b/src/commands/diff-scan/fetch-diff-scan.mts
@@ -37,12 +37,15 @@ export async function fetchDiffScan({
     }
   }
 
-  const result = await handleApiCall(
-    (await response.json()) as Promise<
-      SocketSdkReturnType<'GetOrgDiffScan'>['data']
-    >,
-    'Deserializing json'
-  )
+  const result = (await response.json()) as Promise<
+    SocketSdkReturnType<'GetOrgDiffScan'>
+  >
 
-  return { ok: true, data: result }
+  return await handleApiCall(
+    result,
+    'Deserializing json',
+    'Received API response (requested a diff-scan).',
+    'Error fetching diff-scan',
+    'GetOrgDiffScan'
+  )
 }

--- a/src/commands/diff-scan/fetch-diff-scan.mts
+++ b/src/commands/diff-scan/fetch-diff-scan.mts
@@ -1,5 +1,5 @@
 import constants from '../../constants.mts'
-import { handleApiCall, handleApiError, queryApi } from '../../utils/api.mts'
+import { handleApiError, queryApi } from '../../utils/api.mts'
 import { getDefaultToken } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'

--- a/src/commands/diff-scan/fetch-diff-scan.mts
+++ b/src/commands/diff-scan/fetch-diff-scan.mts
@@ -37,15 +37,8 @@ export async function fetchDiffScan({
     }
   }
 
-  const result = (await response.json()) as Promise<
-    SocketSdkReturnType<'GetOrgDiffScan'>
-  >
+  const result =
+    (await response.json()) as SocketSdkReturnType<'GetOrgDiffScan'>['data']
 
-  return await handleApiCall(
-    result,
-    'Deserializing json',
-    'Received API response (requested a diff-scan).',
-    'Error fetching diff-scan',
-    'GetOrgDiffScan'
-  )
+  return { ok: true, data: result }
 }

--- a/src/commands/info/fetch-package-info.mts
+++ b/src/commands/info/fetch-package-info.mts
@@ -16,17 +16,11 @@ export async function fetchPackageInfo(
 
   const result = await handleApiCall(
     sockSdk.getIssuesByNPMPackage(pkgName, pkgVersion),
-    'Requesting package issues...',
-    'Received API response (requested package issues).',
-    'Error fetching package issues',
-    'getIssuesByNPMPackage'
+    'package issues'
   )
   const scoreResult = await handleApiCall(
     sockSdk.getScoreByNPMPackage(pkgName, pkgVersion),
-    'looking up package score',
-    'Received API response (requested package score).',
-    'Error fetching package score',
-    'getScoreByNPMPackage'
+    'package score'
   )
 
   if (!result.ok) {

--- a/src/commands/info/fetch-package-info.mts
+++ b/src/commands/info/fetch-package-info.mts
@@ -1,4 +1,3 @@
-import constants from '../../constants.mts'
 import { getSeverityCount } from '../../utils/alert/severity.mts'
 import {
   handleApiCall,
@@ -15,32 +14,37 @@ export async function fetchPackageInfo(
 ): Promise<void | PackageData> {
   const sockSdk = await setupSdk(getPublicToken())
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start(
-    pkgVersion === 'latest'
-      ? `Looking up data for the latest version of ${pkgName}`
-      : `Looking up data for version ${pkgVersion} of ${pkgName}`
-  )
-
   const result = await handleApiCall(
     sockSdk.getIssuesByNPMPackage(pkgName, pkgVersion),
-    'looking up package'
+    'Requesting package issues...',
+    'Received API response (requested package issues).',
+    'Error fetching package issues',
+    'getIssuesByNPMPackage'
   )
   const scoreResult = await handleApiCall(
     sockSdk.getScoreByNPMPackage(pkgName, pkgVersion),
-    'looking up package score'
+    'looking up package score',
+    'Received API response (requested package score).',
+    'Error fetching package score',
+    'getScoreByNPMPackage'
   )
 
-  spinner.successAndStop('Data fetched')
-
-  if (result.success === false) {
-    handleUnsuccessfulApiResponse('getIssuesByNPMPackage', result)
+  if (!result.ok) {
+    handleUnsuccessfulApiResponse(
+      'getIssuesByNPMPackage',
+      result.message,
+      result.cause ?? '',
+      (result.data as any)?.code ?? 0
+    )
   }
 
-  if (scoreResult.success === false) {
-    handleUnsuccessfulApiResponse('getScoreByNPMPackage', scoreResult)
+  if (!scoreResult.ok) {
+    handleUnsuccessfulApiResponse(
+      'getScoreByNPMPackage',
+      scoreResult.message,
+      scoreResult.cause ?? '',
+      (scoreResult.data as any)?.code ?? 0
+    )
   }
 
   const severityCount = getSeverityCount(

--- a/src/commands/login/attempt-login.mts
+++ b/src/commands/login/attempt-login.mts
@@ -35,10 +35,7 @@ export async function attemptLogin(
 
   const result = await handleApiCall(
     sdk.getOrganizations(),
-    'Verifying API key...',
-    'Received response',
-    'Error verifying API key',
-    'getOrganizations'
+    'token verification'
   )
 
   if (!result.ok) {

--- a/src/commands/organization/fetch-license-policy.mts
+++ b/src/commands/organization/fetch-license-policy.mts
@@ -11,9 +11,6 @@ export async function fetchLicensePolicy(
 
   return await handleApiCall(
     sockSdk.getOrgLicensePolicy(orgSlug),
-    'looking up organization quota',
-    'Received organization license policy response.',
-    'Error fetching organization license policy',
-    'getOrgLicensePolicy'
+    'organization license policy'
   )
 }

--- a/src/commands/organization/fetch-license-policy.mts
+++ b/src/commands/organization/fetch-license-policy.mts
@@ -1,5 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -10,21 +9,11 @@ export async function fetchLicensePolicy(
 ): Promise<CResult<SocketSdkReturnType<'getOrgLicensePolicy'>['data']>> {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start('Fetching organization license policy...')
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.getOrgLicensePolicy(orgSlug),
-    'looking up organization quota'
+    'looking up organization quota',
+    'Received organization license policy response.',
+    'Error fetching organization license policy',
+    'getOrgLicensePolicy'
   )
-
-  spinner.successAndStop('Received organization license policy response.')
-
-  if (!result.success) {
-    return handleFailedApiResponse('getOrgLicensePolicy', result)
-  }
-
-  return { ok: true, data: result.data }
 }

--- a/src/commands/organization/fetch-organization-list.mts
+++ b/src/commands/organization/fetch-organization-list.mts
@@ -1,5 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -10,21 +9,11 @@ export async function fetchOrganization(): Promise<
 > {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start('Fetching organization list...')
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.getOrganizations(),
-    'looking up organizations'
+    'Requesting organization list from API...',
+    'Received API response (requested organization list).',
+    'Error fetching organization list',
+    'getOrganizations'
   )
-
-  spinner.successAndStop('Received organization list response.')
-
-  if (!result.success) {
-    return handleFailedApiResponse('getOrganizations', result)
-  }
-
-  return { ok: true, data: result.data }
 }

--- a/src/commands/organization/fetch-organization-list.mts
+++ b/src/commands/organization/fetch-organization-list.mts
@@ -9,11 +9,5 @@ export async function fetchOrganization(): Promise<
 > {
   const sockSdk = await setupSdk()
 
-  return await handleApiCall(
-    sockSdk.getOrganizations(),
-    'Requesting organization list from API...',
-    'Received API response (requested organization list).',
-    'Error fetching organization list',
-    'getOrganizations'
-  )
+  return await handleApiCall(sockSdk.getOrganizations(), 'organization list')
 }

--- a/src/commands/organization/fetch-quota.mts
+++ b/src/commands/organization/fetch-quota.mts
@@ -9,11 +9,5 @@ export async function fetchQuota(): Promise<
 > {
   const sockSdk = await setupSdk()
 
-  return await handleApiCall(
-    sockSdk.getQuota(),
-    'Requesting token quota from API...',
-    'Received API response (requested token quota).',
-    'Error fetching token quota',
-    'getQuota'
-  )
+  return await handleApiCall(sockSdk.getQuota(), 'token quota')
 }

--- a/src/commands/organization/fetch-quota.mts
+++ b/src/commands/organization/fetch-quota.mts
@@ -1,5 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -10,21 +9,11 @@ export async function fetchQuota(): Promise<
 > {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start('Fetching organization quota...')
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.getQuota(),
-    'looking up organization quota'
+    'Requesting token quota from API...',
+    'Received API response (requested token quota).',
+    'Error fetching token quota',
+    'getQuota'
   )
-
-  spinner.successAndStop('Received organization quota response.')
-
-  if (!result.success) {
-    return handleFailedApiResponse('getQuota', result)
-  }
-
-  return { ok: true, data: result.data }
 }

--- a/src/commands/organization/fetch-security-policy.mts
+++ b/src/commands/organization/fetch-security-policy.mts
@@ -11,9 +11,6 @@ export async function fetchSecurityPolicy(
 
   return await handleApiCall(
     sockSdk.getOrgSecurityPolicy(orgSlug),
-    'Requesting organization security policy from API...',
-    'Received API response (requested organization security policy).',
-    'Error fetching organization security policy',
-    'getOrgSecurityPolicy'
+    'organization security policy'
   )
 }

--- a/src/commands/organization/fetch-security-policy.mts
+++ b/src/commands/organization/fetch-security-policy.mts
@@ -1,5 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -10,21 +9,11 @@ export async function fetchSecurityPolicy(
 ): Promise<CResult<SocketSdkReturnType<'getOrgSecurityPolicy'>['data']>> {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start('Fetching organization security policy...')
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.getOrgSecurityPolicy(orgSlug),
-    'looking up organization quota'
+    'Requesting organization security policy from API...',
+    'Received API response (requested organization security policy).',
+    'Error fetching organization security policy',
+    'getOrgSecurityPolicy'
   )
-
-  spinner.successAndStop('Received organization security policy response.')
-
-  if (!result.success) {
-    return handleFailedApiResponse('getOrgSecurityPolicy', result)
-  }
-
-  return { ok: true, data: result.data }
 }

--- a/src/commands/package/fetch-purl-deep-score.mts
+++ b/src/commands/package/fetch-purl-deep-score.mts
@@ -1,7 +1,7 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import constants from '../../constants.mts'
-import { handleApiCall, handleApiError, queryApi } from '../../utils/api.mts'
+import { handleApiError, queryApi } from '../../utils/api.mts'
 import { getDefaultToken } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -100,10 +100,13 @@ export async function fetchPurlDeepScore(
     }
   }
 
-  const data = await handleApiCall(await result.text(), 'Reading text')
+  const data = await result.text()
 
   try {
-    return { ok: true, data: JSON.parse(data) }
+    return {
+      ok: true,
+      data: JSON.parse(data) // as PurlDataResponse
+    }
   } catch (e) {
     return {
       ok: false,

--- a/src/commands/package/fetch-purls-shallow-score.mts
+++ b/src/commands/package/fetch-purls-shallow-score.mts
@@ -1,7 +1,10 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import {
+  handleFailedApiResponse,
+  tmpHandleApiCall as oldHandleApiCall
+} from '../../utils/api.mts'
 import { getPublicToken, setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -24,8 +27,8 @@ export async function fetchPurlsShallowScore(
 
   spinner.start(`Requesting data ...`)
 
-  const result: Awaited<SocketSdkResultType<'batchPackageFetch'>> =
-    await handleApiCall(
+  const result: SocketSdkResultType<'batchPackageFetch'> =
+    await oldHandleApiCall(
       sockSdk.batchPackageFetch(
         {
           alerts: 'true'

--- a/src/commands/repos/fetch-create-repo.mts
+++ b/src/commands/repos/fetch-create-repo.mts
@@ -1,5 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -22,12 +21,7 @@ export async function fetchCreateRepo({
 }): Promise<CResult<SocketSdkReturnType<'createOrgRepo'>['data']>> {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start('Sending request ot create a repository...')
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.createOrgRepo(orgSlug, {
       name: repoName,
       description,
@@ -35,14 +29,9 @@ export async function fetchCreateRepo({
       default_branch,
       visibility
     }),
-    'creating repository'
+    'Requesting to create a repository...',
+    'Received API response (requested to create a repository).',
+    'Error creating repository',
+    'createOrgRepo'
   )
-
-  spinner.successAndStop('Received response requesting to create a repository.')
-
-  if (!result.success) {
-    return handleFailedApiResponse('createOrgRepo', result)
-  }
-
-  return { ok: true, data: result.data }
 }

--- a/src/commands/repos/fetch-create-repo.mts
+++ b/src/commands/repos/fetch-create-repo.mts
@@ -29,9 +29,6 @@ export async function fetchCreateRepo({
       default_branch,
       visibility
     }),
-    'Requesting to create a repository...',
-    'Received API response (requested to create a repository).',
-    'Error creating repository',
-    'createOrgRepo'
+    'to create a repository'
   )
 }

--- a/src/commands/repos/fetch-delete-repo.mts
+++ b/src/commands/repos/fetch-delete-repo.mts
@@ -1,5 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -11,21 +10,11 @@ export async function fetchDeleteRepo(
 ): Promise<CResult<SocketSdkReturnType<'deleteOrgRepo'>['data']>> {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start('Sending request to delete a repository...')
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.deleteOrgRepo(orgSlug, repoName),
-    'deleting repository'
+    'Requesting to delete a repository...',
+    'Received API response (requested to delete a repository).',
+    'Error deleting repository',
+    'deleteOrgRepo'
   )
-
-  spinner.successAndStop('Received response requesting to delete a repository.')
-
-  if (!result.success) {
-    return handleFailedApiResponse('deleteOrgRepo', result)
-  }
-
-  return { ok: true, data: result.data }
 }

--- a/src/commands/repos/fetch-delete-repo.mts
+++ b/src/commands/repos/fetch-delete-repo.mts
@@ -12,9 +12,6 @@ export async function fetchDeleteRepo(
 
   return await handleApiCall(
     sockSdk.deleteOrgRepo(orgSlug, repoName),
-    'Requesting to delete a repository...',
-    'Received API response (requested to delete a repository).',
-    'Error deleting repository',
-    'deleteOrgRepo'
+    'to delete a repository'
   )
 }

--- a/src/commands/repos/fetch-list-repos.mts
+++ b/src/commands/repos/fetch-list-repos.mts
@@ -26,9 +26,6 @@ export async function fetchListRepos({
       per_page: String(per_page),
       page: String(page)
     }),
-    'Requesting list of repositories...',
-    'Received API response (requested list of repositories).',
-    'Error fetching list of repositories',
-    'getOrgRepoList'
+    'list of repositories'
   )
 }

--- a/src/commands/repos/fetch-list-repos.mts
+++ b/src/commands/repos/fetch-list-repos.mts
@@ -1,5 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -20,26 +19,16 @@ export async function fetchListRepos({
 }): Promise<CResult<SocketSdkReturnType<'getOrgRepoList'>['data']>> {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start('Fetching list of repositories...')
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.getOrgRepoList(orgSlug, {
       sort,
       direction,
       per_page: String(per_page),
       page: String(page)
     }),
-    'listing repositories'
+    'Requesting list of repositories...',
+    'Received API response (requested list of repositories).',
+    'Error fetching list of repositories',
+    'getOrgRepoList'
   )
-
-  spinner.successAndStop('Received response for repository list.')
-
-  if (!result.success) {
-    return handleFailedApiResponse('getOrgRepoList', result)
-  }
-
-  return { ok: true, data: result.data }
 }

--- a/src/commands/repos/fetch-update-repo.mts
+++ b/src/commands/repos/fetch-update-repo.mts
@@ -30,9 +30,6 @@ export async function fetchUpdateRepo({
       default_branch,
       visibility
     }),
-    'Requesting to update a repository...',
-    'Received API response (requested to update a repository).',
-    'Error updating repository',
-    'updateOrgRepo'
+    'to update a repository'
   )
 }

--- a/src/commands/repos/fetch-update-repo.mts
+++ b/src/commands/repos/fetch-update-repo.mts
@@ -1,5 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -22,12 +21,7 @@ export async function fetchUpdateRepo({
 }): Promise<CResult<SocketSdkReturnType<'updateOrgRepo'>['data']>> {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start('Sending request to update a repository...')
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.updateOrgRepo(orgSlug, repoName, {
       orgSlug,
       name: repoName,
@@ -36,14 +30,9 @@ export async function fetchUpdateRepo({
       default_branch,
       visibility
     }),
-    'updating repository'
+    'Requesting to update a repository...',
+    'Received API response (requested to update a repository).',
+    'Error updating repository',
+    'updateOrgRepo'
   )
-
-  spinner.successAndStop('Received response trying to update a repository')
-
-  if (!result.success) {
-    return handleFailedApiResponse('updateOrgRepo', result)
-  }
-
-  return { ok: true, data: result.data }
 }

--- a/src/commands/repos/fetch-view-repo.mts
+++ b/src/commands/repos/fetch-view-repo.mts
@@ -12,9 +12,6 @@ export async function fetchViewRepo(
 
   return await handleApiCall(
     sockSdk.getOrgRepo(orgSlug, repoName),
-    'Requesting repository data...',
-    'Received API response (requested repository data).',
-    'Error fetching repository data',
-    'getOrgRepo'
+    'repository data'
   )
 }

--- a/src/commands/repos/fetch-view-repo.mts
+++ b/src/commands/repos/fetch-view-repo.mts
@@ -1,5 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -11,21 +10,11 @@ export async function fetchViewRepo(
 ): Promise<CResult<SocketSdkReturnType<'getOrgRepo'>['data']>> {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start('Fetching repository data...')
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.getOrgRepo(orgSlug, repoName),
-    'fetching repository'
+    'Requesting repository data...',
+    'Received API response (requested repository data).',
+    'Error fetching repository data',
+    'getOrgRepo'
   )
-
-  spinner.successAndStop('Received response while fetched repository data.')
-
-  if (!result.success) {
-    return handleFailedApiResponse('getOrgRepo', result)
-  }
-
-  return { ok: true, data: result.data }
 }

--- a/src/commands/scan/cmd-scan-diff.mts
+++ b/src/commands/scan/cmd-scan-diff.mts
@@ -103,15 +103,15 @@ async function run(
   } = cli.flags
   const outputKind = getOutputKind(json, markdown)
 
-  const [orgSlug, defaultOrgSlug] = await determineOrgSlug(
+  const [orgSlug] = await determineOrgSlug(
     String(orgFlag || ''),
     cli.input[0] || '',
     !!interactive,
     !!dryRun
   )
 
-  let id1 = cli.input[defaultOrgSlug ? 0 : 1] || ''
-  let id2 = cli.input[defaultOrgSlug ? 1 : 2] || ''
+  let id1 = cli.input[isTestingV1() || orgSlug ? 0 : 1] || ''
+  let id2 = cli.input[isTestingV1() || orgSlug ? 1 : 2] || ''
   if (id1.startsWith(SOCKET_SBOM_URL_PREFIX)) {
     id1 = id1.slice(SOCKET_SBOM_URL_PREFIX.length)
   }

--- a/src/commands/scan/fetch-create-org-full-scan.mts
+++ b/src/commands/scan/fetch-create-org-full-scan.mts
@@ -46,9 +46,6 @@ export async function fetchCreateOrgFullScan(
       packagePaths,
       cwd
     ),
-    'Requesting to create a scan...',
-    'Received API response (requested to create a scan).',
-    'Error creating scan',
-    'CreateOrgFullScan'
+    'to create a scan'
   )
 }

--- a/src/commands/scan/fetch-create-org-full-scan.mts
+++ b/src/commands/scan/fetch-create-org-full-scan.mts
@@ -1,5 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -30,14 +29,7 @@ export async function fetchCreateOrgFullScan(
 ): Promise<CResult<SocketSdkReturnType<'CreateOrgFullScan'>['data']>> {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start(
-    `Sending request to create a scan with ${packagePaths.length} packages...`
-  )
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.createOrgFullScan(
       orgSlug,
       {
@@ -54,14 +46,9 @@ export async function fetchCreateOrgFullScan(
       packagePaths,
       cwd
     ),
-    'Creating scan'
+    'Requesting to create a scan...',
+    'Received API response (requested to create a scan).',
+    'Error creating scan',
+    'CreateOrgFullScan'
   )
-
-  spinner.successAndStop('Completed request to create a new scan.')
-
-  if (!result.success) {
-    return handleFailedApiResponse('CreateOrgFullScan', result)
-  }
-
-  return { ok: true, data: result.data }
 }

--- a/src/commands/scan/fetch-delete-org-full-scan.mts
+++ b/src/commands/scan/fetch-delete-org-full-scan.mts
@@ -1,5 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -11,21 +10,11 @@ export async function fetchDeleteOrgFullScan(
 ): Promise<CResult<SocketSdkReturnType<'deleteOrgFullScan'>['data']>> {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start('Requesting the scan to be deleted...')
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.deleteOrgFullScan(orgSlug, scanId),
-    'Deleting scan'
+    'Requesting to delete a scan...',
+    'Received API response (requested to delete a scan).',
+    'Error deleting scan',
+    'deleteOrgFullScan'
   )
-
-  spinner.successAndStop('Received response for deleting a scan.')
-
-  if (!result.success) {
-    return handleFailedApiResponse('deleteOrgFullScan', result)
-  }
-
-  return { ok: true, data: result.data }
 }

--- a/src/commands/scan/fetch-delete-org-full-scan.mts
+++ b/src/commands/scan/fetch-delete-org-full-scan.mts
@@ -12,9 +12,6 @@ export async function fetchDeleteOrgFullScan(
 
   return await handleApiCall(
     sockSdk.deleteOrgFullScan(orgSlug, scanId),
-    'Requesting to delete a scan...',
-    'Received API response (requested to delete a scan).',
-    'Error deleting scan',
-    'deleteOrgFullScan'
+    'to delete a scan'
   )
 }

--- a/src/commands/scan/fetch-diff-scan.mts
+++ b/src/commands/scan/fetch-diff-scan.mts
@@ -1,7 +1,7 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import constants from '../../constants.mts'
-import { handleApiCall, handleApiError, queryApi } from '../../utils/api.mts'
+import { handleApiError, queryApi } from '../../utils/api.mts'
 import { getDefaultToken } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -42,12 +42,8 @@ export async function fetchDiffScan({
     }
   }
 
-  const result = await handleApiCall(
-    (await response.json()) as Promise<
-      SocketSdkReturnType<'GetOrgDiffScan'>['data']
-    >,
-    'Deserializing json'
-  )
+  const fullScan =
+    (await response.json()) as SocketSdkReturnType<'GetOrgDiffScan'>['data']
 
-  return { ok: true, data: result }
+  return { ok: true, data: fullScan }
 }

--- a/src/commands/scan/fetch-list-scans.mts
+++ b/src/commands/scan/fetch-list-scans.mts
@@ -1,5 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -26,12 +25,7 @@ export async function fetchListScans({
 }): Promise<CResult<SocketSdkReturnType<'getOrgFullScanList'>['data']>> {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start('Fetching list of scans...')
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.getOrgFullScanList(orgSlug, {
       ...(branch ? { branch } : {}),
       ...(repo ? { repo } : {}),
@@ -41,14 +35,9 @@ export async function fetchListScans({
       page: String(page),
       from: from_time
     }),
-    'Listing scans'
+    'Requesting list of scans...',
+    'Received API response (requested list of scans).',
+    'Error fetching list of scans',
+    'getOrgFullScanList'
   )
-
-  spinner.successAndStop(`Received response for list of scans.`)
-
-  if (!result.success) {
-    return handleFailedApiResponse('getOrgFullScanList', result)
-  }
-
-  return { ok: true, data: result.data }
 }

--- a/src/commands/scan/fetch-list-scans.mts
+++ b/src/commands/scan/fetch-list-scans.mts
@@ -35,9 +35,6 @@ export async function fetchListScans({
       page: String(page),
       from: from_time
     }),
-    'Requesting list of scans...',
-    'Received API response (requested list of scans).',
-    'Error fetching list of scans',
-    'getOrgFullScanList'
+    'list of scans'
   )
 }

--- a/src/commands/scan/fetch-report-data.mts
+++ b/src/commands/scan/fetch-report-data.mts
@@ -89,7 +89,7 @@ export async function fetchReportData(
       return {
         ok: false,
         message: 'Socket API returned an error',
-        cause: `${response.statusText}${err ? ` (cause: ${err}` : ''}`
+        cause: `${response.statusText}${err ? ` (cause: ${err})` : ''}`
       }
     }
 

--- a/src/commands/scan/fetch-scan-metadata.mts
+++ b/src/commands/scan/fetch-scan-metadata.mts
@@ -1,5 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -11,21 +10,11 @@ export async function fetchScanMetadata(
 ): Promise<CResult<SocketSdkReturnType<'getOrgFullScanMetadata'>['data']>> {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start('Fetching meta data for a full scan...')
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.getOrgFullScanMetadata(orgSlug, scanId),
-    'Listing scans'
+    'Requesting meta data for a full scan...',
+    'Received API response (requested meta data for a full scan).',
+    'Error fetching meta data for a full scan',
+    'getOrgFullScanMetadata'
   )
-
-  spinner.successAndStop('Received response for scan meta data.')
-
-  if (!result.success) {
-    return handleFailedApiResponse('getOrgFullScanMetadata', result)
-  }
-
-  return { ok: true, data: result.data }
 }

--- a/src/commands/scan/fetch-scan-metadata.mts
+++ b/src/commands/scan/fetch-scan-metadata.mts
@@ -12,9 +12,6 @@ export async function fetchScanMetadata(
 
   return await handleApiCall(
     sockSdk.getOrgFullScanMetadata(orgSlug, scanId),
-    'Requesting meta data for a full scan...',
-    'Received API response (requested meta data for a full scan).',
-    'Error fetching meta data for a full scan',
-    'getOrgFullScanMetadata'
+    'meta data for a full scan'
   )
 }

--- a/src/commands/scan/fetch-supported-scan-file-names.mts
+++ b/src/commands/scan/fetch-supported-scan-file-names.mts
@@ -1,7 +1,4 @@
-import { logger } from '@socketsecurity/registry/lib/logger'
-
-import constants from '../../constants.mts'
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
@@ -12,22 +9,11 @@ export async function fetchSupportedScanFileNames(): Promise<
 > {
   const sockSdk = await setupSdk()
 
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start('Requesting supported scan file types from API...')
-
-  const result = await handleApiCall(
+  return await handleApiCall(
     sockSdk.getReportSupportedFiles(),
-    'fetching supported scan file types'
+    'Requesting supported scan file types from API...',
+    'Received API response (requested supported scan file types).',
+    'Error fetching supported scan file types',
+    'getReportSupportedFiles'
   )
-
-  spinner.stop()
-  logger.error('Received response while fetching supported scan file types.')
-
-  if (!result.success) {
-    return handleFailedApiResponse('getReportSupportedFiles', result)
-  }
-
-  return { ok: true, data: result.data }
 }

--- a/src/commands/scan/fetch-supported-scan-file-names.mts
+++ b/src/commands/scan/fetch-supported-scan-file-names.mts
@@ -11,9 +11,6 @@ export async function fetchSupportedScanFileNames(): Promise<
 
   return await handleApiCall(
     sockSdk.getReportSupportedFiles(),
-    'Requesting supported scan file types from API...',
-    'Received API response (requested supported scan file types).',
-    'Error fetching supported scan file types',
-    'getReportSupportedFiles'
+    'supported scan file types'
   )
 }

--- a/src/commands/scan/stream-scan.mts
+++ b/src/commands/scan/stream-scan.mts
@@ -1,8 +1,7 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 
-import { handleApiCall, handleFailedApiResponse } from '../../utils/api.mts'
+import { handleApiCall } from '../../utils/api.mts'
 import { setupSdk } from '../../utils/sdk.mts'
-import { serializeResultJson } from '../../utils/serialize-result-json.mts'
 
 export async function streamScan(
   orgSlug: string,
@@ -16,13 +15,11 @@ export async function streamScan(
   // Note: this will write to stdout or target file. It's not a noop
   const data = await handleApiCall(
     sockSdk.getOrgFullScan(orgSlug, scanId, file === '-' ? undefined : file),
-    'Fetching a scan'
+    'Fetching a scan',
+    'Received API response (requested a scan).',
+    'Error fetching a scan',
+    'GetOrgFullScan'
   )
 
-  if (!data?.success) {
-    // Note: this is always --json
-    const result = handleFailedApiResponse('getOrgFullScan', data)
-    logger.log(serializeResultJson(result))
-    return
-  }
+  return data
 }

--- a/src/commands/scan/stream-scan.mts
+++ b/src/commands/scan/stream-scan.mts
@@ -13,13 +13,8 @@ export async function streamScan(
   logger.error('Requesting data from API...')
 
   // Note: this will write to stdout or target file. It's not a noop
-  const data = await handleApiCall(
+  return await handleApiCall(
     sockSdk.getOrgFullScan(orgSlug, scanId, file === '-' ? undefined : file),
-    'Fetching a scan',
-    'Received API response (requested a scan).',
-    'Error fetching a scan',
-    'GetOrgFullScan'
+    'a scan'
   )
-
-  return data
 }

--- a/src/commands/scan/suggest-org-slug.mts
+++ b/src/commands/scan/suggest-org-slug.mts
@@ -6,12 +6,10 @@ import { setupSdk } from '../../utils/sdk.mts'
 
 export async function suggestOrgSlug(): Promise<string | void> {
   const sockSdk = await setupSdk()
+
   const result = await handleApiCall(
     sockSdk.getOrganizations(),
-    'looking up organizations',
-    'Received API response (requested list of organizations).',
-    'Error fetching list of organizations',
-    'getOrganizations'
+    'list of organizations'
   )
 
   // Ignore a failed request here. It was not the primary goal of

--- a/src/commands/scan/suggest-org-slug.mts
+++ b/src/commands/scan/suggest-org-slug.mts
@@ -8,11 +8,15 @@ export async function suggestOrgSlug(): Promise<string | void> {
   const sockSdk = await setupSdk()
   const result = await handleApiCall(
     sockSdk.getOrganizations(),
-    'looking up organizations'
+    'looking up organizations',
+    'Received API response (requested list of organizations).',
+    'Error fetching list of organizations',
+    'getOrganizations'
   )
+
   // Ignore a failed request here. It was not the primary goal of
   // running this command and reporting it only leads to end-user confusion.
-  if (result.success) {
+  if (result.ok) {
     const proceed = await select<string>({
       message:
         'Missing org name; do you want to use any of these orgs for this scan?',

--- a/src/commands/scan/suggest-repo-slug.mts
+++ b/src/commands/scan/suggest-repo-slug.mts
@@ -12,7 +12,7 @@ export async function suggestRepoSlug(orgSlug: string): Promise<{
 } | void> {
   const sockSdk = await setupSdk()
 
-  // Same as above, but if there's a repo with the same name as cwd then
+  // If there's a repo with the same name as cwd then
   // default the selection to that name.
   const result = await handleApiCall(
     sockSdk.getOrgRepoList(orgSlug, {
@@ -25,12 +25,17 @@ export async function suggestRepoSlug(orgSlug: string): Promise<{
       perPage: '10',
       page: '0'
     }),
-    'looking up known repos'
+    'Requesting list of repositories...',
+    'Received API response (requested list of repositories).',
+    'Error fetching list of repositories',
+    'getOrgRepoList'
   )
+
+  console.log('huh wtf?', result)
 
   // Ignore a failed request here. It was not the primary goal of
   // running this command and reporting it only leads to end-user confusion.
-  if (result.success) {
+  if (result.ok) {
     const currentDirName = dirNameToSlug(path.basename(process.cwd()))
 
     let cwdIsKnown =
@@ -40,9 +45,12 @@ export async function suggestRepoSlug(orgSlug: string): Promise<{
       // Do an explicit request so we can assert that the cwd exists or not
       const result = await handleApiCall(
         sockSdk.getOrgRepo(orgSlug, currentDirName),
-        'checking if current cwd is a known repo'
+        'Requesting to check if current cwd is a known repo...',
+        'Received API response (requested to check if current cwd is a known repo).',
+        'Error checking if current cwd is a known repo',
+        'getOrgRepo'
       )
-      if (result.success) {
+      if (result.ok) {
         cwdIsKnown = true
       }
     }

--- a/src/commands/scan/suggest-repo-slug.mts
+++ b/src/commands/scan/suggest-repo-slug.mts
@@ -25,13 +25,8 @@ export async function suggestRepoSlug(orgSlug: string): Promise<{
       perPage: '10',
       page: '0'
     }),
-    'Requesting list of repositories...',
-    'Received API response (requested list of repositories).',
-    'Error fetching list of repositories',
-    'getOrgRepoList'
+    'list of repositories'
   )
-
-  console.log('huh wtf?', result)
 
   // Ignore a failed request here. It was not the primary goal of
   // running this command and reporting it only leads to end-user confusion.
@@ -45,10 +40,7 @@ export async function suggestRepoSlug(orgSlug: string): Promise<{
       // Do an explicit request so we can assert that the cwd exists or not
       const result = await handleApiCall(
         sockSdk.getOrgRepo(orgSlug, currentDirName),
-        'Requesting to check if current cwd is a known repo...',
-        'Received API response (requested to check if current cwd is a known repo).',
-        'Error checking if current cwd is a known repo',
-        'getOrgRepo'
+        'check if current cwd is a known repo'
       )
       if (result.ok) {
         cwdIsKnown = true

--- a/src/utils/api.mts
+++ b/src/utils/api.mts
@@ -51,25 +51,25 @@ export function handleFailedApiResponse<T extends SocketSdkOperations>(
 
 export async function handleApiCall<T extends SocketSdkOperations>(
   value: Promise<SocketSdkResultType<T>>,
-  spinnerBefore: string,
-  spinnerAfterOk: string,
-  spinnerAfterError: string,
-  description: string
+  fetchingDesc: string
 ): Promise<CResult<SocketSdkReturnType<T>['data']>> {
   // Lazily access constants.spinner.
   const { spinner } = constants
 
-  spinner.start(spinnerBefore)
+  spinner.start(`Requesting ${fetchingDesc} from API...`)
 
   let result: SocketSdkResultType<T>
   try {
     result = await value
 
-    spinner.successAndStop(spinnerAfterOk)
+    // TODO: info, not success (looks weird when response is non-200)
+    spinner.successAndStop(
+      `Received API response (after requesting ${fetchingDesc}).`
+    )
   } catch (e) {
-    spinner.failAndStop(spinnerAfterError)
+    spinner.failAndStop(`An error was thrown while requesting ${fetchingDesc}`)
 
-    debugLog(`handleApiCall(${description}) threw error:\n`, e)
+    debugLog(`handleApiCall(${fetchingDesc}) threw error:\n`, e)
 
     const message = `${e || 'No error message returned'}`
     const cause = `${e || 'No error message returned'}`
@@ -87,7 +87,7 @@ export async function handleApiCall<T extends SocketSdkOperations>(
   if (result.success === false) {
     const err = result as SocketSdkErrorType<T>
     const message = `${err.error || 'No error message returned'}`
-    debugLog(`handleApiCall(${description}) bad response:\n`, err)
+    debugLog(`handleApiCall(${fetchingDesc}) bad response:\n`, err)
 
     return {
       ok: false,

--- a/src/utils/api.mts
+++ b/src/utils/api.mts
@@ -10,12 +10,17 @@ import { failMsgWithBadge } from './fail-msg-with-badge.mts'
 import type { CResult } from '../types.mts'
 import type {
   SocketSdkErrorType,
-  SocketSdkOperations
+  SocketSdkOperations,
+  SocketSdkResultType,
+  SocketSdkReturnType
 } from '@socketsecurity/sdk'
 
+// TODO: this function is removed after v1.0.0
 export function handleUnsuccessfulApiResponse<T extends SocketSdkOperations>(
   _name: T,
-  { cause, error, status }: SocketSdkErrorType<T>
+  error: string,
+  cause: string,
+  status: number
 ): never {
   const message = `${error || 'No error message returned'}${cause ? ` (reason: ${cause})` : ''}`
   if (status === 401 || status === 403) {
@@ -44,19 +49,117 @@ export function handleFailedApiResponse<T extends SocketSdkOperations>(
   }
 }
 
-export async function handleApiCall<T>(
-  value: T,
+export async function handleApiCall<T extends SocketSdkOperations>(
+  value: Promise<SocketSdkResultType<T>>,
+  spinnerBefore: string,
+  spinnerAfterOk: string,
+  spinnerAfterError: string,
   description: string
-): Promise<T> {
-  let result: T
+): Promise<CResult<SocketSdkReturnType<T>['data']>> {
+  // Lazily access constants.spinner.
+  const { spinner } = constants
+
+  spinner.start(spinnerBefore)
+
+  let result: SocketSdkResultType<T>
   try {
     result = await value
+
+    spinner.successAndStop(spinnerAfterOk)
+  } catch (e) {
+    spinner.failAndStop(spinnerAfterError)
+
+    debugLog(`handleApiCall(${description}) threw error:\n`, e)
+
+    const message = `${e || 'No error message returned'}`
+    const cause = `${e || 'No error message returned'}`
+
+    return {
+      ok: false,
+      message: 'Socket API returned an error',
+      cause: `${message}${cause ? ` ( Reason: ${cause} )` : ''}`
+    }
+  } finally {
+    spinner.stop()
+  }
+
+  // Note: TS can't narrow down the type of result due to generics
+  if (result.success === false) {
+    const err = result as SocketSdkErrorType<T>
+    const message = `${err.error || 'No error message returned'}`
+    debugLog(`handleApiCall(${description}) bad response:\n`, err)
+
+    return {
+      ok: false,
+      message: 'Socket API returned an error',
+      cause: `${message}${err.cause ? ` ( Reason: ${err.cause} )` : ''}`,
+      data: {
+        code: result.status
+      }
+    }
+  } else {
+    const ok = result as SocketSdkReturnType<T>
+    return {
+      ok: true,
+      data: ok.data
+    }
+  }
+}
+
+export async function tmpHandleApiCall<T>(
+  value: Promise<T>,
+  description: string
+): Promise<Awaited<T>> {
+  try {
+    return await value
   } catch (e) {
     debugLog(`handleApiCall[${description}] error:\n`, e)
     // TODO: eliminate this throw in favor of CResult (or anything else)
     throw new Error(`Failed ${description}`, { cause: e })
   }
-  return result
+}
+
+export async function handleApiCallNoSpinner<T extends SocketSdkOperations>(
+  value: Promise<SocketSdkResultType<T>>,
+  description: string
+): Promise<CResult<SocketSdkReturnType<T>['data']>> {
+  let result: SocketSdkResultType<T>
+  try {
+    result = await value
+  } catch (e) {
+    debugLog(`handleApiCall(${description}) threw error:\n`, e)
+
+    const message = `${e || 'No error message returned'}`
+    const cause = `${e || 'No error message returned'}`
+
+    return {
+      ok: false,
+      message: 'Socket API returned an error',
+      cause: `${message}${cause ? ` ( Reason: ${cause} )` : ''}`
+    }
+  }
+
+  // Note: TS can't narrow down the type of result due to generics
+  if (result.success === false) {
+    const err = result as SocketSdkErrorType<T>
+    const message = `${err.error || 'No error message returned'}`
+    debugLog(`handleApiCall(${description}) bad response:\n`, err)
+
+    return {
+      ok: false,
+      message: 'Socket API returned an error',
+      cause: `${message}${err.cause ? ` ( Reason: ${err.cause} )` : ''}`,
+      data: {
+        code: result.status
+      }
+    }
+  } else {
+    const ok = result as SocketSdkReturnType<T>
+    return {
+      ok: true,
+      data: ok.data
+    }
+  }
 }
 
 export async function handleApiError(code: number) {

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -456,7 +456,6 @@ if should_run_section "organization"; then
     run_socket 0 organization policy security --org $DEFORG_BAK
 
     run_socket 0 organization policy license --markdown
-    run_socket 0 organization policy license --json
     run_json   0 organization policy license --json
     run_socket 1 organization policy license --org trash
     run_socket 1 organization policy license --org trash --markdown
@@ -520,7 +519,7 @@ if should_run_section "raw-npx"; then
     run_socket 0 raw-npx                                    # interactive shell...
     run_socket 2 raw-npx --help
     run_socket 0 raw-npx --dry-run
-    run_socket 0 rax-npx socket --dry-run
+    run_socket 0 raw-npx socket --dry-run
 fi
 
 ### repos


### PR DESCRIPTION
This is an effort to update most references that used to call the unsafe `handleApiCall` to not throw but handle the CResult flow instead. This makes it friendly for consumption with --json.

There are some old cases left and the non-sdk cases are a bit of a head ache due to typing. We'll fix them forward.