### PR TITLE
Improve handling of non-sdk api calls

### DIFF
--- a/src/commands/analytics/cmd-analytics.test.mts
+++ b/src/commands/analytics/cmd-analytics.test.mts
@@ -53,7 +53,7 @@ describe('socket analytics', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket analytics\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket analytics`'
       )
@@ -159,7 +159,7 @@ describe('socket analytics', async () => {
         \\x1b[39m"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket analytics`'
       )

--- a/src/commands/audit-log/cmd-audit-log.test.mts
+++ b/src/commands/audit-log/cmd-audit-log.test.mts
@@ -52,7 +52,7 @@ describe('socket audit-log', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket audit-log\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket audit-log`'
       )

--- a/src/commands/cdxgen/cmd-cdxgen.test.mts
+++ b/src/commands/cdxgen/cmd-cdxgen.test.mts
@@ -86,7 +86,7 @@ describe('socket cdxgen', async () => {
         |_____|___|___|_,_|___|_|.dev   | Command: \`socket cdxgen\`, cwd: <redacted>"
     `)
 
-    // expect(code, 'help should exit with code 2').toBe(2)
+    // expect(code, 'explicit help should exit with code 0').toBe(0)
     expect(code, 'help should exit with code 2').toBe(0) // cdxgen special case
     expect(stderr, 'banner includes base command').toContain('`socket cdxgen`')
   })

--- a/src/commands/ci/cmd-ci.test.mts
+++ b/src/commands/ci/cmd-ci.test.mts
@@ -38,7 +38,7 @@ describe('socket ci', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket ci\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain('`socket ci`')
     }
   )

--- a/src/commands/config/cmd-config-get.test.mts
+++ b/src/commands/config/cmd-config-get.test.mts
@@ -49,7 +49,7 @@ describe('socket config get', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket config get\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket config get`'
       )

--- a/src/commands/config/cmd-config-list.test.mts
+++ b/src/commands/config/cmd-config-list.test.mts
@@ -50,7 +50,7 @@ describe('socket config get', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket config list\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket config list`'
       )

--- a/src/commands/config/cmd-config-set.test.mts
+++ b/src/commands/config/cmd-config-set.test.mts
@@ -54,7 +54,7 @@ describe('socket config get', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket config set\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket config set`'
       )

--- a/src/commands/config/cmd-config-unset.test.mts
+++ b/src/commands/config/cmd-config-unset.test.mts
@@ -49,7 +49,7 @@ describe('socket config unset', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket config unset\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket config unset`'
       )

--- a/src/commands/config/cmd-config.test.mts
+++ b/src/commands/config/cmd-config.test.mts
@@ -45,7 +45,7 @@ describe('socket config', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket config\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket config`'
       )

--- a/src/commands/dependencies/cmd-dependencies.test.mts
+++ b/src/commands/dependencies/cmd-dependencies.test.mts
@@ -46,7 +46,7 @@ describe('socket dependencies', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket dependencies\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket dependencies`'
       )

--- a/src/commands/diff-scan/cmd-diff-scan-get.test.mts
+++ b/src/commands/diff-scan/cmd-diff-scan-get.test.mts
@@ -54,7 +54,7 @@ describe('socket diff-scan get', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan get\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket diff-scan get`'
       )

--- a/src/commands/diff-scan/cmd-diff-scan.test.mts
+++ b/src/commands/diff-scan/cmd-diff-scan.test.mts
@@ -41,7 +41,7 @@ describe('socket diff-scan', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket diff-scan\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket diff-scan`'
       )

--- a/src/commands/diff-scan/fetch-diff-scan.mts
+++ b/src/commands/diff-scan/fetch-diff-scan.mts
@@ -1,6 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiError, queryApi } from '../../utils/api.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { queryApiSafeJson } from '../../utils/api.mts'
 
 import type { CResult } from '../../types.mts'
 import type { SocketSdkReturnType } from '@socketsecurity/sdk'
@@ -14,31 +12,8 @@ export async function fetchDiffScan({
   before: string
   orgSlug: string
 }): Promise<CResult<SocketSdkReturnType<'GetOrgDiffScan'>['data']>> {
-  const apiToken = getDefaultToken()
-
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start('Fetching diff-scan...')
-
-  const response = await queryApi(
+  return await queryApiSafeJson<SocketSdkReturnType<'GetOrgDiffScan'>['data']>(
     `orgs/${orgSlug}/full-scans/diff?before=${encodeURIComponent(before)}&after=${encodeURIComponent(after)}`,
-    apiToken || ''
+    'a scan diff'
   )
-
-  spinner.successAndStop('Received diff-scan response')
-
-  if (!response.ok) {
-    const err = await handleApiError(response.status)
-    return {
-      ok: false,
-      message: 'Socket API returned an error',
-      cause: `${response.statusText}${err ? ` ( Reason: ${err} )` : ''}`
-    }
-  }
-
-  const result =
-    (await response.json()) as SocketSdkReturnType<'GetOrgDiffScan'>['data']
-
-  return { ok: true, data: result }
 }

--- a/src/commands/fix/cmd-fix.test.mts
+++ b/src/commands/fix/cmd-fix.test.mts
@@ -53,7 +53,7 @@ describe('socket fix', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket fix\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain('`socket fix`')
     }
   )

--- a/src/commands/info/cmd-info.test.mts
+++ b/src/commands/info/cmd-info.test.mts
@@ -45,7 +45,7 @@ describe('socket info', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket info\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain('`socket info`')
     }
   )

--- a/src/commands/login/cmd-login.test.mts
+++ b/src/commands/login/cmd-login.test.mts
@@ -46,7 +46,7 @@ describe('socket login', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket login\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain('`socket login`')
     }
   )

--- a/src/commands/logout/cmd-logout.test.mts
+++ b/src/commands/logout/cmd-logout.test.mts
@@ -34,7 +34,7 @@ describe('socket logout', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket logout\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket logout`'
       )

--- a/src/commands/manifest/cmd-manifest-auto.test.mts
+++ b/src/commands/manifest/cmd-manifest-auto.test.mts
@@ -41,7 +41,7 @@ describe('socket manifest auto', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest auto\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket manifest auto`'
       )

--- a/src/commands/manifest/cmd-manifest-conda.test.mts
+++ b/src/commands/manifest/cmd-manifest-conda.test.mts
@@ -53,7 +53,7 @@ describe('socket manifest conda', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest conda\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket manifest conda`'
       )

--- a/src/commands/manifest/cmd-manifest-gradle.test.mts
+++ b/src/commands/manifest/cmd-manifest-gradle.test.mts
@@ -65,7 +65,7 @@ describe('socket manifest gradle', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest gradle\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket manifest gradle`'
       )

--- a/src/commands/manifest/cmd-manifest-kotlin.test.mts
+++ b/src/commands/manifest/cmd-manifest-kotlin.test.mts
@@ -65,7 +65,7 @@ describe('socket manifest kotlin', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest kotlin\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket manifest kotlin`'
       )

--- a/src/commands/manifest/cmd-manifest-scala.test.mts
+++ b/src/commands/manifest/cmd-manifest-scala.test.mts
@@ -71,7 +71,7 @@ describe('socket manifest scala', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest scala\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket manifest scala`'
       )

--- a/src/commands/manifest/cmd-manifest.test.mts
+++ b/src/commands/manifest/cmd-manifest.test.mts
@@ -45,7 +45,7 @@ describe('socket manifest', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket manifest`'
       )

--- a/src/commands/npm/cmd-npm.test.mts
+++ b/src/commands/npm/cmd-npm.test.mts
@@ -32,7 +32,7 @@ describe('socket npm', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket npm\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain('`socket npm`')
     }
   )

--- a/src/commands/npx/cmd-npx.test.mts
+++ b/src/commands/npx/cmd-npx.test.mts
@@ -32,7 +32,7 @@ describe('socket npx', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket npx\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain('`socket npx`')
     }
   )

--- a/src/commands/oops/cmd-oops.test.mts
+++ b/src/commands/oops/cmd-oops.test.mts
@@ -34,7 +34,7 @@ describe('socket oops', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket oops\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain('`socket oops`')
     }
   )

--- a/src/commands/optimize/cmd-optimize.test.mts
+++ b/src/commands/optimize/cmd-optimize.test.mts
@@ -41,7 +41,7 @@ describe('socket optimize', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket optimize\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket optimize`'
       )

--- a/src/commands/organization/cmd-organization-list.test.mts
+++ b/src/commands/organization/cmd-organization-list.test.mts
@@ -41,7 +41,7 @@ describe('socket organization list', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization list\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket organization list`'
       )

--- a/src/commands/organization/cmd-organization-policy-license.test.mts
+++ b/src/commands/organization/cmd-organization-policy-license.test.mts
@@ -50,7 +50,7 @@ describe('socket organization policy license', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy license\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket organization policy license`'
       )

--- a/src/commands/organization/cmd-organization-policy-security.test.mts
+++ b/src/commands/organization/cmd-organization-policy-security.test.mts
@@ -50,7 +50,7 @@ describe('socket organization policy security', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy security\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket organization policy security`'
       )

--- a/src/commands/organization/cmd-organization-policy.test.mts
+++ b/src/commands/organization/cmd-organization-policy.test.mts
@@ -41,7 +41,7 @@ describe('socket organization list', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket organization policy`'
       )

--- a/src/commands/organization/cmd-organization-quota.test.mts
+++ b/src/commands/organization/cmd-organization-quota.test.mts
@@ -37,7 +37,7 @@ describe('socket organization quota', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization quota\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket organization quota`'
       )

--- a/src/commands/organization/cmd-organization.test.mts
+++ b/src/commands/organization/cmd-organization.test.mts
@@ -41,7 +41,7 @@ describe('socket organization', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket organization`'
       )

--- a/src/commands/package/cmd-package-score.test.mts
+++ b/src/commands/package/cmd-package-score.test.mts
@@ -62,7 +62,7 @@ describe('socket package score', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket package score\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(
         stderr,
         'header should include command (without params)'

--- a/src/commands/package/cmd-package-shallow.test.mts
+++ b/src/commands/package/cmd-package-shallow.test.mts
@@ -62,7 +62,7 @@ describe('socket package shallow', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket package shallow\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket package shallow`'
       )

--- a/src/commands/package/cmd-package.test.mts
+++ b/src/commands/package/cmd-package.test.mts
@@ -42,7 +42,7 @@ describe('socket package', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket package\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket package`'
       )

--- a/src/commands/package/fetch-purl-deep-score.mts
+++ b/src/commands/package/fetch-purl-deep-score.mts
@@ -1,8 +1,6 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 
-import constants from '../../constants.mts'
-import { handleApiError, queryApi } from '../../utils/api.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { queryApiSafeJson } from '../../utils/api.mts'
 
 import type { CResult } from '../../types.mts'
 
@@ -60,58 +58,8 @@ export async function fetchPurlDeepScore(
 ): Promise<CResult<PurlDataResponse>> {
   logger.error(`Requesting deep score data for this purl: ${purl}`)
 
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    return {
-      ok: false,
-      message: 'Authentication Error',
-      cause:
-        'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    }
-  }
-
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start('Getting deep package score...')
-
-  let result
-  try {
-    result = await queryApi(`purl/score/${encodeURIComponent(purl)}`, apiToken)
-  } catch (e) {
-    spinner.failAndStop('The request was unsuccessful.')
-    const msg = (e as undefined | { message: string })?.message
-
-    return {
-      ok: false,
-      message: 'API Request failed to complete',
-      ...(msg ? { cause: msg } : {})
-    }
-  }
-
-  spinner.successAndStop('Received deep package score response.')
-
-  if (!result.ok) {
-    const cause = await handleApiError(result.status)
-    return {
-      ok: false,
-      message: 'Socket API returned an error',
-      cause: `${result.statusText}${cause ? ` (cause: ${cause})` : ''}`
-    }
-  }
-
-  const data = await result.text()
-
-  try {
-    return {
-      ok: true,
-      data: JSON.parse(data) // as PurlDataResponse
-    }
-  } catch (e) {
-    return {
-      ok: false,
-      message: 'Server returned invalid JSON',
-      cause: `Please report this. JSON.parse threw an error over the following response: \`${data}\``
-    }
-  }
+  return await queryApiSafeJson<PurlDataResponse>(
+    `purl/score/${encodeURIComponent(purl)}`,
+    'the deep package scores'
+  )
 }

--- a/src/commands/raw-npm/cmd-raw-npm.test.mts
+++ b/src/commands/raw-npm/cmd-raw-npm.test.mts
@@ -35,7 +35,7 @@ describe('socket raw-npm', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket raw-npm\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket raw-npm`'
       )

--- a/src/commands/raw-npx/cmd-raw-npx.test.mts
+++ b/src/commands/raw-npx/cmd-raw-npx.test.mts
@@ -35,7 +35,7 @@ describe('socket raw-npx', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket raw-npx\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket raw-npx`'
       )

--- a/src/commands/report/cmd-report-create.test.mts
+++ b/src/commands/report/cmd-report-create.test.mts
@@ -32,7 +32,7 @@ describe('socket report create', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket report create\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket report create`'
       )

--- a/src/commands/report/cmd-report-view.test.mts
+++ b/src/commands/report/cmd-report-view.test.mts
@@ -32,7 +32,7 @@ describe('socket report create', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket report create\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket report create`'
       )

--- a/src/commands/report/cmd-report.test.mts
+++ b/src/commands/report/cmd-report.test.mts
@@ -42,7 +42,7 @@ describe('socket report', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket report\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket report`'
       )

--- a/src/commands/repos/cmd-repos-create.test.mts
+++ b/src/commands/repos/cmd-repos-create.test.mts
@@ -51,7 +51,7 @@ describe('socket repos create', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos create\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket repos create`'
       )

--- a/src/commands/repos/cmd-repos-del.test.mts
+++ b/src/commands/repos/cmd-repos-del.test.mts
@@ -46,7 +46,7 @@ describe('socket repos del', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos del\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket repos del`'
       )

--- a/src/commands/repos/cmd-repos-list.test.mts
+++ b/src/commands/repos/cmd-repos-list.test.mts
@@ -50,7 +50,7 @@ describe('socket repos list', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos list\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket repos list`'
       )

--- a/src/commands/repos/cmd-repos-update.test.mts
+++ b/src/commands/repos/cmd-repos-update.test.mts
@@ -51,7 +51,7 @@ describe('socket repos update', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos update\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket repos update`'
       )

--- a/src/commands/repos/cmd-repos-view.test.mts
+++ b/src/commands/repos/cmd-repos-view.test.mts
@@ -47,7 +47,7 @@ describe('socket repos view', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos view\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket repos view`'
       )

--- a/src/commands/repos/cmd-repos.test.mts
+++ b/src/commands/repos/cmd-repos.test.mts
@@ -45,7 +45,7 @@ describe('socket repos', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain('`socket repos`')
     }
   )

--- a/src/commands/scan/cmd-scan-create.test.mts
+++ b/src/commands/scan/cmd-scan-create.test.mts
@@ -80,7 +80,7 @@ describe('socket scan create', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan create\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket scan create`'
       )

--- a/src/commands/scan/cmd-scan-del.test.mts
+++ b/src/commands/scan/cmd-scan-del.test.mts
@@ -46,7 +46,7 @@ describe('socket scan del', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan del\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket scan del`'
       )

--- a/src/commands/scan/cmd-scan-diff.test.mts
+++ b/src/commands/scan/cmd-scan-diff.test.mts
@@ -56,7 +56,7 @@ describe('socket scan diff', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan diff\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket scan diff`'
       )

--- a/src/commands/scan/cmd-scan-list.test.mts
+++ b/src/commands/scan/cmd-scan-list.test.mts
@@ -54,7 +54,7 @@ describe('socket scan list', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan list\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket scan list`'
       )

--- a/src/commands/scan/cmd-scan-metadata.test.mts
+++ b/src/commands/scan/cmd-scan-metadata.test.mts
@@ -46,7 +46,7 @@ describe('socket scan metadata', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan metadata\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket scan metadata`'
       )

--- a/src/commands/scan/cmd-scan-report.test.mts
+++ b/src/commands/scan/cmd-scan-report.test.mts
@@ -60,7 +60,7 @@ describe('socket scan report', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan report\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket scan report`'
       )

--- a/src/commands/scan/cmd-scan-view.test.mts
+++ b/src/commands/scan/cmd-scan-view.test.mts
@@ -49,7 +49,7 @@ describe('socket scan view', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan view\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket scan view`'
       )

--- a/src/commands/scan/cmd-scan.test.mts
+++ b/src/commands/scan/cmd-scan.test.mts
@@ -47,7 +47,7 @@ describe('socket scan', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain('`socket scan`')
     }
   )

--- a/src/commands/threat-feed/cmd-threat-feed.test.mts
+++ b/src/commands/threat-feed/cmd-threat-feed.test.mts
@@ -79,7 +79,7 @@ describe('socket threat-feed', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket threat-feed\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket threat-feed`'
       )

--- a/src/commands/threat-feed/fetch-threat-feed.mts
+++ b/src/commands/threat-feed/fetch-threat-feed.mts
@@ -1,6 +1,4 @@
-import constants from '../../constants.mts'
-import { handleApiError, queryApi } from '../../utils/api.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { queryApiSafeJson } from '../../utils/api.mts'
 
 import type { ThreadFeedResponse } from './types.mts'
 import type { CResult } from '../../types.mts'
@@ -26,57 +24,8 @@ export async function fetchThreatFeed({
     ['per_page', String(perPage)]
   ])
 
-  const apiToken = getDefaultToken()
-  if (!apiToken) {
-    return {
-      ok: false,
-      message: 'Authentication Error',
-      cause:
-        'User must be authenticated to run this command. To log in, run the command `socket login` and enter your API key.'
-    }
-  }
-
-  // Lazily access constants.spinner.
-  const { spinner } = constants
-
-  spinner.start('Fetching Threat Feed data...')
-
-  let result
-  try {
-    result = await queryApi(`threat-feed?${queryParams}`, apiToken)
-  } catch (e) {
-    spinner.failAndStop('The request was unsuccessful.')
-    const msg = (e as undefined | { message: string })?.message
-
-    return {
-      ok: false,
-      message: 'API Request failed to complete',
-      ...(msg ? { cause: msg } : {})
-    }
-  }
-
-  spinner.successAndStop('Received response while fetching Threat Feed data.')
-
-  if (!result.ok) {
-    const cause = await handleApiError(result.status)
-    return {
-      ok: false,
-      message: 'Socket API returned an error',
-      cause: `${result.statusText}${cause ? ` (cause: ${cause})` : ''}`
-    }
-  }
-
-  const data = (await result.json()) as
-    | ThreadFeedResponse
-    | { error: { message: string } }
-
-  if ('error' in data && data.error) {
-    return {
-      ok: false,
-      message: 'Socket API returned an error',
-      cause: data.error.message
-    }
-  }
-
-  return { ok: true, data: data as ThreadFeedResponse }
+  return await queryApiSafeJson(
+    `threat-feed?${queryParams}`,
+    'the Threat Feed data'
+  )
 }

--- a/src/commands/wrapper/cmd-wrapper.test.mts
+++ b/src/commands/wrapper/cmd-wrapper.test.mts
@@ -41,7 +41,7 @@ describe('socket wrapper', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket wrapper\`, cwd: <redacted>"
       `)
 
-      expect(code, 'help should exit with code 2').toBe(2)
+      expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain(
         '`socket wrapper`'
       )


### PR DESCRIPTION
This improves handling of API calls that do not go through our sdk.

It abstracts the CResult stuff and the .text() and .json() stuff in a way that should always return a CResult.

Also tweaked the meow exit code for emitting help.

Updated the smoke test accordingly. Also added better handling for backing up and restoring certain config values. Just don't ctrl+c too quickly and you'll be fine :)