### PR TITLE
Cleanup getDefualtToken usage, show prefix of token

### DIFF
--- a/src/commands/analytics/cmd-analytics.mts
+++ b/src/commands/analytics/cmd-analytics.mts
@@ -8,7 +8,7 @@ import { isTestingV1 } from '../../utils/config.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -137,7 +137,7 @@ async function run(
     }
   }
 
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -204,7 +204,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/audit-log/cmd-audit-log.mts
+++ b/src/commands/audit-log/cmd-audit-log.mts
@@ -9,7 +9,7 @@ import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -109,7 +109,7 @@ async function run(
     !!dryRun
   )
 
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -124,7 +124,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/config/discover-config-value.mts
+++ b/src/commands/config/discover-config-value.mts
@@ -1,6 +1,6 @@
 import { handleApiCall } from '../../utils/api.mts'
 import { supportedConfigKeys } from '../../utils/config.mts'
-import { getDefaultToken, setupSdk } from '../../utils/sdk.mts'
+import { hasDefaultToken, setupSdk } from '../../utils/sdk.mts'
 
 import type { CResult } from '../../types.mts'
 import type { LocalConfig } from '../../utils/config.mts'
@@ -50,8 +50,8 @@ export async function discoverConfigValue(
   }
 
   if (key === 'defaultOrg') {
-    const apiToken = getDefaultToken()
-    if (!apiToken) {
+    const hasApiToken = hasDefaultToken()
+    if (!hasApiToken) {
       return {
         ok: false,
         message: 'Auto discover failed',
@@ -84,8 +84,8 @@ export async function discoverConfigValue(
   }
 
   if (key === 'enforcedOrgs') {
-    const apiToken = getDefaultToken()
-    if (!apiToken) {
+    const hasApiToken = hasDefaultToken()
+    if (!hasApiToken) {
       return {
         ok: false,
         message: 'Auto discover failed',

--- a/src/commands/dependencies/cmd-dependencies.mts
+++ b/src/commands/dependencies/cmd-dependencies.mts
@@ -7,7 +7,7 @@ import { checkCommandInput } from '../../utils/check-input.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -71,7 +71,7 @@ async function run(
   const { json, limit, markdown, offset } = cli.flags
   const outputKind = getOutputKind(json, markdown)
 
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -85,7 +85,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/diff-scan/cmd-diff-scan-get.mts
+++ b/src/commands/diff-scan/cmd-diff-scan-get.mts
@@ -8,7 +8,7 @@ import { getConfigValueOrUndef, isTestingV1 } from '../../utils/config.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -103,7 +103,7 @@ async function run(
   const defaultOrgSlugResult = getConfigValueOrUndef('defaultOrg')
   const orgSlug = defaultOrgSlugResult || cli.input[0] || ''
 
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -136,7 +136,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/organization/cmd-organization-list.mts
+++ b/src/commands/organization/cmd-organization-list.mts
@@ -7,7 +7,7 @@ import { checkCommandInput } from '../../utils/check-input.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -55,7 +55,7 @@ async function run(
   const { json, markdown } = cli.flags
   const outputKind = getOutputKind(json, markdown)
 
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -69,7 +69,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/organization/cmd-organization-policy-license.mts
+++ b/src/commands/organization/cmd-organization-policy-license.mts
@@ -9,7 +9,7 @@ import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -83,7 +83,7 @@ async function run(
     !!dryRun
   )
 
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -105,7 +105,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/organization/cmd-organization-policy-security.mts
+++ b/src/commands/organization/cmd-organization-policy-security.mts
@@ -9,7 +9,7 @@ import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -83,7 +83,7 @@ async function run(
     !!dryRun
   )
 
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -103,7 +103,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/organization/cmd-organization-quota.mts
+++ b/src/commands/organization/cmd-organization-quota.mts
@@ -7,7 +7,7 @@ import { checkCommandInput } from '../../utils/check-input.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -52,7 +52,7 @@ async function run(
   const markdown = Boolean(cli.flags['markdown'])
   const outputKind = getOutputKind(json, markdown)
 
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -65,7 +65,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/organization/output-organization-list.mts
+++ b/src/commands/organization/output-organization-list.mts
@@ -2,9 +2,8 @@ import colors from 'yoctocolors-cjs'
 
 import { logger } from '@socketsecurity/registry/lib/logger'
 
-import { getLastFiveOfApiToken } from '../../utils/api.mts'
 import { failMsgWithBadge } from '../../utils/fail-msg-with-badge.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { getVisibleTokenPrefix } from '../../utils/sdk.mts'
 import { serializeResultJson } from '../../utils/serialize-result-json.mts'
 
 import type { CResult, OutputKind } from '../../types.mts'
@@ -28,8 +27,7 @@ export async function outputOrganizationList(
   }
 
   const organizations = Object.values(result.data.organizations)
-  const apiToken = getDefaultToken()
-  const lastFiveOfApiToken = getLastFiveOfApiToken(apiToken ?? '?????')
+  const visibleTokenPrefix = getVisibleTokenPrefix()
 
   switch (outputKind) {
     case 'markdown': {
@@ -47,7 +45,7 @@ export async function outputOrganizationList(
       }
       logger.log('# Organizations\n')
       logger.log(
-        `List of organizations associated with your API key, ending with: ${colors.italic(lastFiveOfApiToken)}\n`
+        `List of organizations associated with your API key, starting with: ${colors.italic(visibleTokenPrefix)}\n`
       )
       logger.log(
         `| Name${' '.repeat(mw1 - 4)} | ID${' '.repeat(mw2 - 2)} | Plan${' '.repeat(mw3 - 4)} |`
@@ -67,7 +65,7 @@ export async function outputOrganizationList(
     }
     default: {
       logger.log(
-        `List of organizations associated with your API key, ending with: ${colors.italic(lastFiveOfApiToken)}\n`
+        `List of organizations associated with your API key, starting with: ${colors.italic(visibleTokenPrefix)}\n`
       )
       // Just dump
       for (const o of organizations) {

--- a/src/commands/package/cmd-package-score.mts
+++ b/src/commands/package/cmd-package-score.mts
@@ -8,7 +8,7 @@ import { checkCommandInput } from '../../utils/check-input.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -79,7 +79,8 @@ async function run(
   const outputKind = getOutputKind(json, markdown)
 
   const [ecosystem = '', purl] = cli.input
-  const apiToken = getDefaultToken()
+
+  const hasApiToken = hasDefaultToken()
 
   const { purls, valid } = parsePackageSpecifiers(ecosystem, purl ? [purl] : [])
 
@@ -106,7 +107,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/repos/cmd-repos-create.mts
+++ b/src/commands/repos/cmd-repos-create.mts
@@ -9,7 +9,7 @@ import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -117,7 +117,7 @@ async function run(
 
   const repoName = (isTestingV1() ? cli.input[0] : repoNameFlag) || ''
 
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -140,7 +140,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/repos/cmd-repos-del.mts
+++ b/src/commands/repos/cmd-repos-del.mts
@@ -9,7 +9,7 @@ import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -81,7 +81,7 @@ async function run(
   const repoName =
     (defaultOrgSlug || isTestingV1() ? cli.input[0] : cli.input[1]) || ''
 
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -104,7 +104,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/repos/cmd-repos-list.mts
+++ b/src/commands/repos/cmd-repos-list.mts
@@ -126,7 +126,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!hasApiToken,
+      test: hasApiToken ,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/repos/cmd-repos-list.mts
+++ b/src/commands/repos/cmd-repos-list.mts
@@ -9,7 +9,7 @@ import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -103,7 +103,7 @@ async function run(
     !!dryRun
   )
 
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -126,7 +126,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: !!hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/repos/cmd-repos-update.mts
+++ b/src/commands/repos/cmd-repos-update.mts
@@ -9,7 +9,7 @@ import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -111,7 +111,7 @@ async function run(
   const repoNameFlag = cli.flags['repoName']
   const repoName = (isTestingV1() ? cli.input[0] : repoNameFlag) || ''
 
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -134,7 +134,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/repos/cmd-repos-view.mts
+++ b/src/commands/repos/cmd-repos-view.mts
@@ -9,7 +9,7 @@ import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -92,7 +92,7 @@ async function run(
 
   const repoName = (isTestingV1() ? cli.input[0] : repoNameFlag) || ''
 
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -123,7 +123,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/scan/cmd-scan-create.mts
+++ b/src/commands/scan/cmd-scan-create.mts
@@ -11,7 +11,7 @@ import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -225,7 +225,7 @@ async function run(
   // We're going to need an api token to suggest data because those suggestions
   // must come from data we already know. Don't error on missing api token yet.
   // If the api-token is not set, ignore it for the sake of suggestions.
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   // If we updated any inputs then we should print the command line to repeat
   // the command without requiring user input, as a suggestion.
@@ -240,7 +240,7 @@ async function run(
   // If the current cwd is unknown and is used as a repo slug anyways, we will
   // first need to register the slug before we can use it.
   // Only do suggestions with an apiToken and when not in dryRun mode
-  if (apiToken && !dryRun && interactive) {
+  if (hasApiToken && !dryRun && interactive) {
     if (!orgSlug) {
       const suggestion = await suggestOrgSlug()
       if (suggestion) {
@@ -290,7 +290,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: hasApiToken,
       message: 'This command requires an API token for access',
       pass: 'ok',
       fail: 'missing (try `socket login`)'

--- a/src/commands/scan/cmd-scan-del.mts
+++ b/src/commands/scan/cmd-scan-del.mts
@@ -9,7 +9,7 @@ import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -80,7 +80,7 @@ async function run(
 
   const scanId =
     (isTestingV1() || defaultOrgSlug ? cli.input[0] : cli.input[1]) || ''
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -104,7 +104,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/scan/cmd-scan-diff.mts
+++ b/src/commands/scan/cmd-scan-diff.mts
@@ -154,7 +154,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!hasApiToken,
+      test: hasApiToken ,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/scan/cmd-scan-diff.mts
+++ b/src/commands/scan/cmd-scan-diff.mts
@@ -9,7 +9,7 @@ import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -119,7 +119,7 @@ async function run(
     id2 = id2.slice(SOCKET_SBOM_URL_PREFIX.length)
   }
 
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -154,7 +154,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: !!hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/scan/cmd-scan-list.mts
+++ b/src/commands/scan/cmd-scan-list.mts
@@ -159,7 +159,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!hasApiToken,
+      test: hasApiToken ,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/scan/cmd-scan-list.mts
+++ b/src/commands/scan/cmd-scan-list.mts
@@ -9,7 +9,7 @@ import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type {
   CliCommandConfig,
@@ -134,7 +134,7 @@ async function run(
     !!dryRun
   )
 
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -159,7 +159,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: !!hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/scan/cmd-scan-metadata.mts
+++ b/src/commands/scan/cmd-scan-metadata.mts
@@ -9,7 +9,7 @@ import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type {
   CliCommandConfig,
@@ -83,7 +83,7 @@ async function run(
 
   const scanId =
     (isTestingV1() || defaultOrgSlug ? cli.input[0] : cli.input[1]) || ''
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -114,7 +114,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: !!hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/scan/cmd-scan-metadata.mts
+++ b/src/commands/scan/cmd-scan-metadata.mts
@@ -114,7 +114,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!hasApiToken,
+      test: hasApiToken ,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/scan/cmd-scan-report.mts
+++ b/src/commands/scan/cmd-scan-report.mts
@@ -9,7 +9,7 @@ import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type {
   CliCommandConfig,
@@ -124,7 +124,7 @@ async function run(
     (isTestingV1() || defaultOrgSlug ? cli.input[0] : cli.input[1]) || ''
   const file =
     (isTestingV1() || defaultOrgSlug ? cli.input[1] : cli.input[2]) || '-'
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -155,7 +155,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/scan/cmd-scan-view.mts
+++ b/src/commands/scan/cmd-scan-view.mts
@@ -10,7 +10,7 @@ import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type {
   CliCommandConfig,
@@ -101,7 +101,7 @@ async function run(
     (isTestingV1() || defaultOrgSlug ? cli.input[0] : cli.input[1]) || ''
   const file =
     (isTestingV1() || defaultOrgSlug ? cli.input[1] : cli.input[2]) || '-'
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -133,7 +133,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: !!hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/scan/cmd-scan-view.mts
+++ b/src/commands/scan/cmd-scan-view.mts
@@ -133,7 +133,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!hasApiToken,
+      test: hasApiToken ,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/threat-feed/cmd-threat-feed.mts
+++ b/src/commands/threat-feed/cmd-threat-feed.mts
@@ -156,7 +156,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!hasApiToken,
+      test: hasApiToken ,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/commands/threat-feed/cmd-threat-feed.mts
+++ b/src/commands/threat-feed/cmd-threat-feed.mts
@@ -9,7 +9,7 @@ import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
-import { getDefaultToken } from '../../utils/sdk.mts'
+import { hasDefaultToken } from '../../utils/sdk.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -136,7 +136,7 @@ async function run(
     !!dryRun
   )
 
-  const apiToken = getDefaultToken()
+  const hasApiToken = hasDefaultToken()
 
   const wasValidInput = checkCommandInput(
     outputKind,
@@ -156,7 +156,7 @@ async function run(
     },
     {
       nook: true,
-      test: !!apiToken,
+      test: !!hasApiToken,
       message:
         'You need to be logged in to use this command. See `socket login`.',
       pass: 'ok',

--- a/src/utils/api.mts
+++ b/src/utils/api.mts
@@ -179,11 +179,6 @@ export async function getErrorMessageForHttpStatusCode(code: number) {
   return `Server responded with status code ${code}`
 }
 
-export function getLastFiveOfApiToken(token: string): string {
-  // Get the last 5 characters of the API token before the trailing "_api".
-  return token.slice(-9, -4)
-}
-
 // The API server that should be used for operations.
 export function getDefaultApiBaseUrl(): string | undefined {
   // Lazily access constants.ENV.SOCKET_SECURITY_API_BASE_URL.

--- a/src/utils/meow-with-subcommands.mts
+++ b/src/utils/meow-with-subcommands.mts
@@ -9,7 +9,6 @@ import { toSortedObject } from '@socketsecurity/registry/lib/objects'
 import { normalizePath } from '@socketsecurity/registry/lib/path'
 import { escapeRegExp } from '@socketsecurity/registry/lib/regexps'
 
-import { getLastFiveOfApiToken } from './api.mts'
 import {
   getConfigValueOrUndef,
   isReadOnlyConfig,
@@ -20,7 +19,7 @@ import {
 import { getFlagListOutput, getHelpListOutput } from './output-formatting.mts'
 import constants from '../constants.mts'
 import { commonFlags } from '../flags.mts'
-import { getDefaultToken } from './sdk.mts'
+import { getVisibleTokenPrefix } from './sdk.mts'
 
 import type { MeowFlags } from '../flags.mts'
 import type { Options } from 'meow'
@@ -339,7 +338,6 @@ function getAsciiHeader(command: string) {
     : // Lazily access constants.ENV.INLINED_SOCKET_CLI_VERSION_HASH.
       constants.ENV.INLINED_SOCKET_CLI_VERSION_HASH
   const nodeVersion = redacting ? REDACTED : process.version
-  const apiToken = getDefaultToken()
   const defaultOrg = getConfigValueOrUndef('defaultOrg')
   const readOnlyConfig = isReadOnlyConfig() ? '*' : '.'
   const v1test = isTestingV1() ? ' (is testing v1)' : ''
@@ -348,11 +346,7 @@ function getAsciiHeader(command: string) {
         '   (Thank you for testing the v1 bump! Please send us any feedback you might have!)\n'
       )
     : ''
-  const shownToken = redacting
-    ? REDACTED
-    : apiToken
-      ? getLastFiveOfApiToken(apiToken)
-      : 'no'
+  const shownToken = redacting ? REDACTED : getVisibleTokenPrefix() || 'no'
   const relCwd = redacting
     ? REDACTED
     : normalizePath(

--- a/src/utils/sdk.mts
+++ b/src/utils/sdk.mts
@@ -45,6 +45,20 @@ export function getDefaultToken(): string | undefined {
   return _defaultToken
 }
 
+export function getVisibleTokenPrefix(): string {
+  const apiToken = getDefaultToken()
+  if (!apiToken) {
+    return ''
+  }
+
+  const PREFIX = 'sktsec_'
+  return apiToken.slice(PREFIX.length, PREFIX.length + 5)
+}
+
+export function hasDefaultToken(): boolean {
+  return !!getDefaultToken()
+}
+
 export function getPublicToken(): string {
   return (
     // Lazily access constants.ENV.SOCKET_SECURITY_API_TOKEN.


### PR DESCRIPTION
This cleans up the `getDefaultToken()` calls a bit and replaces them with `hasDefaultToken`, which is what most callsites want to know.

Changing the visible part of the token in the banner to the first five character rather than the last, because that's what's visible in the dashboard. And ultimately it doesn't really matter which chars are visible, anyways. It's just a clue to yourself and for debugging.
