### PR TITLE
Cleanup lsat old handleApi usage

### DIFF
--- a/src/commands/oops/cmd-oops.mts
+++ b/src/commands/oops/cmd-oops.mts
@@ -1,8 +1,10 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import constants from '../../constants.mts'
-import { commonFlags } from '../../flags.mts'
+import { commonFlags, outputFlags } from '../../flags.mts'
+import { failMsgWithBadge } from '../../utils/fail-msg-with-badge.mjs'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
+import { serializeResultJson } from '../../utils/serialize-result-json.mjs'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -13,7 +15,8 @@ const config: CliCommandConfig = {
   description: 'Trigger an intentional error (for development)',
   hidden: true,
   flags: {
-    ...commonFlags
+    ...commonFlags,
+    ...outputFlags
   },
   help: (parentName, config) => `
     Usage
@@ -41,10 +44,29 @@ async function run(
     parentName
   })
 
-  // TODO: impl json/md
+  const { json, markdown } = cli.flags
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAILING_NOW)
+    return
+  }
+
+  if (json) {
+    process.exitCode = 1
+    logger.log(
+      serializeResultJson({
+        ok: false,
+        message: 'Oops',
+        cause: 'This error was intentionally left blank'
+      })
+    )
+  }
+
+  if (markdown) {
+    process.exitCode = 1
+    logger.fail(
+      failMsgWithBadge('Oops', 'This error was intentionally left blank')
+    )
     return
   }
 

--- a/src/utils/api.mts
+++ b/src/utils/api.mts
@@ -37,19 +37,6 @@ export function handleUnsuccessfulApiResponse<T extends SocketSdkOperations>(
   process.exit(1)
 }
 
-export function handleFailedApiResponse<T extends SocketSdkOperations>(
-  _name: T,
-  { cause, error }: SocketSdkErrorType<T>
-): CResult<never> {
-  const message = `${error || 'No error message returned'}`
-  // logger.error(failMsgWithBadge('Socket API returned an error', message))
-  return {
-    ok: false,
-    message: 'Socket API returned an error',
-    cause: `${message}${cause ? ` ( Reason: ${cause} )` : ''}`
-  }
-}
-
 export async function handleApiCall<T extends SocketSdkOperations>(
   value: Promise<SocketSdkResultType<T>>,
   fetchingDesc: string
@@ -104,19 +91,6 @@ export async function handleApiCall<T extends SocketSdkOperations>(
       ok: true,
       data: ok.data
     }
-  }
-}
-
-export async function tmpHandleApiCall<T>(
-  value: Promise<T>,
-  description: string
-): Promise<Awaited<T>> {
-  try {
-    return await value
-  } catch (e) {
-    debugLog(`handleApiCall[${description}] error:\n`, e)
-    // TODO: eliminate this throw in favor of CResult (or anything else)
-    throw new Error(`Failed ${description}`, { cause: e })
   }
 }
 


### PR DESCRIPTION
This cleans up the last usage. Missed it in the previous sweep.

Also adds json/markdown flag for the oops command. Not super relevant to anyone else.