### PR TITLE
Create alias for toplevel cdxgen

### DIFF
--- a/src/cli.mts
+++ b/src/cli.mts
@@ -10,6 +10,7 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { cmdAnalytics } from './commands/analytics/cmd-analytics.mts'
 import { cmdAuditLog } from './commands/audit-log/cmd-audit-log.mts'
+import { cmdCdxgen } from './commands/cdxgen/cmd-cdxgen.mts'
 import { cmdCI } from './commands/ci/cmd-ci.mts'
 import { cmdConfig } from './commands/config/cmd-config.mts'
 import { cmdScanCreate } from './commands/dependencies/cmd-dependencies.mts'
@@ -56,6 +57,7 @@ void (async () => {
     await meowWithSubcommands(
       {
         ci: cmdCI,
+        cdxgen: cmdCdxgen,
         config: cmdConfig,
         fix: cmdFix,
         info: cmdInfo,

--- a/src/commands/cdxgen/cmd-cdxgen.mts
+++ b/src/commands/cdxgen/cmd-cdxgen.mts
@@ -1,0 +1,37 @@
+import { logger } from '@socketsecurity/registry/lib/logger'
+
+import { handleCdxgen } from './handle-cdxgen.mts'
+import { commonFlags } from '../../flags.mts'
+
+import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
+
+const config: CliCommandConfig = {
+  commandName: 'cdxgen',
+  description: 'Create an SBOM with CycloneDX generator (cdxgen)',
+  hidden: true,
+  flags: {
+    ...commonFlags,
+  },
+  help: (parentName, _config) => `
+    Usage
+      $ ${parentName}
+  `,
+}
+
+export const cmdCdxgen = {
+  description: config.description,
+  hidden: config.hidden,
+  run,
+}
+
+async function run(
+  argv: string[] | readonly string[],
+  importMeta: ImportMeta,
+  { parentName }: { parentName: string },
+): Promise<void> {
+  logger.warn(
+    'Warning: The `socket cdxgen` command moved to `socket manifest cdxgen` and will be removed as a toplevel command in the next major bump.',
+  )
+
+  await handleCdxgen(argv, importMeta, { parentName })
+}

--- a/src/commands/cdxgen/cmd-cdxgen.test.mts
+++ b/src/commands/cdxgen/cmd-cdxgen.test.mts
@@ -1,0 +1,89 @@
+import path from 'node:path'
+
+import { describe, expect } from 'vitest'
+
+import constants from '../../../src/constants.mts'
+import { cmdit, invokeNpm } from '../../../test/utils.mts'
+
+const { CLI } = constants
+
+describe('socket cdxgen', async () => {
+  // Lazily access constants.rootBinPath.
+  const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
+
+  cmdit(['cdxgen', '--help'], 'should support --help', async cmd => {
+    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+    expect(stdout).toMatchInlineSnapshot(
+      `
+        "cdxgen [command]
+
+        Commands:
+          cdxgen completion  Generate bash/zsh completion
+
+        Options:
+          -o, --output                 Output file. Default bom.json  [default: "bom.json"]
+          -t, --type                   Project type. Please refer to https://cyclonedx.github.io/cdxgen/#/PROJECT_TYPES for supported languages/platforms.  [array]
+              --exclude-type           Project types to exclude. Please refer to https://cyclonedx.github.io/cdxgen/#/PROJECT_TYPES for supported languages/platforms.
+          -r, --recurse                Recurse mode suitable for mono-repos. Defaults to true. Pass --no-recurse to disable.  [boolean] [default: true]
+          -p, --print                  Print the SBOM as a table with tree.  [boolean]
+          -c, --resolve-class          Resolve class names for packages. jars only for now.  [boolean]
+              --deep                   Perform deep searches for components. Useful while scanning C/C++ apps, live OS and oci images.  [boolean]
+              --server-url             Dependency track url. Eg: https://deptrack.cyclonedx.io
+              --skip-dt-tls-check      Skip TLS certificate check when calling Dependency-Track.  [boolean] [default: false]
+              --api-key                Dependency track api key
+              --project-group          Dependency track project group
+              --project-name           Dependency track project name. Default use the directory name
+              --project-version        Dependency track project version  [string] [default: ""]
+              --project-id             Dependency track project id. Either provide the id or the project name and version together  [string]
+              --parent-project-id      Dependency track parent project id  [string]
+              --required-only          Include only the packages with required scope on the SBOM. Would set compositions.aggregate to incomplete unless --no-auto-compositions is passed.  [boolean]
+              --fail-on-error          Fail if any dependency extractor fails.  [boolean]
+              --no-babel               Do not use babel to perform usage analysis for JavaScript/TypeScript projects.  [boolean]
+              --generate-key-and-sign  Generate an RSA public/private key pair and then sign the generated SBOM using JSON Web Signatures.  [boolean]
+              --server                 Run cdxgen as a server  [boolean]
+              --server-host            Listen address  [default: "127.0.0.1"]
+              --server-port            Listen port  [default: "9090"]
+              --install-deps           Install dependencies automatically for some projects. Defaults to true but disabled for containers and oci scans. Use --no-install-deps to disable this feature.  [boolean] [default: true]
+              --validate               Validate the generated SBOM using json schema. Defaults to true. Pass --no-validate to disable.  [boolean] [default: true]
+              --evidence               Generate SBOM with evidence for supported languages.  [boolean] [default: false]
+              --spec-version           CycloneDX Specification version to use. Defaults to 1.6  [number] [choices: 1.4, 1.5, 1.6] [default: 1.6]
+              --filter                 Filter components containing this word in purl or component.properties.value. Multiple values allowed.  [array]
+              --only                   Include components only containing this word in purl. Useful to generate BOM with first party components alone. Multiple values allowed.  [array]
+              --author                 The person(s) who created the BOM. Set this value if you're intending the modify the BOM and claim authorship.  [array] [default: "OWASP Foundation"]
+              --profile                BOM profile to use for generation. Default generic.  [choices: "appsec", "research", "operational", "threat-modeling", "license-compliance", "generic", "machine-learning", "ml", "deep-learning", "ml-deep", "ml-tiny"] [default: "generic"]
+              --exclude                Additional glob pattern(s) to ignore  [array]
+              --include-formulation    Generate formulation section with git metadata and build tools. Defaults to false.  [boolean] [default: false]
+              --include-crypto         Include crypto libraries as components.  [boolean] [default: false]
+              --standard               The list of standards which may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements which can be evaluated against or attested to.  [array] [choices: "asvs-5.0", "asvs-4.0.3", "bsimm-v13", "masvs-2.0.0", "nist_ssdf-1.1", "pcissc-secure-slc-1.1", "scvs-1.0.0", "ssaf-DRAFT-2023-11"]
+              --json-pretty            Pretty-print the generated BOM json.  [boolean] [default: false]
+              --min-confidence         Minimum confidence needed for the identity of a component from 0 - 1, where 1 is 100% confidence.  [number] [default: 0]
+              --technique              Analysis technique to use  [array] [choices: "auto", "source-code-analysis", "binary-analysis", "manifest-analysis", "hash-comparison", "instrumentation", "filename"]
+              --auto-compositions      Automatically set compositions when the BOM was filtered. Defaults to true  [boolean] [default: true]
+          -h, --help                   Show help  [boolean]
+          -v, --version                Show version number  [boolean]
+
+        Examples:
+          cdxgen -t java .                       Generate a Java SBOM for the current directory
+          cdxgen -t java -t js .                 Generate a SBOM for Java and JavaScript in the current directory
+          cdxgen -t java --profile ml .          Generate a Java SBOM for machine learning purposes.
+          cdxgen -t python --profile research .  Generate a Python SBOM for appsec research.
+          cdxgen --server                        Run cdxgen as a server
+
+        for documentation, visit https://cyclonedx.github.io/cdxgen"
+      `,
+    )
+    expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           \\x1b[33m\\u203c\\x1b[39m Warning: The \`socket cdxgen\` command moved to \`socket manifest cdxgen\` and will be removed as a toplevel command in the next major bump.
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>, default org: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket cdxgen\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
+      `)
+
+    expect(code, 'explicit help should exit with code 0').toBe(0)
+    expect(stderr, 'banner includes base command').toContain('`socket cdxgen`')
+  })
+})

--- a/src/commands/cdxgen/cmd-cdxgen.test.mts
+++ b/src/commands/cdxgen/cmd-cdxgen.test.mts
@@ -12,7 +12,10 @@ describe('socket cdxgen', async () => {
   const entryPath = path.join(constants.rootBinPath, `${CLI}.js`)
 
   cmdit(['cdxgen', '--help'], 'should support --help', async cmd => {
-    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
+    const { code, stderr, stdout } = await invokeNpm(entryPath, cmd,  {
+      // Need to pass it on as env because --config will break cdxgen
+      SOCKET_CLI_CONFIG: '{}',
+    })
     expect(stdout).toMatchInlineSnapshot(
       `
         "cdxgen [command]
@@ -73,15 +76,13 @@ describe('socket cdxgen', async () => {
       `,
     )
     expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
-        "
-           \\x1b[33m\\u203c\\x1b[39m Warning: The \`socket cdxgen\` command moved to \`socket manifest cdxgen\` and will be removed as a toplevel command in the next major bump.
-           _____         _       _        /---------------
-          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
-          |__   | . |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>, default org: <redacted>
-          |_____|___|___|_,_|___|_|.dev   | Command: \`socket cdxgen\`, cwd: <redacted>
-        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
-        \\x1b[39m"
-      `)
+      "
+         \\x1b[33m\\u203c\\x1b[39m Warning: The \`socket cdxgen\` command moved to \`socket manifest cdxgen\` and will be removed as a toplevel command in the next major bump.
+         _____         _       _        /---------------
+        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+        |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+        |_____|___|___|_,_|___|_|.dev   | Command: \`socket cdxgen\`, cwd: <redacted>"
+    `)
 
     expect(code, 'explicit help should exit with code 0').toBe(0)
     expect(stderr, 'banner includes base command').toContain('`socket cdxgen`')

--- a/src/commands/cdxgen/handle-cdxgen.mts
+++ b/src/commands/cdxgen/handle-cdxgen.mts
@@ -1,0 +1,9 @@
+import { cmdManifestCdxgen } from '../manifest/cmd-manifest-cdxgen.mts'
+
+export async function handleCdxgen(
+  argv: string[] | readonly string[],
+  importMeta: ImportMeta,
+  { parentName }: { parentName: string },
+): Promise<void> {
+  await cmdManifestCdxgen.run(argv, importMeta, { parentName })
+}


### PR DESCRIPTION
This makes `socket cdxgen` work again by forwarding to the new location. It will print a small deprecation warning, too.
