### PR TITLE
Update few logger calls to better methods

### DIFF
--- a/src/commands/analytics/output-analytics.mts
+++ b/src/commands/analytics/output-analytics.mts
@@ -84,7 +84,7 @@ export async function outputAnalytics(
     if (filePath) {
       try {
         await fs.writeFile(filePath, serialized, 'utf8')
-        logger.error(`Data successfully written to ${filePath}`)
+        logger.success(`Data successfully written to ${filePath}`)
       } catch (e) {
         process.exitCode = 1
         logger.log(
@@ -112,7 +112,7 @@ export async function outputAnalytics(
     if (filePath) {
       try {
         await fs.writeFile(filePath, serialized, 'utf8')
-        logger.log(`Data successfully written to ${filePath}`)
+        logger.success(`Data successfully written to ${filePath}`)
       } catch (e) {
         logger.error(e)
       }

--- a/src/commands/audit-log/cmd-audit-log.test.mts
+++ b/src/commands/audit-log/cmd-audit-log.test.mts
@@ -118,7 +118,9 @@ describe('socket audit-log', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(stdout).toMatchInlineSnapshot(
+        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+      )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------
@@ -127,8 +129,7 @@ describe('socket audit-log', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket audit-log\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        Missing the org slug and no --org flag set. Trying to auto-discover the org now...
-        Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
+        \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/audit-log/cmd-audit-log.test.mts
+++ b/src/commands/audit-log/cmd-audit-log.test.mts
@@ -119,7 +119,7 @@ describe('socket audit-log', async () => {
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
-        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+        `""`,
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
@@ -130,6 +130,7 @@ describe('socket audit-log', async () => {
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
         \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
+        \\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/audit-log/cmd-audit-log.test.mts
+++ b/src/commands/audit-log/cmd-audit-log.test.mts
@@ -118,9 +118,7 @@ describe('socket audit-log', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(
-        `""`,
-      )
+      expect(stdout).toMatchInlineSnapshot(`""`)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------

--- a/src/commands/diff-scan/output-diff-scan.mts
+++ b/src/commands/diff-scan/output-diff-scan.mts
@@ -48,21 +48,21 @@ export async function outputDiffScan(
     const json = serializeResultJson(result)
 
     if (file && file !== '-') {
-      logger.log(`Writing json to \`${file}\``)
+      logger.info(`Writing json to \`${file}\``)
       fs.writeFile(file, JSON.stringify(result, null, 2), err => {
         if (err) {
           logger.fail(`Writing to \`${file}\` failed...`)
           logger.error(err)
         } else {
-          logger.log(`Data successfully written to \`${file}\``)
+          logger.success(`Data successfully written to \`${file}\``)
         }
-        logger.error(dashboardMessage)
+        logger.info(dashboardMessage)
       })
     } else {
-      // TODO: expose different method for writing to stderr when simply dodging stdout
-      logger.error(`\n Diff scan result: \n`)
+      // Note: only the .log will go to stdout
+      logger.success(`\n Diff scan result: \n`)
       logger.log(json)
-      logger.error(dashboardMessage)
+      logger.info(dashboardMessage)
     }
 
     return
@@ -71,7 +71,7 @@ export async function outputDiffScan(
   // In this case neither the --json nor the --file flag was passed
   // Dump the JSON to CLI and let NodeJS deal with truncation
 
-  logger.log('Diff scan result:')
+  logger.success('Diff scan result:')
   logger.log(
     util.inspect(result, {
       showHidden: false,
@@ -80,7 +80,7 @@ export async function outputDiffScan(
       maxArrayLength: null,
     }),
   )
-  logger.log(
+  logger.info(
     `\n 📝 To display the detailed report in the terminal, use the --json flag \n`,
   )
   logger.log(dashboardMessage)

--- a/src/commands/fix/cmd-fix.test.mts
+++ b/src/commands/fix/cmd-fix.test.mts
@@ -70,10 +70,13 @@ describe('socket fix', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket fix\`, cwd: <redacted>
 
-        \\x1b[33m\\u203c\\x1b[39m socket fix: Package package-lock.json found at <redacted>
-        \\x1b[34mi\\x1b[39m Fixing packages for npm"
+        \\x1b[33m\\u203c\\x1b[39m socket fix: Package package-lock.json found at <redacted>"
       `)
-      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Not saving"`)
+      expect(stdout).toMatchInlineSnapshot(`
+        "\\x1b[34mi\\x1b[39m Fixing packages for npm
+
+        [DryRun]: Not saving"
+      `)
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
     },
   )

--- a/src/commands/fix/cmd-fix.test.mts
+++ b/src/commands/fix/cmd-fix.test.mts
@@ -70,13 +70,10 @@ describe('socket fix', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket fix\`, cwd: <redacted>
 
-        \\x1b[33m\\u203c\\x1b[39m socket fix: Package package-lock.json found at <redacted>"
+        \\x1b[33m\\u203c\\x1b[39m socket fix: Package package-lock.json found at <redacted>
+        \\x1b[34mi\\x1b[39m Fixing packages for npm"
       `)
-      expect(stdout).toMatchInlineSnapshot(`
-        "\\x1b[34mi\\x1b[39m Fixing packages for npm
-
-        [DryRun]: Not saving"
-      `)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Not saving"`)
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
     },
   )

--- a/src/commands/manifest/cmd-manifest-conda.mts
+++ b/src/commands/manifest/cmd-manifest-conda.mts
@@ -122,7 +122,7 @@ async function run(
     return
   }
 
-  logger.error(
+  logger.warn(
     'Warning: This will approximate your Conda dependencies using PyPI. We do not yet officially support Conda. Use at your own risk.',
   )
 

--- a/src/commands/manifest/cmd-manifest-conda.test.mts
+++ b/src/commands/manifest/cmd-manifest-conda.test.mts
@@ -103,7 +103,7 @@ describe('socket manifest conda', async () => {
           |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest conda\`, cwd: <redacted>
 
-        Warning: This will approximate your Conda dependencies using PyPI. We do not yet officially support Conda. Use at your own risk."
+        \\x1b[33m\\u203c\\x1b[39m Warning: This will approximate your Conda dependencies using PyPI. We do not yet officially support Conda. Use at your own risk."
       `)
 
       expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
@@ -135,7 +135,7 @@ describe('socket manifest conda', async () => {
             |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
             |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest conda\`, cwd: <redacted>
 
-          Warning: This will approximate your Conda dependencies using PyPI. We do not yet officially support Conda. Use at your own risk."
+          \\x1b[33m\\u203c\\x1b[39m Warning: This will approximate your Conda dependencies using PyPI. We do not yet officially support Conda. Use at your own risk."
         `)
       },
     )
@@ -169,7 +169,7 @@ describe('socket manifest conda', async () => {
             |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
             |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest conda\`, cwd: <redacted>
 
-          Warning: This will approximate your Conda dependencies using PyPI. We do not yet officially support Conda. Use at your own risk."
+          \\x1b[33m\\u203c\\x1b[39m Warning: This will approximate your Conda dependencies using PyPI. We do not yet officially support Conda. Use at your own risk."
         `)
       },
     )
@@ -205,7 +205,7 @@ describe('socket manifest conda', async () => {
             |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
             |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest conda\`, cwd: <redacted>
 
-          Warning: This will approximate your Conda dependencies using PyPI. We do not yet officially support Conda. Use at your own risk."
+          \\x1b[33m\\u203c\\x1b[39m Warning: This will approximate your Conda dependencies using PyPI. We do not yet officially support Conda. Use at your own risk."
         `)
       },
     )

--- a/src/commands/manifest/convert-conda-to-requirements.mts
+++ b/src/commands/manifest/convert-conda-to-requirements.mts
@@ -13,7 +13,7 @@ export async function convertCondaToRequirements(
   let contents: string
   if (target === '-') {
     if (verbose) {
-      logger.error(`[VERBOSE] reading input from stdin`)
+      logger.info(`[VERBOSE] reading input from stdin`)
     }
 
     const buf: string[] = []
@@ -59,7 +59,7 @@ export async function convertCondaToRequirements(
     const f = path.resolve(cwd, target)
 
     if (verbose) {
-      logger.error(`[VERBOSE] target file: ${f}`)
+      logger.info(`[VERBOSE] target file: ${f}`)
     }
 
     if (!fs.existsSync(f)) {

--- a/src/commands/manifest/convert_sbt_to_maven.mts
+++ b/src/commands/manifest/convert_sbt_to_maven.mts
@@ -90,7 +90,7 @@ export async function convertSbtToMaven(
         'Requested out target was stdout but there are multiple generated files',
       )
       poms.forEach(fn => logger.error('-', fn))
-      logger.error('Exiting now...')
+      logger.info('Exiting now...')
       return
     } else {
       // if (verbose) {

--- a/src/commands/organization/cmd-organization-policy-license.test.mts
+++ b/src/commands/organization/cmd-organization-policy-license.test.mts
@@ -120,9 +120,7 @@ describe('socket organization policy license', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(
-        `""`,
-      )
+      expect(stdout).toMatchInlineSnapshot(`""`)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------

--- a/src/commands/organization/cmd-organization-policy-license.test.mts
+++ b/src/commands/organization/cmd-organization-policy-license.test.mts
@@ -121,7 +121,7 @@ describe('socket organization policy license', async () => {
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
-        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+        `""`,
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
@@ -132,6 +132,7 @@ describe('socket organization policy license', async () => {
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
         \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
+        \\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/organization/cmd-organization-policy-license.test.mts
+++ b/src/commands/organization/cmd-organization-policy-license.test.mts
@@ -120,7 +120,9 @@ describe('socket organization policy license', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(stdout).toMatchInlineSnapshot(
+        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+      )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------
@@ -129,8 +131,7 @@ describe('socket organization policy license', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy license\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        Missing the org slug and no --org flag set. Trying to auto-discover the org now...
-        Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
+        \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/organization/cmd-organization-policy-security.test.mts
+++ b/src/commands/organization/cmd-organization-policy-security.test.mts
@@ -121,7 +121,7 @@ describe('socket organization policy security', async () => {
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
-        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+        `""`,
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
@@ -132,6 +132,7 @@ describe('socket organization policy security', async () => {
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
         \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
+        \\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/organization/cmd-organization-policy-security.test.mts
+++ b/src/commands/organization/cmd-organization-policy-security.test.mts
@@ -120,9 +120,7 @@ describe('socket organization policy security', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(
-        `""`,
-      )
+      expect(stdout).toMatchInlineSnapshot(`""`)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------

--- a/src/commands/organization/cmd-organization-policy-security.test.mts
+++ b/src/commands/organization/cmd-organization-policy-security.test.mts
@@ -120,7 +120,9 @@ describe('socket organization policy security', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(stdout).toMatchInlineSnapshot(
+        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+      )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------
@@ -129,8 +131,7 @@ describe('socket organization policy security', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket organization policy security\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        Missing the org slug and no --org flag set. Trying to auto-discover the org now...
-        Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
+        \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/organization/output-license-policy.mts
+++ b/src/commands/organization/output-license-policy.mts
@@ -24,7 +24,7 @@ export async function outputLicensePolicy(
     return
   }
 
-  logger.error('Use --json to get the full result')
+  logger.info('Use --json to get the full result')
   logger.log('# License policy')
   logger.log('')
   logger.log('This is the license policy for your organization:')

--- a/src/commands/package/fetch-purl-deep-score.mts
+++ b/src/commands/package/fetch-purl-deep-score.mts
@@ -56,7 +56,7 @@ export interface PurlDataResponse {
 export async function fetchPurlDeepScore(
   purl: string,
 ): Promise<CResult<PurlDataResponse>> {
-  logger.error(`Requesting deep score data for this purl: ${purl}`)
+  logger.info(`Requesting deep score data for this purl: ${purl}`)
 
   return await queryApiSafeJson<PurlDataResponse>(
     `purl/score/${encodeURIComponent(purl)}`,

--- a/src/commands/package/fetch-purls-shallow-score.mts
+++ b/src/commands/package/fetch-purls-shallow-score.mts
@@ -9,7 +9,7 @@ import type { SocketSdkReturnType } from '@socketsecurity/sdk'
 export async function fetchPurlsShallowScore(
   purls: string[],
 ): Promise<CResult<SocketSdkReturnType<'batchPackageFetch'>>> {
-  logger.error(
+  logger.info(
     `Requesting shallow score data for ${purls.length} package urls (purl): ${purls.join(', ')}`,
   )
 

--- a/src/commands/package/output-purl-score.mts
+++ b/src/commands/package/output-purl-score.mts
@@ -44,7 +44,7 @@ export async function outputPurlScore(
       },
     } = result.data
 
-    logger.error(`Score report for "${requestedPurl}" ("${purl}"):\n`)
+    logger.success(`Score report for "${requestedPurl}" ("${purl}"):\n`)
     logger.log('# Complete Package Score')
     logger.log('')
     if (dependencyCount) {

--- a/src/commands/repos/cmd-repos-create.test.mts
+++ b/src/commands/repos/cmd-repos-create.test.mts
@@ -125,7 +125,7 @@ describe('socket repos create', async () => {
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
-        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+        `""`,
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
@@ -136,6 +136,7 @@ describe('socket repos create', async () => {
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
         \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
+        \\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/repos/cmd-repos-create.test.mts
+++ b/src/commands/repos/cmd-repos-create.test.mts
@@ -124,9 +124,7 @@ describe('socket repos create', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(
-        `""`,
-      )
+      expect(stdout).toMatchInlineSnapshot(`""`)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------

--- a/src/commands/repos/cmd-repos-create.test.mts
+++ b/src/commands/repos/cmd-repos-create.test.mts
@@ -124,7 +124,9 @@ describe('socket repos create', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(stdout).toMatchInlineSnapshot(
+        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+      )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------
@@ -133,8 +135,7 @@ describe('socket repos create', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos create\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        Missing the org slug and no --org flag set. Trying to auto-discover the org now...
-        Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
+        \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/repos/cmd-repos-del.test.mts
+++ b/src/commands/repos/cmd-repos-del.test.mts
@@ -118,7 +118,9 @@ describe('socket repos del', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(stdout).toMatchInlineSnapshot(
+        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+      )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------
@@ -127,8 +129,7 @@ describe('socket repos del', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos del\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        Missing the org slug and no --org flag set. Trying to auto-discover the org now...
-        Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
+        \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/repos/cmd-repos-del.test.mts
+++ b/src/commands/repos/cmd-repos-del.test.mts
@@ -119,7 +119,7 @@ describe('socket repos del', async () => {
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
-        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+        `""`,
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
@@ -130,6 +130,7 @@ describe('socket repos del', async () => {
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
         \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
+        \\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/repos/cmd-repos-del.test.mts
+++ b/src/commands/repos/cmd-repos-del.test.mts
@@ -118,9 +118,7 @@ describe('socket repos del', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(
-        `""`,
-      )
+      expect(stdout).toMatchInlineSnapshot(`""`)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------

--- a/src/commands/repos/cmd-repos-list.test.mts
+++ b/src/commands/repos/cmd-repos-list.test.mts
@@ -111,7 +111,9 @@ describe('socket repos list', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(stdout).toMatchInlineSnapshot(
+        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+      )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------
@@ -120,8 +122,7 @@ describe('socket repos list', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos list\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        Missing the org slug and no --org flag set. Trying to auto-discover the org now...
-        Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
+        \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/repos/cmd-repos-list.test.mts
+++ b/src/commands/repos/cmd-repos-list.test.mts
@@ -112,7 +112,7 @@ describe('socket repos list', async () => {
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
-        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+        `""`,
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
@@ -123,6 +123,7 @@ describe('socket repos list', async () => {
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
         \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
+        \\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/repos/cmd-repos-list.test.mts
+++ b/src/commands/repos/cmd-repos-list.test.mts
@@ -111,9 +111,7 @@ describe('socket repos list', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(
-        `""`,
-      )
+      expect(stdout).toMatchInlineSnapshot(`""`)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------

--- a/src/commands/repos/cmd-repos-update.test.mts
+++ b/src/commands/repos/cmd-repos-update.test.mts
@@ -97,9 +97,7 @@ describe('socket repos update', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(
-        `""`,
-      )
+      expect(stdout).toMatchInlineSnapshot(`""`)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------

--- a/src/commands/repos/cmd-repos-update.test.mts
+++ b/src/commands/repos/cmd-repos-update.test.mts
@@ -98,7 +98,7 @@ describe('socket repos update', async () => {
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
-        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+        `""`,
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
@@ -109,6 +109,7 @@ describe('socket repos update', async () => {
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
         \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
+        \\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/repos/cmd-repos-update.test.mts
+++ b/src/commands/repos/cmd-repos-update.test.mts
@@ -97,7 +97,9 @@ describe('socket repos update', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(stdout).toMatchInlineSnapshot(
+        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+      )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------
@@ -106,8 +108,7 @@ describe('socket repos update', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos update\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        Missing the org slug and no --org flag set. Trying to auto-discover the org now...
-        Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
+        \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/repos/cmd-repos-view.test.mts
+++ b/src/commands/repos/cmd-repos-view.test.mts
@@ -120,9 +120,7 @@ describe('socket repos view', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(
-        `""`,
-      )
+      expect(stdout).toMatchInlineSnapshot(`""`)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------

--- a/src/commands/repos/cmd-repos-view.test.mts
+++ b/src/commands/repos/cmd-repos-view.test.mts
@@ -121,7 +121,7 @@ describe('socket repos view', async () => {
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
-        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+        `""`,
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
@@ -132,6 +132,7 @@ describe('socket repos view', async () => {
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
         \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
+        \\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/repos/cmd-repos-view.test.mts
+++ b/src/commands/repos/cmd-repos-view.test.mts
@@ -120,7 +120,9 @@ describe('socket repos view', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(stdout).toMatchInlineSnapshot(
+        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+      )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------
@@ -129,8 +131,7 @@ describe('socket repos view', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket repos view\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        Missing the org slug and no --org flag set. Trying to auto-discover the org now...
-        Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
+        \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/scan/cmd-scan-create.mts
+++ b/src/commands/scan/cmd-scan-create.mts
@@ -251,14 +251,14 @@ async function run(
   }
 
   if (updatedInput && orgSlug && targets?.length) {
-    logger.error(
+    logger.info(
       'Note: You can invoke this command next time to skip the interactive questions:',
     )
-    logger.error('```')
-    logger.error(
+    logger.info('```')
+    logger.info(
       `    socket scan create [other flags...] ${defaultOrgSlug ? '' : orgSlug} ${targets.join(' ')}`,
     )
-    logger.error('```\n')
+    logger.info('```\n')
   }
 
   const wasValidInput = checkCommandInput(

--- a/src/commands/scan/fetch-diff-scan.mts
+++ b/src/commands/scan/fetch-diff-scan.mts
@@ -14,9 +14,9 @@ export async function fetchDiffScan({
   id2: string
   orgSlug: string
 }): Promise<CResult<SocketSdkReturnType<'GetOrgDiffScan'>['data']>> {
-  logger.error('Scan ID 1:', id1)
-  logger.error('Scan ID 2:', id2)
-  logger.error('Note: this request may take some time if the scans are big')
+  logger.info('Scan ID 1:', id1)
+  logger.info('Scan ID 2:', id2)
+  logger.info('Note: this request may take some time if the scans are big')
 
   return await queryApiSafeJson<SocketSdkReturnType<'GetOrgDiffScan'>['data']>(
     `orgs/${orgSlug}/full-scans/diff?before=${encodeURIComponent(id1)}&after=${encodeURIComponent(id2)}`,

--- a/src/commands/scan/fetch-report-data.mts
+++ b/src/commands/scan/fetch-report-data.mts
@@ -49,7 +49,7 @@ export async function fetchReportData(
   function updateProgress() {
     if (finishedFetching) {
       spinner.stop()
-      logger.error(
+      logger.info(
         `Scan result: ${scanStatus}. Security policy: ${policyStatus}.`,
       )
     } else {

--- a/src/commands/scan/output-diff-scan.mts
+++ b/src/commands/scan/output-diff-scan.mts
@@ -71,10 +71,10 @@ export async function outputDiffScan(
       maxArrayLength: null,
     }),
   )
-  logger.error(
+  logger.info(
     `\n 📝 To display the detailed report in the terminal, use the --json flag. For a friendlier report, use the --markdown flag.\n`,
   )
-  logger.log(dashboardMessage)
+  logger.info(dashboardMessage)
 }
 
 async function handleJson(
@@ -91,15 +91,15 @@ async function handleJson(
         logger.fail(`Writing to \`${file}\` failed...`)
         logger.error(err)
       } else {
-        logger.log(`Data successfully written to \`${file}\``)
+        logger.success(`Data successfully written to \`${file}\``)
       }
       logger.error(dashboardMessage)
     })
   } else {
-    // TODO: expose different method for writing to stderr when simply dodging stdout
-    logger.error(`\n Diff scan result: \n`)
+    // only .log goes to stdout
+    logger.info(`\n Diff scan result: \n`)
     logger.log(json)
-    logger.error(dashboardMessage)
+    logger.info(dashboardMessage)
   }
 }
 

--- a/src/commands/scan/stream-scan.mts
+++ b/src/commands/scan/stream-scan.mts
@@ -14,7 +14,7 @@ export async function streamScan(
   }
   const sockSdk = sockSdkResult.data
 
-  logger.error('Requesting data from API...')
+  logger.info('Requesting data from API...')
 
   // Note: this will write to stdout or target file. It's not a noop
   return await handleApiCall(

--- a/src/commands/threat-feed/cmd-threat-feed.test.mts
+++ b/src/commands/threat-feed/cmd-threat-feed.test.mts
@@ -139,9 +139,7 @@ describe('socket threat-feed', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(
-        `""`,
-      )
+      expect(stdout).toMatchInlineSnapshot(`""`)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------

--- a/src/commands/threat-feed/cmd-threat-feed.test.mts
+++ b/src/commands/threat-feed/cmd-threat-feed.test.mts
@@ -139,7 +139,9 @@ describe('socket threat-feed', async () => {
     'should report missing org name in v1',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(stdout).toMatchInlineSnapshot(
+        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+      )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
            _____         _       _        /---------------
@@ -148,8 +150,7 @@ describe('socket threat-feed', async () => {
           |_____|___|___|_,_|___|_|.dev   | Command: \`socket threat-feed\`, cwd: <redacted>
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
-        Missing the org slug and no --org flag set. Trying to auto-discover the org now...
-        Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
+        \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/threat-feed/cmd-threat-feed.test.mts
+++ b/src/commands/threat-feed/cmd-threat-feed.test.mts
@@ -140,7 +140,7 @@ describe('socket threat-feed', async () => {
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(entryPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
-        `"\\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag."`,
+        `""`,
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
         "
@@ -151,6 +151,7 @@ describe('socket threat-feed', async () => {
         \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
         \\x1b[39m
         \\x1b[33m\\u203c\\x1b[39m Missing the org slug and no --org flag set. Trying to auto-discover the org now...
+        \\x1b[34mi\\x1b[39m Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.
         \\x1b[31m\\xd7\\x1b[39m Skipping auto-discovery of org in dry-run mode
         \\x1b[31m\\xd7\\x1b[39m \\x1b[41m\\x1b[1m\\x1b[37m Input error: \\x1b[39m\\x1b[22m\\x1b[49m \\x1b[1mPlease review the input requirements and try again
 

--- a/src/commands/threat-feed/output-threat-feed.mts
+++ b/src/commands/threat-feed/output-threat-feed.mts
@@ -30,7 +30,7 @@ export async function outputThreatFeed(
   }
 
   if (!result.data?.results?.length) {
-    logger.error('Did not receive any data to display...')
+    logger.warn('Did not receive any data to display...')
     return
   }
 

--- a/src/instrument-with-sentry.mts
+++ b/src/instrument-with-sentry.mts
@@ -42,7 +42,7 @@ if (constants.ENV.INLINED_SOCKET_CLI_SENTRY_BUILD) {
   // Lazily access constants.ENV.SOCKET_CLI_DEBUG.
   if (constants.ENV.SOCKET_CLI_DEBUG) {
     Sentry.setTag('debugging', true)
-    logger.log('[DEBUG] Set up Sentry.')
+    logger.info('[DEBUG] Set up Sentry.')
   } else {
     Sentry.setTag('debugging', false)
   }
@@ -54,5 +54,5 @@ if (constants.ENV.INLINED_SOCKET_CLI_SENTRY_BUILD) {
 }
 // Lazily access constants.ENV.SOCKET_CLI_DEBUG.
 else if (constants.ENV.SOCKET_CLI_DEBUG) {
-  logger.log('[DEBUG] Sentry disabled explicitly.')
+  logger.info('[DEBUG] Sentry disabled explicitly.')
 }

--- a/src/utils/determine-org-slug.mts
+++ b/src/utils/determine-org-slug.mts
@@ -14,10 +14,10 @@ export async function determineOrgSlug(
   if (!orgSlug) {
     if (isTestingV1()) {
       // ask from server
-      logger.error(
+      logger.warn(
         'Missing the org slug and no --org flag set. Trying to auto-discover the org now...',
       )
-      logger.error(
+      logger.info(
         'Note: you can set the default org slug to prevent this issue. You can also override all that with the --org flag.',
       )
       if (dryRun) {

--- a/src/utils/serialize-result-json.mts
+++ b/src/utils/serialize-result-json.mts
@@ -32,7 +32,7 @@ export function serializeResultJson(data: CResult<unknown>): string {
     // This could be caused by circular references, which is an "us" problem
     const msg =
       'There was a problem converting the data set to JSON. Please try again without --json'
-    logger.error(msg)
+    logger.fail(msg)
     return (
       JSON.stringify({
         ok: false,


### PR DESCRIPTION
This updates a few lingering calls to logger.error to a more apt method like .success, .warn. or .info, now that those are all going to stderr.