### PR TITLE
Make manifest auto detect all cases and run any found

### DIFF
--- a/src/commands/manifest/cmd-manifest-auto.mts
+++ b/src/commands/manifest/cmd-manifest-auto.mts
@@ -1,7 +1,5 @@
 import path from 'node:path'
 
-import meow from 'meow'
-
 import { debugLog } from '@socketsecurity/registry/lib/debug'
 import { logger } from '@socketsecurity/registry/lib/logger'
 

--- a/src/commands/manifest/cmd-manifest-auto.mts
+++ b/src/commands/manifest/cmd-manifest-auto.mts
@@ -1,15 +1,17 @@
-import { existsSync } from 'node:fs'
 import path from 'node:path'
 
 import meow from 'meow'
 
+import { debugLog } from '@socketsecurity/registry/lib/debug'
 import { logger } from '@socketsecurity/registry/lib/logger'
 
-import { cmdManifestConda } from './cmd-manifest-conda.mts'
-import { cmdManifestGradle } from './cmd-manifest-gradle.mts'
-import { cmdManifestScala } from './cmd-manifest-scala.mts'
+import { convertGradleToMaven } from './convert_gradle_to_maven.mts'
+import { convertSbtToMaven } from './convert_sbt_to_maven.mts'
+import { detectManifestActions } from './detect-manifest-actions.mts'
+import { handleManifestConda } from './handle-manifest-conda.mts'
 import constants from '../../constants.mts'
 import { commonFlags } from '../../flags.mts'
+import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
 
@@ -32,7 +34,6 @@ const config: CliCommandConfig = {
       default: false,
       description: 'Enable debug output, may help when running into errors',
     },
-    // TODO: support output flags
   },
   help: (command, config) => `
     Usage
@@ -64,9 +65,10 @@ async function run(
     importMeta,
     parentName,
   })
-  const verbose = !!cli.flags['verbose']
-  const cwd = (cli.flags['cwd'] as string) ?? process.cwd()
-  // TODO: impl json/md
+  const { cwd: cwdFlag, json, markdown, verbose: verboseFlag } = cli.flags
+  const outputKind = getOutputKind(json, markdown) // TODO: impl json/md further
+  const cwd = String(cwdFlag || process.cwd())
+  const verbose = !!verboseFlag
 
   if (verbose) {
     logger.group('- ', parentName, config.commandName, ':')
@@ -77,83 +79,59 @@ async function run(
     logger.groupEnd()
   }
 
-  const subArgs = []
-  if (verbose) {
-    subArgs.push('--verbose')
-  }
+  // Both ways work (with and without `=`)
+  // const tmp = meow('', {argv: '--bin x --foo=y'.split(' '), allowUnknownFlags:true, importMeta})
+  // console.log('--->', tmp.input, tmp.flags);
 
-  const dir = cwd
-
-  if (existsSync(path.join(dir, 'build.sbt'))) {
-    logger.log('Detected a Scala sbt build, running default Scala generator...')
-    if (cwd) {
-      subArgs.push('--cwd', cwd)
-    }
-    subArgs.push(dir)
-    if (cli.flags['dryRun']) {
-      logger.log(DRY_RUN_BAILING_NOW)
-      return
-    }
-    await cmdManifestScala.run(subArgs, importMeta, { parentName })
-    return
-  }
-
-  if (existsSync(path.join(dir, 'gradlew'))) {
-    logger.log('Detected a gradle build, running default gradle generator...')
-    if (cwd) {
-      // This command takes the cwd as first arg.
-      subArgs.push(cwd)
-    }
-    if (cli.flags['dryRun']) {
-      logger.log(DRY_RUN_BAILING_NOW)
-      return
-    }
-    await cmdManifestGradle.run(subArgs, importMeta, { parentName })
-    return
-  }
-
-  const envyml = path.join(dir, 'environment.yml')
-  const hasEnvyml = existsSync(envyml)
-  const envyaml = path.join(dir, 'environment.yaml')
-  const hasEnvyaml = !hasEnvyml && existsSync(envyaml)
-  if (hasEnvyml || hasEnvyaml) {
-    logger.log(
-      'Detected an environment.yml file, running default Conda generator...',
-    )
-    // This command takes the TARGET as first arg.
-    subArgs.push(hasEnvyml ? envyml : hasEnvyaml ? envyaml : '')
-    if (cli.flags['dryRun']) {
-      logger.log(DRY_RUN_BAILING_NOW)
-      return
-    }
-    await cmdManifestConda.run(subArgs, importMeta, { parentName })
-    return
-  }
+  const result = await detectManifestActions(String(cwd))
+  debugLog(result)
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAILING_NOW)
     return
   }
 
-  // Show new help screen and exit.
-  meow(
-    `
-    $ ${parentName} ${config.commandName}
+  const found = Object.values(result).reduce(
+    (sum, now) => (now ? sum + 1 : sum),
+    0,
+  )
 
-    Unfortunately this script did not discover a supported language in the
-    current folder.
+  if (!found) {
+    logger.fail(
+      ' Was unable to discover any targets for which we can generate manifest files...',
+    )
+    logger.log('')
+    logger.log(
+      '- Make sure this script would work with your target build (see `socket manifest --help` for your target).',
+    )
+    logger.log(
+      '- Make sure to run it from the correct dir (use --cwd to target another dir)',
+    )
+    logger.log('- Make sure the necessary build tools are available (`PATH`)')
+    process.exitCode = 1
+    return
+  }
 
-    - Make sure this script would work with your target build
-    - Make sure to run it from the correct folder
-    - Make sure the necessary build tools are available (\`PATH\`)
+  if (result.sbt) {
+    logger.log('Detected a Scala sbt build, generating pom files with sbt...')
+    await convertSbtToMaven(cwd, 'sbt', './socket.sbt.pom.xml', verbose, [])
+  }
 
-    If that doesn't work, see \`${parentName} <lang> --help\` for config details for
-    your target language.
-  `,
-    {
-      argv: [],
-      description: config.description,
-      importMeta,
-    },
-  ).showHelp()
+  if (result.gradle) {
+    logger.log(
+      'Detected a gradle build (Gradle, Kotlin, Scala), running default gradle generator...',
+    )
+    await convertGradleToMaven(cwd, path.join(cwd, 'gradlew'), cwd, verbose, [])
+  }
+
+  if (result.conda) {
+    logger.log(
+      'Detected an environment.yml file, running default Conda generator...',
+    )
+    await handleManifestConda(cwd, '', outputKind, cwd, verbose)
+  }
+
+  logger.success(
+    `Finished. Should have attempted to generate manifest files for ${found} targets.`,
+  )
 }

--- a/src/commands/manifest/cmd-manifest-auto.mts
+++ b/src/commands/manifest/cmd-manifest-auto.mts
@@ -77,10 +77,6 @@ async function run(
     logger.groupEnd()
   }
 
-  // Both ways work (with and without `=`)
-  // const tmp = meow('', {argv: '--bin x --foo=y'.split(' '), allowUnknownFlags:true, importMeta})
-  // console.log('--->', tmp.input, tmp.flags);
-
   const result = await detectManifestActions(String(cwd))
   debugLog(result)
 

--- a/src/commands/manifest/detect-manifest-actions.mts
+++ b/src/commands/manifest/detect-manifest-actions.mts
@@ -7,12 +7,13 @@ import path from 'node:path'
 import { debugLog } from '@socketsecurity/registry/lib/debug'
 
 export async function detectManifestActions(cwd = process.cwd()): Promise<{
+  cdxgen: boolean
   conda: boolean
   gradle: boolean
   sbt: boolean
 }> {
   const output = {
-    cdxgen: false,
+    cdxgen: false, // TODO
     conda: false,
     gradle: false,
     sbt: false,

--- a/src/commands/manifest/detect-manifest-actions.mts
+++ b/src/commands/manifest/detect-manifest-actions.mts
@@ -1,0 +1,44 @@
+// The point here is to attempt to detect the various supported manifest files
+// the CLI can generate. This would be environments that we can't do server side
+
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+
+import { debugLog } from '@socketsecurity/registry/lib/debug'
+
+export async function detectManifestActions(cwd = process.cwd()): Promise<{
+  conda: boolean
+  gradle: boolean
+  sbt: boolean
+}> {
+  const output = {
+    cdxgen: false,
+    conda: false,
+    gradle: false,
+    sbt: false,
+  }
+
+  if (existsSync(path.join(cwd, 'build.sbt'))) {
+    debugLog('Detected a Scala sbt build, running default Scala generator...')
+
+    output.sbt = true
+  }
+
+  if (existsSync(path.join(cwd, 'gradlew'))) {
+    debugLog('Detected a gradle build, running default gradle generator...')
+    output.gradle = true
+  }
+
+  const envyml = path.join(cwd, 'environment.yml')
+  const hasEnvyml = existsSync(envyml)
+  const envyaml = path.join(cwd, 'environment.yaml')
+  const hasEnvyaml = !hasEnvyml && existsSync(envyaml)
+  if (hasEnvyml || hasEnvyaml) {
+    debugLog(
+      'Detected an environment.yml file, running default Conda generator...',
+    )
+    output.conda = true
+  }
+
+  return output
+}

--- a/src/commands/scan/cmd-scan-create.mts
+++ b/src/commands/scan/cmd-scan-create.mts
@@ -297,13 +297,6 @@ async function run(
     },
     {
       nook: true,
-      test: !pendingHead || !tmp,
-      message: 'Can not use --pendingHead and --tmp at the same time',
-      pass: 'ok',
-      fail: 'remove at least one flag',
-    },
-    {
-      nook: true,
       test: !pendingHead || !!branchName,
       message: 'When --pendingHead is set, --branch is mandatory',
       pass: 'ok',


### PR DESCRIPTION
This will make `socket manifest auto` first detect all targets and then run any found, rather than only the first one.

This detect script will also be shared with `socket scan create`, later.