### PR TITLE
Add --all to repos list, cleanup pagination ux

### DIFF
--- a/src/commands/repos/cmd-repos-list.test.mts
+++ b/src/commands/repos/cmd-repos-list.test.mts
@@ -28,6 +28,7 @@ describe('socket repos list', async () => {
             - Permissions: repo:list
 
           Options
+            --all             By default view shows the last n repos. This flag allows you to fetch the entire list. Will ignore --page and --perPage.
             --direction       Direction option
             --help            Print this help
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.

--- a/src/commands/repos/fetch-list-all-repos.mts
+++ b/src/commands/repos/fetch-list-all-repos.mts
@@ -1,0 +1,58 @@
+import { handleApiCall } from '../../utils/api.mts'
+import { setupSdk } from '../../utils/sdk.mts'
+
+import type { CResult } from '../../types.mts'
+import type { SocketSdkReturnType } from '@socketsecurity/sdk'
+
+export async function fetchListAllRepos({
+  direction,
+  orgSlug,
+  sort,
+}: {
+  direction: string
+  orgSlug: string
+  sort: string
+}): Promise<CResult<SocketSdkReturnType<'getOrgRepoList'>['data']>> {
+  const sockSdkResult = await setupSdk()
+  if (!sockSdkResult.ok) {
+    return sockSdkResult
+  }
+  const sockSdk = sockSdkResult.data
+
+  const rows: SocketSdkReturnType<'getOrgRepoList'>['data']['results'] = []
+  let protection = 0
+  let nextPage = 0
+  while (nextPage >= 0) {
+    if (++protection > 100) {
+      return {
+        ok: false,
+        message: 'Infinite loop detected',
+        cause: `Either there are over 100 pages of results or the fetch has run into an infinite loop. Breaking it off now. nextPage=${nextPage}`,
+      }
+    }
+    // eslint-disable-next-line no-await-in-loop
+    const result = await handleApiCall(
+      sockSdk.getOrgRepoList(orgSlug, {
+        sort,
+        direction,
+        per_page: String(100), // max
+        page: String(nextPage),
+      }),
+      'list of repositories',
+    )
+    if (!result.ok) {
+      return result
+    }
+
+    result.data.results.forEach(row => rows.push(row))
+    nextPage = result.data.nextPage ?? -1
+  }
+
+  return {
+    ok: true,
+    data: {
+      results: rows,
+      nextPage: null,
+    },
+  }
+}

--- a/src/commands/repos/handle-list-repos.mts
+++ b/src/commands/repos/handle-list-repos.mts
@@ -1,9 +1,11 @@
+import { fetchListAllRepos } from './fetch-list-all-repos.mts'
 import { fetchListRepos } from './fetch-list-repos.mts'
 import { outputListRepos } from './output-list-repos.mts'
 
 import type { OutputKind } from '../../types.mts'
 
 export async function handleListRepos({
+  all,
   direction,
   orgSlug,
   outputKind,
@@ -11,20 +13,40 @@ export async function handleListRepos({
   per_page,
   sort,
 }: {
-  direction: string
+  all: boolean
+  direction: 'asc' | 'desc'
   orgSlug: string
   outputKind: OutputKind
   page: number
   per_page: number
   sort: string
 }): Promise<void> {
-  const data = await fetchListRepos({
-    direction,
-    orgSlug,
-    page,
-    per_page,
-    sort,
-  })
+  if (all) {
+    const data = await fetchListAllRepos({ direction, orgSlug, sort })
 
-  await outputListRepos(data, outputKind)
+    await outputListRepos(data, outputKind, 0, 0, sort, Infinity, direction)
+  } else {
+    const data = await fetchListRepos({
+      direction,
+      orgSlug,
+      page,
+      per_page,
+      sort,
+    })
+
+    if (!data.ok) {
+      await outputListRepos(data, outputKind, 0, 0, '', 0, direction)
+    } else {
+      // Note: nextPage defaults to 0, is null when there's no next page
+      await outputListRepos(
+        data,
+        outputKind,
+        page,
+        data.data.nextPage,
+        sort,
+        per_page,
+        direction,
+      )
+    }
+  }
 }


### PR DESCRIPTION
We never really looked into this but all these list commands have a pretty bad UX around pagination. In particular being notified whether there is more left to be fetched, or an ability to just batch-fetch them all. So this PR fixes that for the `socket repos list` command. Should probably do this for all the others too (or at least where it makes sense, not for something like scans which may have any number).

Now you can do `socket repos list --all` to fetch all repos (up to 10k results).

The result will also tell you more about the query, page state, and whether there is more data left to be fetched. It will also give you a hint on how to fetch the next page (we should do that more often).