### PR TITLE
Implement CResult for the detect func, move types to the top

### DIFF
--- a/src/commands/fix/run-fix.mts
+++ b/src/commands/fix/run-fix.mts
@@ -28,12 +28,15 @@ export async function runFix({
   test: boolean
   testScript: string
 }): Promise<CResult<unknown>> {
-  // TODO: make detectAndValidatePackageEnvironment return a CResult<pkgEnvDetails> and propagate it
-  const pkgEnvDetails = await detectAndValidatePackageEnvironment(cwd, {
+  const result = await detectAndValidatePackageEnvironment(cwd, {
     cmdName: CMD_NAME,
     logger,
   })
 
+  if (!result.ok) {
+    return result
+  }
+  const pkgEnvDetails = result.data
   if (!pkgEnvDetails) {
     return {
       ok: false,

--- a/src/commands/optimize/apply-optimization.mts
+++ b/src/commands/optimize/apply-optimization.mts
@@ -23,13 +23,19 @@ export async function applyOptimization(
   pin: boolean,
   prod: boolean,
 ) {
-  const pkgEnvDetails = await detectAndValidatePackageEnvironment(cwd, {
+  const result = await detectAndValidatePackageEnvironment(cwd, {
     cmdName: CMD_NAME,
     logger,
     prod,
   })
 
+  if (!result.ok) {
+    return result
+  }
+
+  const pkgEnvDetails = result.data
   if (!pkgEnvDetails) {
+    // TODO: probably not necessary
     return
   }
 


### PR DESCRIPTION
Implement CResult for the `detectAndValidatePackageEnvironment` function, which is the last major piece of the `socket fix` command.

After this there are only semantic choices to make whether an error should bubble up and abort the process or not. Leaving that to you @jdalton 

I've also refactored the types and constants in that file, moved them to the top. At this point it might be worthwhile to abstract them into their own file. But that too I'll leave up to you.