### PR TITLE
Add `socket scan setup` for flag defaults

### DIFF
--- a/src/commands/manifest/setup-manifest-config.mts
+++ b/src/commands/manifest/setup-manifest-config.mts
@@ -365,13 +365,11 @@ async function askForStdout(
       {
         name: 'no',
         value: 'no',
-        selected: defaultValue === false,
         description: 'Write output to a file, not stdout',
       },
       {
         name: 'yes',
         value: 'yes',
-        selected: defaultValue === true,
         description: 'Print in stdout (this will supersede --out)',
       },
       {
@@ -394,13 +392,11 @@ async function askForEnabled(
       {
         name: 'Enable',
         value: true,
-        selected: defaultValue === true,
         description: 'Generate manifest files for this language when detected',
       },
       {
         name: 'Disable',
         value: false,
-        selected: defaultValue === false,
         description:
           'Do not generate manifest files for this language when detected, unless explicitly asking for it',
       },
@@ -461,13 +457,11 @@ async function askForVerboseFlag(
       {
         name: 'no',
         value: 'no',
-        selected: current === false,
         description: 'Do not run this manifest in verbose mode',
       },
       {
         name: 'yes',
         value: 'yes',
-        selected: current === true,
         description: 'Run this manifest in verbose mode',
       },
       {

--- a/src/commands/scan/cmd-scan-create.mts
+++ b/src/commands/scan/cmd-scan-create.mts
@@ -135,7 +135,7 @@ const config: CliCommandConfig = {
     - Multiple targets can be specified
     - If a target is a file, only that file is checked
     - If it is a dir, the dir is scanned for any supported manifest files
-    - Dirs MUST be withing the current dir (cwd), you can use --cwd to change it
+    - Dirs MUST be within the current dir (cwd), you can use --cwd to change it
     - Supports globbing such as "**/package.json", "**/requirements.txt", etc.
     - Ignores any file specified in your project's ".gitignore"
     - Also a sensible set of default ignores from the "ignore-by-default" module

--- a/src/commands/scan/cmd-scan-create.mts
+++ b/src/commands/scan/cmd-scan-create.mts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleCreateNewScan } from './handle-create-new-scan.mts'
@@ -28,14 +30,12 @@ const config: CliCommandConfig = {
     ...outputFlags,
     autoManifest: {
       type: 'boolean',
-      default: false,
       description:
         'Run `socket manifest auto` before collecting manifest files? This would be necessary for languages like Scala, Gradle, and Kotlin, See `socket manifest auto --help`.',
     },
     branch: {
       type: 'string',
       shortFlag: 'b',
-      default: 'socket-default-branch',
       description: 'Branch name',
     },
     commitMessage: {
@@ -91,12 +91,10 @@ const config: CliCommandConfig = {
     repo: {
       type: 'string',
       shortFlag: 'r',
-      default: 'socket-default-repository',
       description: 'Repository name',
     },
     report: {
       type: 'boolean',
-      default: false,
       description:
         'Wait for the scan creation to complete, then basically run `socket scan report` on it',
     },
@@ -118,25 +116,29 @@ const config: CliCommandConfig = {
   // TODO: your project's "socket.yml" file's "projectIgnorePaths"
   help: (command, config) => `
     Usage
-      $ ${command} [...options]${isTestingV1() ? '' : ' <org>'} <TARGET> [TARGET...]
+      $ ${command} [options]${isTestingV1() ? '' : ' <org>'} [TARGET...]
 
     API Token Requirements
       - Quota: 1 unit
       - Permissions: full-scans:create
 
-    Uploads the specified "package.json" and lock files for JavaScript, Python,
-    Go, Scala, Gradle, and Kotlin dependency manifests.
+    Options
+      ${getFlagListOutput(config.flags, 6)}
+
+    Uploads the specified dependency manifest files for Go, Gradle, JavaScript,
+    Kotlin, Python, and Scala. Files like "package.json" and "requirements.txt".
     If any folder is specified, the ones found in there recursively are uploaded.
 
-    Supports globbing such as "**/package.json", "**/requirements.txt", etc.
+    Details on TARGET:
 
-    Ignores any file specified in your project's ".gitignore" and also has a
-    sensible set of default ignores from the "ignore-by-default" module.
-
-    TARGET should be a FILE or DIR that _must_ be inside the CWD.
-
-    When a FILE is given only that FILE is targeted. Otherwise any eligible
-    files in the given DIR will be considered.
+    - Defaults to the current dir (cwd) if none given
+    - Multiple targets can be specified
+    - If a target is a file, only that file is checked
+    - If it is a dir, the dir is scanned for any supported manifest files
+    - Dirs MUST be withing the current dir (cwd), you can use --cwd to change it
+    - Supports globbing such as "**/package.json", "**/requirements.txt", etc.
+    - Ignores any file specified in your project's ".gitignore"
+    - Also a sensible set of default ignores from the "ignore-by-default" module
 
     The --repo and --branch flags tell Socket to associate this Scan with that
     repo/branch. The names will show up on your dashboard on the Socket website.
@@ -151,11 +153,10 @@ const config: CliCommandConfig = {
     this by using --no-setAsAlertsPage. This flag is ignored for any branch that
     is not designated as the "default branch". It is disabled when using --tmp.
 
-    Options
-      ${getFlagListOutput(config.flags, 6)}
+    You can use \`socket scan setup\` to configure certain repo flag defaults.
 
     Examples
-      $ ${command}${isTestingV1() ? '' : ' FakeOrg'} .
+      $ ${command}${isTestingV1() ? '' : ' FakeOrg'}
       $ ${command} --repo=test-repo --branch=main${isTestingV1() ? '' : ' FakeOrg'} ./package.json
   `,
 }
@@ -179,8 +180,6 @@ async function run(
   })
 
   const {
-    autoManifest = false,
-    branch: branchName = 'socket-default-branch',
     commitHash,
     commitMessage,
     committers,
@@ -193,13 +192,9 @@ async function run(
     org: orgFlag,
     pullRequest,
     readOnly,
-    repo: repoName = 'socket-default-repository',
-    report,
     setAsAlertsPage: pendingHeadFlag,
     tmp,
   } = cli.flags as {
-    autoManifest: boolean
-    branch: string
     cwd: string
     commitHash: string
     commitMessage: string
@@ -212,10 +207,19 @@ async function run(
     org: string
     pullRequest: number
     readOnly: boolean
-    repo: string
-    report: boolean
     setAsAlertsPage: boolean
     tmp: boolean
+  }
+  let {
+    autoManifest,
+    branch: branchName,
+    repo: repoName,
+    report,
+  } = cli.flags as {
+    autoManifest?: boolean
+    branch: string
+    repo: string
+    report?: boolean
   }
   const outputKind = getOutputKind(json, markdown)
 
@@ -232,12 +236,53 @@ async function run(
     defaultOrgSlug = ''
   }
 
-  let targets = cli.input.slice(isTestingV1() || defaultOrgSlug ? 0 : 1)
+  // Accept zero or more paths. Default to cwd() if none given.
+  let targets =
+    cli.input.slice(isTestingV1() || defaultOrgSlug ? 0 : 1) || process.cwd()
 
   const cwd =
     cwdOverride && cwdOverride !== 'process.cwd()'
-      ? String(cwdOverride)
+      ? path.resolve(process.cwd(), String(cwdOverride))
       : process.cwd()
+
+  const socketJson = await readOrDefaultSocketJson(cwd)
+
+  // Note: This needs meow booleanDefault=undefined
+  if (typeof autoManifest !== 'boolean') {
+    if (socketJson.defaults?.scan?.create?.autoManifest !== undefined) {
+      autoManifest = socketJson.defaults.scan.create.autoManifest
+      logger.info(
+        'Using default --autoManifest from socket.json:',
+        autoManifest,
+      )
+    } else {
+      autoManifest = false
+    }
+  }
+  if (!branchName) {
+    if (socketJson.defaults?.scan?.create?.branch) {
+      branchName = socketJson.defaults.scan.create.branch
+      logger.info('Using default --branch from socket.json:', branchName)
+    } else {
+      branchName = 'socket-default-branch'
+    }
+  }
+  if (!repoName) {
+    if (socketJson.defaults?.scan?.create?.repo) {
+      repoName = socketJson.defaults.scan.create.repo
+      logger.info('Using default --repo from socket.json:', repoName)
+    } else {
+      repoName = 'socket-default-repository'
+    }
+  }
+  if (typeof report !== 'boolean') {
+    if (socketJson.defaults?.scan?.create?.report !== undefined) {
+      report = socketJson.defaults.scan.create.report
+      logger.info('Using default --report from socket.json:', report)
+    } else {
+      report = false
+    }
+  }
 
   // We're going to need an api token to suggest data because those suggestions
   // must come from data we already know. Don't error on missing api token yet.
@@ -266,8 +311,6 @@ async function run(
       updatedInput = true
     }
   }
-
-  const socketJson = await readOrDefaultSocketJson(cwd)
 
   const detected = await detectManifestActions(socketJson, cwd)
   if (detected.count > 0 && !autoManifest) {

--- a/src/commands/scan/cmd-scan-create.test.mts
+++ b/src/commands/scan/cmd-scan-create.test.mts
@@ -54,7 +54,7 @@ describe('socket scan create', async () => {
           - Multiple targets can be specified
           - If a target is a file, only that file is checked
           - If it is a dir, the dir is scanned for any supported manifest files
-          - Dirs MUST be withing the current dir (cwd), you can use --cwd to change it
+          - Dirs MUST be within the current dir (cwd), you can use --cwd to change it
           - Supports globbing such as "**/package.json", "**/requirements.txt", etc.
           - Ignores any file specified in your project's ".gitignore"
           - Also a sensible set of default ignores from the "ignore-by-default" module

--- a/src/commands/scan/cmd-scan-create.test.mts
+++ b/src/commands/scan/cmd-scan-create.test.mts
@@ -18,38 +18,11 @@ describe('socket scan create', async () => {
         "Create a scan
 
           Usage
-            $ socket scan create [...options] <org> <TARGET> [TARGET...]
+            $ socket scan create [options] <org> [TARGET...]
 
           API Token Requirements
             - Quota: 1 unit
             - Permissions: full-scans:create
-
-          Uploads the specified "package.json" and lock files for JavaScript, Python,
-          Go, Scala, Gradle, and Kotlin dependency manifests.
-          If any folder is specified, the ones found in there recursively are uploaded.
-
-          Supports globbing such as "**/package.json", "**/requirements.txt", etc.
-
-          Ignores any file specified in your project's ".gitignore" and also has a
-          sensible set of default ignores from the "ignore-by-default" module.
-
-          TARGET should be a FILE or DIR that _must_ be inside the CWD.
-
-          When a FILE is given only that FILE is targeted. Otherwise any eligible
-          files in the given DIR will be considered.
-
-          The --repo and --branch flags tell Socket to associate this Scan with that
-          repo/branch. The names will show up on your dashboard on the Socket website.
-
-          Note: for a first run you probably want to set --defaultBranch to indicate
-                the default branch name, like "main" or "master".
-
-          The "alerts page" (https://socket.dev/dashboard/org/YOURORG/alerts) will show
-          the results from the last scan designated as the "pending head" on the branch
-          configured on Socket to be the "default branch". When creating a scan the
-          --setAsAlertsPage flag will default to true to update this. You can prevent
-          this by using --no-setAsAlertsPage. This flag is ignored for any branch that
-          is not designated as the "default branch". It is disabled when using --tmp.
 
           Options
             --autoManifest    Run \`socket manifest auto\` before collecting manifest files? This would be necessary for languages like Scala, Gradle, and Kotlin, See \`socket manifest auto --help\`.
@@ -71,8 +44,38 @@ describe('socket scan create', async () => {
             --setAsAlertsPage When true and if this is the "default branch" then this Scan will be the one reflected on your alerts page. See help for details. Defaults to true.
             --tmp             Set the visibility (true/false) of the scan in your dashboard.
 
+          Uploads the specified dependency manifest files for Go, Gradle, JavaScript,
+          Kotlin, Python, and Scala. Files like "package.json" and "requirements.txt".
+          If any folder is specified, the ones found in there recursively are uploaded.
+
+          Details on TARGET:
+
+          - Defaults to the current dir (cwd) if none given
+          - Multiple targets can be specified
+          - If a target is a file, only that file is checked
+          - If it is a dir, the dir is scanned for any supported manifest files
+          - Dirs MUST be withing the current dir (cwd), you can use --cwd to change it
+          - Supports globbing such as "**/package.json", "**/requirements.txt", etc.
+          - Ignores any file specified in your project's ".gitignore"
+          - Also a sensible set of default ignores from the "ignore-by-default" module
+
+          The --repo and --branch flags tell Socket to associate this Scan with that
+          repo/branch. The names will show up on your dashboard on the Socket website.
+
+          Note: for a first run you probably want to set --defaultBranch to indicate
+                the default branch name, like "main" or "master".
+
+          The "alerts page" (https://socket.dev/dashboard/org/YOURORG/alerts) will show
+          the results from the last scan designated as the "pending head" on the branch
+          configured on Socket to be the "default branch". When creating a scan the
+          --setAsAlertsPage flag will default to true to update this. You can prevent
+          this by using --no-setAsAlertsPage. This flag is ignored for any branch that
+          is not designated as the "default branch". It is disabled when using --tmp.
+
+          You can use \`socket scan setup\` to configure certain repo flag defaults.
+
           Examples
-            $ socket scan create FakeOrg .
+            $ socket scan create FakeOrg
             $ socket scan create --repo=test-repo --branch=main FakeOrg ./package.json"
       `)
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`

--- a/src/commands/scan/cmd-scan-github.mts
+++ b/src/commands/scan/cmd-scan-github.mts
@@ -256,6 +256,6 @@ async function run(
     orgSlug,
     orgGithub,
     outputKind,
-    repos: repos,
+    repos,
   })
 }

--- a/src/commands/scan/cmd-scan-github.mts
+++ b/src/commands/scan/cmd-scan-github.mts
@@ -167,9 +167,7 @@ async function run(
     }
   }
   if (!orgGithub) {
-    if (orgGithub) {
-      orgSlug = orgGithub
-    } else if (socketJson.defaults?.scan?.github?.orgGithub !== undefined) {
+    if (socketJson.defaults?.scan?.github?.orgGithub !== undefined) {
       orgGithub = socketJson.defaults.scan.github.orgGithub
     } else {
       // Default to Socket org slug. Often that's fine. Vanity and all that.

--- a/src/commands/scan/cmd-scan-github.test.mts
+++ b/src/commands/scan/cmd-scan-github.test.mts
@@ -19,7 +19,7 @@ describe('socket scan github', async () => {
         "Create a scan for given GitHub repo
 
           Usage
-            $ socket scan github
+            $ socket scan github [options] [CWD=.]
 
           API Token Requirements
             - Quota: 1 unit
@@ -35,6 +35,8 @@ describe('socket scan github', async () => {
           requires local access to the repo while this command runs entirely through the
           GitHub for file access.
 
+          You can use \`socket scan setup\` to configure certain repo flag defaults.
+
           Options
             --all             Apply for all known repos reported by the Socket API. Supersedes \`repos\`.
             --githubApiUrl    Base URL of the GitHub API (default: https://api.github.com)
@@ -48,7 +50,8 @@ describe('socket scan github', async () => {
             --repos           List of repos to target in a comma-separated format (e.g., repo1,repo2). If not specified, the script will pull the list from Socket and ask you to pick one. Use --all to use them all.
 
           Examples
-            $ socket scan github"
+            $ socket scan github
+            $ socket scan github ./proj"
       `,
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`

--- a/src/commands/scan/cmd-scan-setup.mts
+++ b/src/commands/scan/cmd-scan-setup.mts
@@ -1,0 +1,82 @@
+import path from 'node:path'
+
+import { logger } from '@socketsecurity/registry/lib/logger'
+
+import { handleScanConfig } from './handle-scan-config.mts'
+import constants from '../../constants.mts'
+import { commonFlags } from '../../flags.mts'
+import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
+import { getFlagListOutput } from '../../utils/output-formatting.mts'
+
+import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
+
+const { DRY_RUN_BAILING_NOW } = constants
+
+const config: CliCommandConfig = {
+  commandName: 'setup',
+  description:
+    'Start interactive configurator to customize default flag values for `socket scan` in this dir',
+  hidden: false,
+  flags: {
+    ...commonFlags,
+    defaultOnReadError: {
+      type: 'boolean',
+      description:
+        'If reading the socket.json fails, just use a default config? Warning: This might override the existing json file!',
+    },
+  },
+  help: (command, config) => `
+    Usage
+      $ ${command} [options] [CWD=.]
+
+    Options
+      ${getFlagListOutput(config.flags, 6)}
+
+    Interactive configurator to create a local json file in the target directory
+    that helps to set flag defaults for \`socket scan create\`.
+
+    This helps to configure the (Socket reported) repo and branch nanes, as well
+    as which branch name is the "default branch" (main, master, etc). This way
+    you don't have to specify these flags when creating a scan in this dir.
+
+    This generated configuration file will only be used locally by the CLI. You
+    can commit it to the repo (useful for collaboration) or choose to add it to
+    your .gitignore all the same. Only this CLI will use it.
+
+    Examples
+
+      $ ${command}
+      $ ${command} ./proj
+  `,
+}
+
+export const cmdScanSetup = {
+  description: config.description,
+  hidden: config.hidden,
+  run,
+}
+
+async function run(
+  argv: string[] | readonly string[],
+  importMeta: ImportMeta,
+  { parentName }: { parentName: string },
+): Promise<void> {
+  const cli = meowOrExit({
+    argv,
+    config,
+    importMeta,
+    parentName,
+  })
+  const { defaultOnReadError = false } = cli.flags
+  let [cwd = '.'] = cli.input
+  // Note: path.resolve vs .join:
+  // If given path is absolute then cwd should not affect it.
+  cwd = path.resolve(process.cwd(), cwd)
+
+  if (cli.flags['dryRun']) {
+    logger.log(DRY_RUN_BAILING_NOW)
+    return
+  }
+
+  await handleScanConfig(cwd, Boolean(defaultOnReadError))
+}

--- a/src/commands/scan/cmd-scan-setup.mts
+++ b/src/commands/scan/cmd-scan-setup.mts
@@ -35,7 +35,7 @@ const config: CliCommandConfig = {
     Interactive configurator to create a local json file in the target directory
     that helps to set flag defaults for \`socket scan create\`.
 
-    This helps to configure the (Socket reported) repo and branch nanes, as well
+    This helps to configure the (Socket reported) repo and branch names, as well
     as which branch name is the "default branch" (main, master, etc). This way
     you don't have to specify these flags when creating a scan in this dir.
 

--- a/src/commands/scan/cmd-scan-setup.test.mts
+++ b/src/commands/scan/cmd-scan-setup.test.mts
@@ -1,0 +1,85 @@
+import path from 'node:path'
+
+import { describe, expect } from 'vitest'
+
+import constants from '../../../src/constants.mts'
+import { cmdit, invokeNpm } from '../../../test/utils.mts'
+
+describe('socket scan setup', async () => {
+  // Lazily access constants.binCliPath.
+  const { binCliPath } = constants
+
+  cmdit(
+    ['scan', 'setup', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(binCliPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
+        "Start interactive configurator to customize default flag values for \`socket scan\` in this dir
+
+          Usage
+            $ socket scan setup [options] [CWD=.]
+
+          Options
+            --defaultOnReadErrorIf reading the socket.json fails, just use a default config? Warning: This might override the existing json file!
+            --help            Print this help
+
+          Interactive configurator to create a local json file in the target directory
+          that helps to set flag defaults for \`socket scan create\`.
+
+          This helps to configure the (Socket reported) repo and branch nanes, as well
+          as which branch name is the "default branch" (main, master, etc). This way
+          you don't have to specify these flags when creating a scan in this dir.
+
+          This generated configuration file will only be used locally by the CLI. You
+          can commit it to the repo (useful for collaboration) or choose to add it to
+          your .gitignore all the same. Only this CLI will use it.
+
+          Examples
+
+            $ socket scan setup
+            $ socket scan setup ./proj"
+      `,
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan setup\`, cwd: <redacted>"
+      `)
+
+      expect(code, 'explicit help should exit with code 0').toBe(0)
+      expect(stderr, 'banner includes base command').toContain(
+        '`socket scan setup`',
+      )
+    },
+  )
+
+  cmdit(
+    [
+      'scan',
+      'setup',
+      'fakeorg',
+      'scanidee',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}',
+    ],
+    'should require args with just dry-run',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(binCliPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket scan setup\`, cwd: <redacted>"
+      `)
+
+      expect(code, 'dry-run should exit with code 0 if input ok').toBe(0)
+    },
+  )
+})

--- a/src/commands/scan/cmd-scan-setup.test.mts
+++ b/src/commands/scan/cmd-scan-setup.test.mts
@@ -28,7 +28,7 @@ describe('socket scan setup', async () => {
           Interactive configurator to create a local json file in the target directory
           that helps to set flag defaults for \`socket scan create\`.
 
-          This helps to configure the (Socket reported) repo and branch nanes, as well
+          This helps to configure the (Socket reported) repo and branch names, as well
           as which branch name is the "default branch" (main, master, etc). This way
           you don't have to specify these flags when creating a scan in this dir.
 

--- a/src/commands/scan/cmd-scan.mts
+++ b/src/commands/scan/cmd-scan.mts
@@ -5,6 +5,7 @@ import { cmdScanGithub } from './cmd-scan-github.mts'
 import { cmdScanList } from './cmd-scan-list.mts'
 import { cmdScanMetadata } from './cmd-scan-metadata.mts'
 import { cmdScanReport } from './cmd-scan-report.mts'
+import { cmdScanSetup } from './cmd-scan-setup.mts'
 import { cmdScanView } from './cmd-scan-view.mts'
 import { meowWithSubcommands } from '../../utils/meow-with-subcommands.mts'
 
@@ -24,6 +25,7 @@ export const cmdScan: CliSubcommand = {
         list: cmdScanList,
         metadata: cmdScanMetadata,
         report: cmdScanReport,
+        setup: cmdScanSetup,
         view: cmdScanView,
       },
       {

--- a/src/commands/scan/cmd-scan.test.mts
+++ b/src/commands/scan/cmd-scan.test.mts
@@ -28,6 +28,7 @@ describe('socket scan', async () => {
             list              List the scans for an organization
             metadata          Get a scan's metadata
             report            Check whether a scan result passes the organizational policies (security, license)
+            setup             Start interactive configurator to customize default flag values for \`socket scan\` in this dir
             view              View the raw results of a scan
 
           Options

--- a/src/commands/scan/handle-scan-config.mts
+++ b/src/commands/scan/handle-scan-config.mts
@@ -1,0 +1,11 @@
+import { outputScanConfigResult } from './output-scan-config-result.mts'
+import { setupScanConfig } from './setup-scan-config.mts'
+
+export async function handleScanConfig(
+  cwd: string,
+  defaultOnReadError = false,
+) {
+  const result = await setupScanConfig(cwd, defaultOnReadError)
+
+  await outputScanConfigResult(result)
+}

--- a/src/commands/scan/output-scan-config-result.mts
+++ b/src/commands/scan/output-scan-config-result.mts
@@ -1,0 +1,20 @@
+import { logger } from '@socketsecurity/registry/lib/logger'
+
+import { failMsgWithBadge } from '../../utils/fail-msg-with-badge.mts'
+
+import type { CResult } from '../../types.mts'
+
+export async function outputScanConfigResult(result: CResult<unknown>) {
+  if (!result.ok) {
+    process.exitCode = result.code ?? 1
+  }
+
+  if (!result.ok) {
+    logger.fail(failMsgWithBadge(result.message, result.cause))
+    return
+  }
+
+  logger.log('')
+  logger.log('Finished')
+  logger.log('')
+}

--- a/src/commands/scan/setup-scan-config.mts
+++ b/src/commands/scan/setup-scan-config.mts
@@ -235,7 +235,7 @@ async function configureScan(
   } else if (alwaysReport === 'no') {
     config.report = false
   } else {
-    delete alwaysReport.defaults.scan.report
+    delete config.report
   }
 
   return notCanceled()
@@ -312,9 +312,9 @@ async function configureGithub(
     defaultGithubApiUrl.trim() &&
     defaultGithubApiUrl.trim() !== 'https://api.github.com'
   ) {
-    config.repos = defaultGithubApiUrl.trim()
+    config.githubApiUrl = defaultGithubApiUrl.trim()
   } else {
-    delete config.repos
+    delete config.githubApiUrl
   }
 
   const defaultOrgGithub = await input({
@@ -328,9 +328,9 @@ async function configureGithub(
     return canceledByUser()
   }
   if (defaultOrgGithub.trim()) {
-    config.repos = defaultOrgGithub.trim()
+    config.orgGithub = defaultOrgGithub.trim()
   } else {
-    delete config.repos
+    delete config.orgGithub
   }
 
   return notCanceled()

--- a/src/utils/meow-with-subcommands.mts
+++ b/src/utils/meow-with-subcommands.mts
@@ -117,6 +117,7 @@ export async function meowWithSubcommands(
     flags,
     // Do not strictly check for flags here.
     allowUnknownFlags: true,
+    booleanDefault: undefined, // We want to detect whether a bool flag is given at all.
     // We will emit help when we're ready
     // Plus, if we allow this then meow() can just exit here.
     autoHelp: false,
@@ -226,6 +227,7 @@ export async function meowWithSubcommands(
       flags,
       // Do not strictly check for flags here.
       allowUnknownFlags: true,
+      booleanDefault: undefined, // We want to detect whether a bool flag is given at all.
       // We will emit help when we're ready
       // Plus, if we allow this then meow() can just exit here.
       autoHelp: false,
@@ -274,6 +276,7 @@ export function meowOrExit({
     importMeta,
     flags: config.flags,
     allowUnknownFlags: true, // meow will exit(1) before printing the banner
+    booleanDefault: undefined, // We want to detect whether a bool flag is given at all.
     autoHelp: false, // meow will exit(0) before printing the banner
   })
 

--- a/src/utils/socketjson.mts
+++ b/src/utils/socketjson.mts
@@ -41,6 +41,20 @@ export interface SocketJson {
         verbose?: boolean
       }
     }
+    scan?: {
+      create?: {
+        autoManifest?: boolean
+        repo?: string
+        report?: boolean
+        branch?: string
+      }
+      github?: {
+        all?: boolean
+        githubApiUrl?: string
+        orgGithub?: string
+        repos?: string
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This adds a `socket scan setup` which allows you to configure a few defaults for flags to `socket scan create` and `socket scan github`.

Also

- Updates the manifest side of things with small lessons learned.
- Refines the help for `scan create`
- Allows TARGET to be omitted for `scan create`, defaulting to the CWD
- Supports a CWD argument for `scan github` for the purpose of resolving the socket.json