### PR TITLE
Allow fetched under eslint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -138,6 +138,7 @@ const sharedRulesForNode = {
         'readline/promises',
         'test',
         'test.describe',
+        'fetch',
       ],
       // Lazily access constants.maintainedNodeVersions.
       version: constants.maintainedNodeVersions.current,


### PR DESCRIPTION
We're kind of depending on `fetch` so this rule is bs.