### PR TITLE
Add warning after wrapper on/off about restarting terminal session

### DIFF
--- a/src/commands/wrapper/add-socket-wrapper.mts
+++ b/src/commands/wrapper/add-socket-wrapper.mts
@@ -10,14 +10,15 @@ export function addSocketWrapper(file: string): void {
       if (err) {
         return new Error(`There was an error setting up the alias: ${err}`)
       }
-      // TODO: pretty sure you need to source the file or restart
-      //       any terminal session before changes are reflected.
-      logger.log(
-        `
-The alias was added to ${file}. Running 'npm install' will now be wrapped in Socket's "safe npm" 🎉
-If you want to disable it at any time, run \`socket wrapper --disable\`
-      `.trim(),
-      )
+      logger.success(`The alias was added to ${file}. Running 'npm install' will now be wrapped in Socket's "safe npm" 🎉`);
+      logger.log(`  If you want to disable it at any time, run \`socket wrapper --disable\``)
+      logger.log('')
+      logger.info(`This will only be active in new terminal sessions going forward.`)
+      logger.log(`  You will need to restart your terminal or run this command to activate the alias in the current session:`)
+      logger.log('')
+      logger.log(`    source ${file}`)
+      logger.log('')
+      logger.log(`(You only need to do this once)`)
     },
   )
 }

--- a/src/commands/wrapper/add-socket-wrapper.mts
+++ b/src/commands/wrapper/add-socket-wrapper.mts
@@ -10,11 +10,19 @@ export function addSocketWrapper(file: string): void {
       if (err) {
         return new Error(`There was an error setting up the alias: ${err}`)
       }
-      logger.success(`The alias was added to ${file}. Running 'npm install' will now be wrapped in Socket's "safe npm" 🎉`);
-      logger.log(`  If you want to disable it at any time, run \`socket wrapper --disable\``)
+      logger.success(
+        `The alias was added to ${file}. Running 'npm install' will now be wrapped in Socket's "safe npm" 🎉`,
+      )
+      logger.log(
+        `  If you want to disable it at any time, run \`socket wrapper --disable\``,
+      )
       logger.log('')
-      logger.info(`This will only be active in new terminal sessions going forward.`)
-      logger.log(`  You will need to restart your terminal or run this command to activate the alias in the current session:`)
+      logger.info(
+        `This will only be active in new terminal sessions going forward.`,
+      )
+      logger.log(
+        `  You will need to restart your terminal or run this command to activate the alias in the current session:`,
+      )
       logger.log('')
       logger.log(`    source ${file}`)
       logger.log('')

--- a/src/commands/wrapper/check-socket-wrapper-setup.mts
+++ b/src/commands/wrapper/check-socket-wrapper-setup.mts
@@ -12,8 +12,16 @@ export function checkSocketWrapperSetup(file: string): boolean {
 
   if (linesWithSocketAlias.length) {
     logger.log(
-      `The Socket npm/npx wrapper is set up in your bash profile (${file})`,
+      `The Socket npm/npx wrapper is set up in your bash profile (${file}).`,
     )
+    logger.log('')
+    logger.log(
+      `If you haven't already since enabling; Restart your terminal or run this command to activate it in the current session:`
+    )
+    logger.log('')
+    logger.log('    source ${file}')
+    logger.log('')
+
     return true
   }
   return false

--- a/src/commands/wrapper/check-socket-wrapper-setup.mts
+++ b/src/commands/wrapper/check-socket-wrapper-setup.mts
@@ -16,10 +16,10 @@ export function checkSocketWrapperSetup(file: string): boolean {
     )
     logger.log('')
     logger.log(
-      `If you haven't already since enabling; Restart your terminal or run this command to activate it in the current session:`
+      `If you haven't already since enabling; Restart your terminal or run this command to activate it in the current session:`,
     )
     logger.log('')
-    logger.log('    source ${file}')
+    logger.log(`    source ${file}`)
     logger.log('')
 
     return true

--- a/src/commands/wrapper/remove-socket-wrapper.mts
+++ b/src/commands/wrapper/remove-socket-wrapper.mts
@@ -22,11 +22,9 @@ export function removeSocketWrapper(file: string): void {
         logger.error(err)
         return
       }
-      // TODO: pretty sure you need to source the file or restart
-      //       any terminal session before changes are reflected.
-      logger.log(
-        `The alias was removed from ${file}. Running 'npm install' will now run the standard npm command.`,
-      )
+      logger.success(`The alias was removed from ${file}. Running 'npm install' will now run the standard npm command in new terminals going forward.`)
+      logger.log('')
+      logger.info(`Note: We cannot deactivate the alias from current terminal sessions. You have to restart existing terminal sessions to finalize this step.`)
     })
   })
 }

--- a/src/commands/wrapper/remove-socket-wrapper.mts
+++ b/src/commands/wrapper/remove-socket-wrapper.mts
@@ -22,9 +22,13 @@ export function removeSocketWrapper(file: string): void {
         logger.error(err)
         return
       }
-      logger.success(`The alias was removed from ${file}. Running 'npm install' will now run the standard npm command in new terminals going forward.`)
+      logger.success(
+        `The alias was removed from ${file}. Running 'npm install' will now run the standard npm command in new terminals going forward.`,
+      )
       logger.log('')
-      logger.info(`Note: We cannot deactivate the alias from current terminal sessions. You have to restart existing terminal sessions to finalize this step.`)
+      logger.info(
+        `Note: We cannot deactivate the alias from current terminal sessions. You have to restart existing terminal sessions to finalize this step.`,
+      )
     })
   })
 }


### PR DESCRIPTION
(Since you can't access the session from which the command was executed, you can't remove the alias. The user will have to do this explicitly or it will naturally cycle as terminals get closed. But to state that it's active/inactive now is misleading.)