### PR TITLE
Add aliases, fixup flags

### DIFF
--- a/src/cli.mts
+++ b/src/cli.mts
@@ -25,6 +25,8 @@ import { cmdNpm } from './commands/npm/cmd-npm.mts'
 import { cmdNpx } from './commands/npx/cmd-npx.mts'
 import { cmdOops } from './commands/oops/cmd-oops.mts'
 import { cmdOptimize } from './commands/optimize/cmd-optimize.mts'
+import { cmdOrganizationPolicyLicense } from './commands/organization/cmd-organization-policy-license.mts'
+import { cmdOrganizationPolicyPolicy } from './commands/organization/cmd-organization-policy-security.mts'
 import { cmdOrganization } from './commands/organization/cmd-organization.mts'
 import { cmdPackage } from './commands/package/cmd-package.mts'
 import { cmdRawNpm } from './commands/raw-npm/cmd-raw-npm.mts'
@@ -85,7 +87,73 @@ void (async () => {
         uninstall: cmdUninstall,
       },
       {
-        aliases: {},
+        aliases: {
+          deps: {
+            description: cmdScanCreate.description,
+            hidden: true,
+            argv: ['dependencies'],
+          },
+          feed: {
+            description: cmdThreatFeed.description,
+            hidden: true,
+            argv: ['threat-feed'],
+          },
+          license: {
+            description: cmdOrganizationPolicyLicense.description,
+            hidden: true,
+            argv: ['organization', 'policy', 'license'],
+          },
+          org: {
+            description: cmdOrganization.description,
+            hidden: true,
+            argv: ['organization'],
+          },
+          orgs: {
+            description: cmdOrganization.description,
+            hidden: true,
+            argv: ['organization'],
+          },
+          organizations: {
+            description: cmdOrganization.description,
+            hidden: true,
+            argv: ['organization'],
+          },
+          organisation: {
+            description: cmdOrganization.description,
+            hidden: true,
+            argv: ['organization'],
+          },
+          organisations: {
+            description: cmdOrganization.description,
+            hidden: true,
+            argv: ['organization'],
+          },
+          pkg: {
+            description: cmdPackage.description,
+            hidden: true,
+            argv: ['package'],
+          },
+          repo: {
+            description: cmdRepos.description,
+            hidden: true,
+            argv: ['repos'],
+          },
+          repository: {
+            description: cmdRepos.description,
+            hidden: true,
+            argv: ['repos'],
+          },
+          repositories: {
+            description: cmdRepos.description,
+            hidden: true,
+            argv: ['repos'],
+          },
+          security: {
+            description: cmdOrganizationPolicyPolicy.description,
+            hidden: true,
+            argv: ['organization', 'policy', 'security'],
+          },
+        },
         argv: process.argv.slice(2),
         name: SOCKET_CLI_BIN_NAME,
         importMeta: { url: `${pathToFileURL(__filename)}` } as ImportMeta,

--- a/src/commands/analytics/cmd-analytics.test.mts
+++ b/src/commands/analytics/cmd-analytics.test.mts
@@ -30,7 +30,6 @@ describe('socket analytics', async () => {
 
           Options
             --file            Filepath to save output. Only valid with --json/--markdown. Defaults to stdout.
-            --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown
             --repo            Name of the repository. Only valid when scope=repo
@@ -134,7 +133,6 @@ describe('socket analytics', async () => {
 
           Options
             --file            Filepath to save output. Only valid with --json/--markdown. Defaults to stdout.
-            --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown
             --repo            Name of the repository. Only valid when scope=repo

--- a/src/commands/audit-log/cmd-audit-log.test.mts
+++ b/src/commands/audit-log/cmd-audit-log.test.mts
@@ -28,10 +28,9 @@ describe('socket audit-log', async () => {
             - Permissions: audit-log:list
 
           This feature requires an Enterprise Plan. To learn more about getting access
-          to this feature and many more, please visit ${SOCKET_WEBSITE_URL}/pricing
+          to this feature and many more, please visit https://socket.dev/pricing
 
           Options
-            --help            Print this help
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/ci/cmd-ci.test.mts
+++ b/src/commands/ci/cmd-ci.test.mts
@@ -23,7 +23,6 @@ describe('socket ci', async () => {
 
           Options
             --autoManifest    Auto generate manifest files where detected? See autoManifest flag in \`socket scan create\`
-            --help            Print this help
 
           This command is intended to use in CI runs to allow automated systems to
           accept or reject a current build. When the scan does not pass your security

--- a/src/commands/cli.test.mts
+++ b/src/commands/cli.test.mts
@@ -29,6 +29,7 @@ describe('socket root command', async () => {
           npm               npm wrapper functionality
           npx               npx wrapper functionality
           optimize          Optimize dependencies with @socketregistry overrides
+          organization      Account details
           package           Commands relating to looking up published packages
           raw-npm           Temporarily disable the Socket npm wrapper
           raw-npx           Temporarily disable the Socket npx wrapper
@@ -42,23 +43,21 @@ describe('socket root command', async () => {
           --config          Allows you to temp overrides the internal CLI config
           --dryRun          Do input validation for a sub-command and then exit
           --help            Give you detailed help information about any sub-command
-          --json            Ensure stdout only receives proper JSON (Most non-interactive commands support this)
-          --markdown        Ensure stdout only receives a markdown report (Many commands that support --json also support this)
           --version         Show version of CLI
 
         Examples
           $ socket --help
-          $ socket scan create
-          $ socket package score npm left-pad"
+          $ socket scan create --json
+          $ socket package score npm left-pad --markdown"
     `,
     )
     expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
-        "
-           _____         _       _        /---------------
-          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
-          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-          |_____|___|___|_,_|___|_|.dev   | Command: \`socket\`, cwd: <redacted>"
-      `)
+      "
+         _____         _       _        /---------------
+        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+        |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+        |_____|___|___|_,_|___|_|.dev   | Command: \`socket\`, cwd: <redacted>"
+    `)
 
     expect(code, 'explicit help should exit with code 0').toBe(0)
     expect(stderr, 'banner includes base command').toContain('`socket`')
@@ -71,75 +70,73 @@ describe('socket root command', async () => {
       const { code, stderr, stdout } = await invokeNpm(binCliPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-      "CLI for Socket.dev
+        "CLI for Socket.dev
 
-        Usage
-          $ socket <command>
+          Usage
+            $ socket <command>
 
 
-          All commands have their own --help page
+            All commands have their own --help page
 
-        Main commands
+          Main commands
 
-          socket login             Setup the CLI with an API Token and defaults
-          socket scan create       Create a new Scan and report
-          socket package score     Request the (shallow) security score of a particular package
-          socket ci                Shorthand for CI; socket scan create --report --no-interactive
+            socket login             Setup the CLI with an API Token and defaults
+            socket scan create       Create a new Scan and report
+            socket package score     Request the (shallow) security score of a particular package
+            socket ci                Shorthand for CI; socket scan create --report --no-interactive
 
-        Socket API
+          Socket API
 
-          analytics                Look up analytics data
-          audit-log                Look up the audit log for an organization
-          organization             Manage organization account details
-          package                  Look up published package details
-          repository               Manage registered repositories
-          scan                     Manage Socket scans
-          threat-feed              [beta] View the threat feed
+            analytics                Look up analytics data
+            audit-log                Look up the audit log for an organization
+            organization             Manage organization account details
+            package                  Look up published package details
+            repository               Manage registered repositories
+            scan                     Manage Socket scans
+            threat-feed              [beta] View the threat feed
 
-        Local tools
+          Local tools
 
-          fix                      Update dependencies with "fixable" Socket alerts
-          manifest                 Generate a dependency manifest for certain languages
-          npm                      npm wrapper functionality
-          npx                      npx wrapper functionality
-          optimize                 Optimize dependencies with @socketregistry overrides
-          raw-npm                  Temporarily disable the Socket npm wrapper
-          raw-npx                  Temporarily disable the Socket npx wrapper
+            fix                      Update dependencies with "fixable" Socket alerts
+            manifest                 Generate a dependency manifest for certain languages
+            npm                      npm wrapper functionality
+            npx                      npx wrapper functionality
+            optimize                 Optimize dependencies with @socketregistry overrides
+            raw-npm                  Temporarily disable the Socket npm wrapper
+            raw-npx                  Temporarily disable the Socket npx wrapper
 
-        CLI configuration
+          CLI configuration
 
-          config                   Manage the CLI configuration directly
-          install                  Manually install CLI tab completion on your system
-          login                    Socket API login and CLI setup
-          logout                   Socket API logout
-          uninstall                Remove the CLI tab completion from your system
-          wrapper                  Enable or disable the Socket npm/npx wrapper
+            config                   Manage the CLI configuration directly
+            install                  Manually install CLI tab completion on your system
+            login                    Socket API login and CLI setup
+            logout                   Socket API logout
+            uninstall                Remove the CLI tab completion from your system
+            wrapper                  Enable or disable the Socket npm/npx wrapper
 
-        Options       (Note: all CLI commands have these flags even when not displayed in their help)
+          Options       (Note: all CLI commands have these flags even when not displayed in their help)
 
-          --config                 Allows you to temp overrides the internal CLI config
-          --dryRun                 Do input validation for a sub-command and then exit
-          --help                   Give you detailed help information about any sub-command
-          --json                   Ensure stdout only receives proper JSON (Most non-interactive commands support this)
-          --markdown               Ensure stdout only receives a markdown report (Many commands that support --json also support this)
-          --version                Show version of CLI
+            --config                 Allows you to temp overrides the internal CLI config
+            --dryRun                 Do input validation for a sub-command and then exit
+            --help                   Give you detailed help information about any sub-command
+            --version                Show version of CLI
 
-        Examples
-          $ socket --help
-          $ socket scan create
-          $ socket package score npm left-pad"
-    `,
+          Examples
+            $ socket --help
+            $ socket scan create --json
+            $ socket package score npm left-pad --markdown"
+      `,
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
-      "
-         \\x1b[31m\\xd7\\x1b[39m Found commands in the list that were not marked as public or were not defined at all: [ 'config', 'install', 'organization', 'uninstall' ]
-         _____         _       _        /---------------
-        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
-        |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket\`, cwd: <redacted>
-      \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
-      \\x1b[39m"
-    `)
+        "
+           \\x1b[31m\\xd7\\x1b[39m Found commands in the list that were not marked as public or were not defined at all: [ 'config', 'install', 'uninstall' ]
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted> (is testing v1)
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket\`, cwd: <redacted>
+        \\x1b[32m   (Thank you for testing the v1 bump! Please send us any feedback you might have!)
+        \\x1b[39m"
+      `)
 
       expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(stderr, 'banner includes base command').toContain('`socket`')

--- a/src/commands/config/cmd-config-get.test.mts
+++ b/src/commands/config/cmd-config-get.test.mts
@@ -22,7 +22,6 @@ describe('socket config get', async () => {
             $ socket config get <org slug>
 
           Options
-            --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown
 

--- a/src/commands/config/cmd-config-list.test.mts
+++ b/src/commands/config/cmd-config-list.test.mts
@@ -23,7 +23,6 @@ describe('socket config get', async () => {
 
           Options
             --full            Show full tokens in plaintext (unsafe)
-            --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown
 

--- a/src/commands/config/cmd-config-set.test.mts
+++ b/src/commands/config/cmd-config-set.test.mts
@@ -22,7 +22,6 @@ describe('socket config get', async () => {
             $ socket config set <key> <value>
 
           Options
-            --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown
 

--- a/src/commands/config/cmd-config-unset.test.mts
+++ b/src/commands/config/cmd-config-unset.test.mts
@@ -22,7 +22,6 @@ describe('socket config unset', async () => {
             $ socket config unset <org slug>
 
           Options
-            --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown
 

--- a/src/commands/config/cmd-config.mts
+++ b/src/commands/config/cmd-config.mts
@@ -11,7 +11,7 @@ const description = 'Commands related to the local CLI configuration'
 
 export const cmdConfig: CliSubcommand = {
   description,
-  hidden: true, // [beta]
+  hidden: true, // [beta]; isTestingV1
   async run(argv, importMeta, { parentName }) {
     await meowWithSubcommands(
       {

--- a/src/commands/config/cmd-config.test.mts
+++ b/src/commands/config/cmd-config.test.mts
@@ -29,7 +29,7 @@ describe('socket config', async () => {
             unset             Clear the value of a local CLI config item
 
           Options
-            --help            Print this help
+            (none)
 
           Examples
             $ socket config --help"

--- a/src/commands/dependencies/cmd-dependencies.test.mts
+++ b/src/commands/dependencies/cmd-dependencies.test.mts
@@ -26,7 +26,6 @@ describe('socket dependencies', async () => {
             - Permissions: none (does need token with access to target org)
 
           Options
-            --help            Print this help
             --json            Output result as json
             --limit           Maximum number of dependencies returned
             --markdown        Output result as markdown

--- a/src/commands/diff-scan/cmd-diff-scan-get.test.mts
+++ b/src/commands/diff-scan/cmd-diff-scan-get.test.mts
@@ -37,7 +37,6 @@ describe('socket diff-scan get', async () => {
             --before          The scan ID of the base scan
             --depth           Max depth of JSON to display before truncating, use zero for no limit (without --json/--file)
             --file            Path to a local file where the output should be saved. Use \`-\` to force stdout.
-            --help            Print this help
             --json            Output result as json. This can be big. Use --file to store it to disk without truncation.
 
           Examples

--- a/src/commands/diff-scan/cmd-diff-scan.test.mts
+++ b/src/commands/diff-scan/cmd-diff-scan.test.mts
@@ -25,7 +25,7 @@ describe('socket diff-scan', async () => {
             get               Get a diff scan for an organization
 
           Options
-            --help            Print this help
+            (none)
 
           Examples
             $ socket diff-scan --help"

--- a/src/commands/fix/cmd-fix.test.mts
+++ b/src/commands/fix/cmd-fix.test.mts
@@ -23,7 +23,6 @@ describe('socket fix', async () => {
             --autoMerge       Enable auto-merge for pull requests that Socket opens.
                               See GitHub documentation (\\u200bhttps://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository\\u200b) for managing auto-merge for pull requests in your repository.
             --autopilot       Shorthand for --autoMerge --test
-            --help            Print this help
             --limit           The number of fixes to attempt at a time
             --purl            Provide a list of package URLs (\\u200bhttps://github.com/package-url/purl-spec?tab=readme-ov-file#purl\\u200b) (PURLs) to fix, as either a comma separated value or as multiple flags,
                               instead of querying the Socket API

--- a/src/commands/info/cmd-info.test.mts
+++ b/src/commands/info/cmd-info.test.mts
@@ -25,7 +25,6 @@ describe('socket info', async () => {
 
           Options
             --all             Include all issues
-            --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown
             --strict          Exits with an error code if any matching issues are found

--- a/src/commands/install/cmd-install-completion.mts
+++ b/src/commands/install/cmd-install-completion.mts
@@ -13,7 +13,7 @@ const { DRY_RUN_BAILING_NOW } = constants
 const config: CliCommandConfig = {
   commandName: 'completion',
   description: 'Install bash completion for Socket CLI',
-  hidden: true, // beta
+  hidden: true, // beta; isTestingV1
   flags: {
     ...commonFlags,
   },

--- a/src/commands/install/cmd-install-completion.test.mts
+++ b/src/commands/install/cmd-install-completion.test.mts
@@ -37,7 +37,7 @@ describe('socket install completion', async () => {
           different alias for socket on your system.
 
           Options
-            --help            Print this help
+            (none)
 
           Examples
 

--- a/src/commands/install/cmd-install.mts
+++ b/src/commands/install/cmd-install.mts
@@ -7,7 +7,7 @@ const description = 'Setup the Socket CLI command in your environment'
 
 export const cmdInstall: CliSubcommand = {
   description,
-  hidden: true, // beta
+  hidden: true, // beta; isTestingV1
   async run(argv, importMeta, { parentName }) {
     await meowWithSubcommands(
       {

--- a/src/commands/install/cmd-install.test.mts
+++ b/src/commands/install/cmd-install.test.mts
@@ -25,7 +25,7 @@ describe('socket install', async () => {
             (none)
 
           Options
-            --help            Print this help
+            (none)
 
           Examples
             $ socket install --help"

--- a/src/commands/login/cmd-login.test.mts
+++ b/src/commands/login/cmd-login.test.mts
@@ -29,7 +29,6 @@ describe('socket login', async () => {
           Options
             --apiBaseUrl      API server to connect to for login
             --apiProxy        Proxy to use when making connection to API server
-            --help            Print this help
 
           Examples
             $ socket login

--- a/src/commands/manifest/cmd-manifest-auto.test.mts
+++ b/src/commands/manifest/cmd-manifest-auto.test.mts
@@ -20,7 +20,6 @@ describe('socket manifest auto', async () => {
             $ socket manifest auto [CWD=.]
 
           Options
-            --help            Print this help
             --verbose         Enable debug output (only for auto itself; sub-steps need to have it pre-configured), may help when running into errors
 
           Tries to figure out what language your target repo uses. If it finds a

--- a/src/commands/manifest/cmd-manifest-cdxgen.test.mts
+++ b/src/commands/manifest/cmd-manifest-cdxgen.test.mts
@@ -75,12 +75,12 @@ describe('socket manifest cdxgen', async () => {
     `,
       )
       expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
-      "
-         _____         _       _        /---------------
-        |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
-        |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
-        |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest cdxgen\`, cwd: <redacted>"
-    `)
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket manifest cdxgen\`, cwd: <redacted>"
+      `)
 
       // expect(code, 'explicit help should exit with code 0').toBe(0)
       expect(code, 'help should exit with code 2').toBe(0) // cdxgen special case

--- a/src/commands/manifest/cmd-manifest-conda.test.mts
+++ b/src/commands/manifest/cmd-manifest-conda.test.mts
@@ -30,7 +30,6 @@ describe('socket manifest conda', async () => {
 
           Options
             --file            Input file name (by default for Conda this is "environment.yml"), relative to cwd
-            --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown
             --out             Output path (relative to cwd)

--- a/src/commands/manifest/cmd-manifest-gradle.test.mts
+++ b/src/commands/manifest/cmd-manifest-gradle.test.mts
@@ -22,7 +22,6 @@ describe('socket manifest gradle', async () => {
           Options
             --bin             Location of gradlew binary to use, default: CWD/gradlew
             --gradleOpts      Additional options to pass on to ./gradlew, see \`./gradlew --help\`
-            --help            Print this help
             --verbose         Print debug messages
 
           Uses gradle, preferably through your local project \`gradlew\`, to generate a

--- a/src/commands/manifest/cmd-manifest-kotlin.test.mts
+++ b/src/commands/manifest/cmd-manifest-kotlin.test.mts
@@ -22,7 +22,6 @@ describe('socket manifest kotlin', async () => {
           Options
             --bin             Location of gradlew binary to use, default: CWD/gradlew
             --gradleOpts      Additional options to pass on to ./gradlew, see \`./gradlew --help\`
-            --help            Print this help
             --verbose         Print debug messages
 
           Uses gradle, preferably through your local project \`gradlew\`, to generate a

--- a/src/commands/manifest/cmd-manifest-scala.test.mts
+++ b/src/commands/manifest/cmd-manifest-scala.test.mts
@@ -21,7 +21,6 @@ describe('socket manifest scala', async () => {
 
           Options
             --bin             Location of sbt binary to use
-            --help            Print this help
             --out             Path of output file; where to store the resulting manifest, see also --stdout
             --sbtOpts         Additional options to pass on to sbt, as per \`sbt --help\`
             --stdout          Print resulting pom.xml to stdout (supersedes --out)

--- a/src/commands/manifest/cmd-manifest-setup.test.mts
+++ b/src/commands/manifest/cmd-manifest-setup.test.mts
@@ -21,7 +21,6 @@ describe('socket manifest setup', async () => {
 
           Options
             --defaultOnReadErrorIf reading the socket.json fails, just use a default config? Warning: This might override the existing json file!
-            --help            Print this help
 
           This command will try to detect all supported ecosystems in given CWD. Then
           it starts a configurator where you can setup default values for certain flags

--- a/src/commands/manifest/cmd-manifest.test.mts
+++ b/src/commands/manifest/cmd-manifest.test.mts
@@ -29,7 +29,7 @@ describe('socket manifest', async () => {
             setup             Start interactive configurator to customize default flag values for \`socket manifest\` in this dir
 
           Options
-            --help            Print this help
+            (none)
 
           Examples
             $ socket manifest --help"

--- a/src/commands/optimize/cmd-optimize.test.mts
+++ b/src/commands/optimize/cmd-optimize.test.mts
@@ -22,7 +22,6 @@ describe('socket optimize', async () => {
             $ socket optimize [options] [CWD=.]
 
           Options
-            --help            Print this help
             --pin             Pin overrides to their latest version
             --prod            Only add overrides for production dependencies
 

--- a/src/commands/organization/cmd-organization-list.test.mts
+++ b/src/commands/organization/cmd-organization-list.test.mts
@@ -26,7 +26,6 @@ describe('socket organization list', async () => {
             - Permissions: none (does need a token)
 
           Options
-            --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown"
       `,

--- a/src/commands/organization/cmd-organization-policy-license.test.mts
+++ b/src/commands/organization/cmd-organization-policy-license.test.mts
@@ -26,7 +26,6 @@ describe('socket organization policy license', async () => {
             - Permissions: license-policy:read
 
           Options
-            --help            Print this help
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/organization/cmd-organization-policy-security.test.mts
+++ b/src/commands/organization/cmd-organization-policy-security.test.mts
@@ -26,7 +26,6 @@ describe('socket organization policy security', async () => {
             - Permissions: security-policy:read
 
           Options
-            --help            Print this help
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/organization/cmd-organization-policy.test.mts
+++ b/src/commands/organization/cmd-organization-policy.test.mts
@@ -25,7 +25,7 @@ describe('socket organization list', async () => {
             (none)
 
           Options
-            --help            Print this help
+            (none)
 
           Examples
             $ socket organization policy --help"

--- a/src/commands/organization/cmd-organization-quota.test.mts
+++ b/src/commands/organization/cmd-organization-quota.test.mts
@@ -22,7 +22,6 @@ describe('socket organization quota', async () => {
             $ socket organization quota
 
           Options
-            --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown"
       `,

--- a/src/commands/organization/cmd-organization.mts
+++ b/src/commands/organization/cmd-organization.mts
@@ -1,4 +1,6 @@
 import { cmdOrganizationList } from './cmd-organization-list.mts'
+import { cmdOrganizationPolicyLicense } from './cmd-organization-policy-license.mts'
+import { cmdOrganizationPolicyPolicy } from './cmd-organization-policy-security.mts'
 import { cmdOrganizationPolicy } from './cmd-organization-policy.mts'
 import { cmdOrganizationQuota } from './cmd-organization-quota.mts'
 import { meowWithSubcommands } from '../../utils/meow-with-subcommands.mts'
@@ -9,11 +11,7 @@ const description = 'Account details'
 
 export const cmdOrganization: CliSubcommand = {
   description,
-  // Hidden because it was broken all this time (nobody could be using it)
-  // and we're not sure if it's useful to anyone in its current state.
-  // Until we do, we'll hide this to keep the help tidier.
-  // And later, we may simply move this under `scan`, anyways.
-  hidden: true,
+  hidden: false,
   async run(argv, importMeta, { parentName }) {
     await meowWithSubcommands(
       {
@@ -22,6 +20,18 @@ export const cmdOrganization: CliSubcommand = {
         policy: cmdOrganizationPolicy,
       },
       {
+        aliases: {
+          license: {
+            description: cmdOrganizationPolicyLicense.description,
+            hidden: true,
+            argv: ['policy', 'license'],
+          },
+          security: {
+            description: cmdOrganizationPolicyPolicy.description,
+            hidden: true,
+            argv: ['policy', 'security'],
+          },
+        },
         argv,
         description,
         defaultSub: 'list', // Backwards compat

--- a/src/commands/organization/cmd-organization.test.mts
+++ b/src/commands/organization/cmd-organization.test.mts
@@ -25,7 +25,7 @@ describe('socket organization', async () => {
             list              List organizations associated with the API key used
 
           Options
-            --help            Print this help
+            (none)
 
           Examples
             $ socket organization --help"

--- a/src/commands/package/cmd-package-score.mts
+++ b/src/commands/package/cmd-package-score.mts
@@ -17,7 +17,7 @@ const { DRY_RUN_BAILING_NOW } = constants
 const config: CliCommandConfig = {
   commandName: 'score',
   description:
-    '[beta] Look up score for one package which reflects all of its transitive dependencies as well',
+    'Look up score for one package which reflects all of its transitive dependencies as well',
   hidden: false,
   flags: {
     ...commonFlags,

--- a/src/commands/package/cmd-package-score.test.mts
+++ b/src/commands/package/cmd-package-score.test.mts
@@ -16,7 +16,7 @@ describe('socket package score', async () => {
       const { code, stderr, stdout } = await invokeNpm(binCliPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-        "[beta] Look up score for one package which reflects all of its transitive dependencies as well
+        "Look up score for one package which reflects all of its transitive dependencies as well
 
           Usage
             $ socket package score <<ecosystem> <name> | <purl>>
@@ -26,7 +26,6 @@ describe('socket package score', async () => {
             - Permissions: packages:list
 
           Options
-            --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown
 

--- a/src/commands/package/cmd-package-shallow.mts
+++ b/src/commands/package/cmd-package-shallow.mts
@@ -16,7 +16,7 @@ const { DRY_RUN_BAILING_NOW } = constants
 const config: CliCommandConfig = {
   commandName: 'shallow',
   description:
-    '[beta] Look up info regarding one or more packages but not their transitives',
+    'Look up info regarding one or more packages but not their transitives',
   hidden: false,
   flags: {
     ...commonFlags,

--- a/src/commands/package/cmd-package-shallow.test.mts
+++ b/src/commands/package/cmd-package-shallow.test.mts
@@ -16,7 +16,7 @@ describe('socket package shallow', async () => {
       const { code, stderr, stdout } = await invokeNpm(binCliPath, cmd)
       expect(stdout).toMatchInlineSnapshot(
         `
-        "[beta] Look up info regarding one or more packages but not their transitives
+        "Look up info regarding one or more packages but not their transitives
 
           Usage
             $ socket package shallow <<ecosystem> <name> [<name> ...] | <purl> [<purl> ...]>
@@ -26,7 +26,6 @@ describe('socket package shallow', async () => {
             - Permissions: packages:list
 
           Options
-            --help            Print this help
             --json            Output result as json
             --markdown        Output result as markdown
 

--- a/src/commands/package/cmd-package.test.mts
+++ b/src/commands/package/cmd-package.test.mts
@@ -22,11 +22,11 @@ describe('socket package', async () => {
             $ socket package <command>
 
           Commands
-            score             [beta] Look up score for one package which reflects all of its transitive dependencies as well
-            shallow           [beta] Look up info regarding one or more packages but not their transitives
+            score             Look up score for one package which reflects all of its transitive dependencies as well
+            shallow           Look up info regarding one or more packages but not their transitives
 
           Options
-            --help            Print this help
+            (none)
 
           Examples
             $ socket package --help"

--- a/src/commands/report/cmd-report.test.mts
+++ b/src/commands/report/cmd-report.test.mts
@@ -26,7 +26,7 @@ describe('socket report', async () => {
             view              [Deprecated] View a project report
 
           Options
-            --help            Print this help
+            (none)
 
           Examples
             $ socket report --help"

--- a/src/commands/repos/cmd-repos-create.test.mts
+++ b/src/commands/repos/cmd-repos-create.test.mts
@@ -27,7 +27,6 @@ describe('socket repos create', async () => {
 
           Options
             --defaultBranch   Repository default branch
-            --help            Print this help
             --homepage        Repository url
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json

--- a/src/commands/repos/cmd-repos-del.test.mts
+++ b/src/commands/repos/cmd-repos-del.test.mts
@@ -26,7 +26,6 @@ describe('socket repos del', async () => {
             - Permissions: repo:delete
 
           Options
-            --help            Print this help
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/repos/cmd-repos-list.test.mts
+++ b/src/commands/repos/cmd-repos-list.test.mts
@@ -28,7 +28,6 @@ describe('socket repos list', async () => {
           Options
             --all             By default view shows the last n repos. This flag allows you to fetch the entire list. Will ignore --page and --perPage.
             --direction       Direction option
-            --help            Print this help
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/repos/cmd-repos-update.test.mts
+++ b/src/commands/repos/cmd-repos-update.test.mts
@@ -27,7 +27,6 @@ describe('socket repos update', async () => {
 
           Options
             --defaultBranch   Repository default branch
-            --help            Print this help
             --homepage        Repository url
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json

--- a/src/commands/repos/cmd-repos-view.test.mts
+++ b/src/commands/repos/cmd-repos-view.test.mts
@@ -26,7 +26,6 @@ describe('socket repos view', async () => {
             - Permissions: repo:list
 
           Options
-            --help            Print this help
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/repos/cmd-repos.test.mts
+++ b/src/commands/repos/cmd-repos.test.mts
@@ -29,7 +29,7 @@ describe('socket repos', async () => {
             view              View repositories in an organization
 
           Options
-            --help            Print this help
+            (none)
 
           Examples
             $ socket repos --help"

--- a/src/commands/scan/cmd-scan-create.test.mts
+++ b/src/commands/scan/cmd-scan-create.test.mts
@@ -32,7 +32,6 @@ describe('socket scan create', async () => {
             --committers      Committers
             --cwd             working directory, defaults to process.cwd()
             --defaultBranch   Set the default branch of the repository to the branch of this full-scan. Should only need to be done once, for example for the "main" or "master" branch.
-            --help            Print this help
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/scan/cmd-scan-del.test.mts
+++ b/src/commands/scan/cmd-scan-del.test.mts
@@ -26,7 +26,6 @@ describe('socket scan del', async () => {
             - Permissions: full-scans:delete
 
           Options
-            --help            Print this help
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/scan/cmd-scan-diff.test.mts
+++ b/src/commands/scan/cmd-scan-diff.test.mts
@@ -35,7 +35,6 @@ describe('socket scan diff', async () => {
           Options
             --depth           Max depth of JSON to display before truncating, use zero for no limit (without --json/--file)
             --file            Path to a local file where the output should be saved. Use \`-\` to force stdout.
-            --help            Print this help
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/scan/cmd-scan-github.test.mts
+++ b/src/commands/scan/cmd-scan-github.test.mts
@@ -41,7 +41,6 @@ describe('socket scan github', async () => {
             --all             Apply for all known repos reported by the Socket API. Supersedes \`repos\`.
             --githubApiUrl    Base URL of the GitHub API (default: https://api.github.com)
             --githubToken     (required) GitHub token for authentication (or set GITHUB_TOKEN as an environment variable)
-            --help            Print this help
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/scan/cmd-scan-list.test.mts
+++ b/src/commands/scan/cmd-scan-list.test.mts
@@ -29,7 +29,6 @@ describe('socket scan list', async () => {
             --branch          Filter to show only scans with this branch name
             --direction       Direction option (\`desc\` or \`asc\`) - Default is \`desc\`
             --fromTime        From time - as a unix timestamp
-            --help            Print this help
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/scan/cmd-scan-metadata.test.mts
+++ b/src/commands/scan/cmd-scan-metadata.test.mts
@@ -26,7 +26,6 @@ describe('socket scan metadata', async () => {
             - Permissions: full-scans:list
 
           Options
-            --help            Print this help
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/scan/cmd-scan-report.test.mts
+++ b/src/commands/scan/cmd-scan-report.test.mts
@@ -27,7 +27,6 @@ describe('socket scan report', async () => {
 
           Options
             --fold            Fold reported alerts to some degree
-            --help            Print this help
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --license         Also report the license policy status. Default: false

--- a/src/commands/scan/cmd-scan-setup.test.mts
+++ b/src/commands/scan/cmd-scan-setup.test.mts
@@ -23,7 +23,6 @@ describe('socket scan setup', async () => {
 
           Options
             --defaultOnReadErrorIf reading the socket.json fails, just use a default config? Warning: This might override the existing json file!
-            --help            Print this help
 
           Interactive configurator to create a local json file in the target directory
           that helps to set flag defaults for \`socket scan create\`.

--- a/src/commands/scan/cmd-scan-view.test.mts
+++ b/src/commands/scan/cmd-scan-view.test.mts
@@ -28,7 +28,6 @@ describe('socket scan view', async () => {
           When no output path is given the contents is sent to stdout.
 
           Options
-            --help            Print this help
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/scan/cmd-scan.mts
+++ b/src/commands/scan/cmd-scan.mts
@@ -32,7 +32,17 @@ export const cmdScan: CliSubcommand = {
       },
       {
         aliases: {
-          // Backwards compat. TODO: Drop next major bump
+          meta: {
+            description: cmdScanMetadata.description,
+            hidden: true,
+            argv: ['metadata'],
+          },
+          reachability: {
+            description: cmdScanReach.description,
+            hidden: true,
+            argv: ['reach'],
+          },
+          // Backwards compat. TODO: Drop next major bump; isTestingV1
           stream: {
             description: cmdScanView.description,
             hidden: true,

--- a/src/commands/scan/cmd-scan.test.mts
+++ b/src/commands/scan/cmd-scan.test.mts
@@ -32,7 +32,7 @@ describe('socket scan', async () => {
             view              View the raw results of a scan
 
           Options
-            --help            Print this help
+            (none)
 
           Examples
             $ socket scan --help"

--- a/src/commands/threat-feed/cmd-threat-feed.test.mts
+++ b/src/commands/threat-feed/cmd-threat-feed.test.mts
@@ -33,7 +33,6 @@ describe('socket threat-feed', async () => {
             --direction       Order asc or desc by the createdAt attribute
             --eco             Only show threats for a particular ecosystem
             --filter          Filter what type of threats to return
-            --help            Print this help
             --interactive     Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json            Output result as json
             --markdown        Output result as markdown

--- a/src/commands/uninstall/cmd-uninstall-completion.mts
+++ b/src/commands/uninstall/cmd-uninstall-completion.mts
@@ -13,7 +13,7 @@ const { DRY_RUN_BAILING_NOW } = constants
 const config: CliCommandConfig = {
   commandName: 'completion',
   description: 'Uninstall bash completion for Socket CLI',
-  hidden: true, // beta
+  hidden: true, // beta; isTestingV1
   flags: {
     ...commonFlags,
   },

--- a/src/commands/uninstall/cmd-uninstall-completion.test.mts
+++ b/src/commands/uninstall/cmd-uninstall-completion.test.mts
@@ -30,7 +30,7 @@ describe('socket uninstall completion', async () => {
           tab completion that is registered for it in bash.
 
           Options
-            --help            Print this help
+            (none)
 
           Examples
 

--- a/src/commands/uninstall/cmd-uninstall.mts
+++ b/src/commands/uninstall/cmd-uninstall.mts
@@ -7,7 +7,7 @@ const description = 'Teardown the Socket command from your environment'
 
 export const cmdUninstall: CliSubcommand = {
   description,
-  hidden: true, // beta
+  hidden: true, // beta; isTestingV1
   async run(argv, importMeta, { parentName }) {
     await meowWithSubcommands(
       {

--- a/src/commands/uninstall/cmd-uninstall.test.mts
+++ b/src/commands/uninstall/cmd-uninstall.test.mts
@@ -25,7 +25,7 @@ describe('socket uninstall', async () => {
             (none)
 
           Options
-            --help            Print this help
+            (none)
 
           Examples
             $ socket uninstall --help"

--- a/src/commands/wrapper/cmd-wrapper.test.mts
+++ b/src/commands/wrapper/cmd-wrapper.test.mts
@@ -24,7 +24,6 @@ describe('socket wrapper', async () => {
           Options
             --disable         Disables the Socket npm/npx wrapper
             --enable          Enables the Socket npm/npx wrapper
-            --help            Print this help
 
           Examples
             $ socket wrapper --enable

--- a/src/flags.mts
+++ b/src/flags.mts
@@ -30,14 +30,21 @@ export const commonFlags: MeowFlags = {
     type: 'boolean',
     default: false,
     shortFlag: 'h',
+    hidden: true,
     description: 'Print this help',
   },
-  silent: {
+  nobanner: {
+    // I know this would be `--no-banner` but that doesn't work with cdxgen.
+    // Mostly for internal usage anyways.
     type: 'boolean',
     default: false,
     hidden: true,
-    shortFlag: 's',
-    description: 'Make the CLI less chatty',
+    description: 'Hide the Socket banner',
+  },
+  version: {
+    type: 'boolean',
+    hidden: true,
+    description: 'Print the app version',
   },
 }
 

--- a/src/utils/meow-with-subcommands.mts
+++ b/src/utils/meow-with-subcommands.mts
@@ -115,18 +115,6 @@ export async function meowWithSubcommands(
       hidden: false, // Only show on root
       description: 'Do input validation for a sub-command and then exit',
     }
-    flags['json'] = {
-      type: 'boolean',
-      hidden: false, // Only show on root
-      description:
-        'Ensure stdout only receives proper JSON (Most non-interactive commands support this)',
-    }
-    flags['markdown'] = {
-      type: 'boolean',
-      hidden: false, // Only show on root
-      description:
-        'Ensure stdout only receives a markdown report (Many commands that support --json also support this)',
-    }
     flags['version'] = {
       type: 'boolean',
       hidden: false, // Only show on root
@@ -367,7 +355,7 @@ ${isRootCommand && isTestingV1() ? '    Options' : '    Options'}${isRootCommand
 
     Examples
       $ ${name} --help
-${isRootCommand ? `      $ ${name} scan create` : ''}${isRootCommand ? `\n      $ ${name} package score npm left-pad` : ''}`,
+${isRootCommand ? `      $ ${name} scan create --json` : ''}${isRootCommand ? `\n      $ ${name} package score npm left-pad --markdown` : ''}`,
     {
       argv,
       importMeta,
@@ -383,7 +371,7 @@ ${isRootCommand ? `      $ ${name} scan create` : ''}${isRootCommand ? `\n      
   )
 
   // ...else we provide basic instructions and help.
-  if (!cli2.flags['silent']) {
+  if (!cli2.flags['nobanner']) {
     emitBanner(name)
   }
   if (!cli2.flags['help'] && cli2.flags['dryRun']) {
@@ -428,7 +416,7 @@ export function meowOrExit({
     autoHelp: false, // meow will exit(0) before printing the banner
   })
 
-  if (!cli.flags['silent']) {
+  if (!cli.flags['nobanner']) {
     emitBanner(command)
   }
 


### PR DESCRIPTION
Hm forgot to make this a PR.

This adds a bunch of aliases for commands, shorthands that make sense like "orgs" for "organization", but also British spelling like "organisation".

Mostly a first pass. We might improve later with detecting spelling mistakes or whatever. Some word distance magic.