### PR TITLE
Add `socket json` to dump the json file to stdout

### DIFF
--- a/src/cli.mts
+++ b/src/cli.mts
@@ -18,6 +18,7 @@ import { cmdDiffScan } from './commands/diff-scan/cmd-diff-scan.mts'
 import { cmdFix } from './commands/fix/cmd-fix.mts'
 import { cmdInfo } from './commands/info/cmd-info.mts'
 import { cmdInstall } from './commands/install/cmd-install.mts'
+import { cmdJson } from './commands/json/cmd-json.mts'
 import { cmdLogin } from './commands/login/cmd-login.mts'
 import { cmdLogout } from './commands/logout/cmd-logout.mts'
 import { cmdManifest } from './commands/manifest/cmd-manifest.mts'
@@ -64,6 +65,7 @@ void (async () => {
         fix: cmdFix,
         info: cmdInfo,
         install: cmdInstall,
+        json: cmdJson,
         login: cmdLogin,
         logout: cmdLogout,
         npm: cmdNpm,

--- a/src/commands/json/cmd-json.mts
+++ b/src/commands/json/cmd-json.mts
@@ -1,0 +1,77 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { logger } from '@socketsecurity/registry/lib/logger'
+
+import constants from '../../constants.mts'
+import { commonFlags } from '../../flags.mts'
+import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
+import { tildify } from '../../utils/tildify.mts'
+
+import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
+
+const config: CliCommandConfig = {
+  commandName: 'json',
+  description:
+    'Display the `socket.json` that would be applied for target folder',
+  hidden: true, // This is a power tool. No need to clutter the toplevel.
+  flags: {
+    ...commonFlags,
+  },
+  help: parentName => `
+    Usage
+      $ ${parentName} [CWD=.]
+
+    Display the \`socket.json\` file that would apply when running relevant commands
+    in the target directory.
+  `,
+}
+
+export const cmdJson = {
+  description: config.description,
+  hidden: config.hidden,
+  run,
+}
+
+async function run(
+  argv: string[] | readonly string[],
+  importMeta: ImportMeta,
+  { parentName }: { parentName: string },
+): Promise<void> {
+  const cli = meowOrExit({
+    argv,
+    config,
+    importMeta,
+    parentName,
+  })
+
+  let [cwd = '.'] = cli.input
+  // Note: path.resolve vs .join:
+  // If given path is absolute then cwd should not affect it.
+  cwd = path.resolve(process.cwd(), cwd)
+
+  logger.info('Target cwd:', constants.ENV.VITEST ? '<redacted>' : tildify(cwd))
+
+  const sjpath = path.join(cwd, 'socket.json')
+  const tildeSjpath = constants.ENV.VITEST ? '<redacted>' : tildify(sjpath)
+
+  if (!fs.existsSync(sjpath)) {
+    logger.fail(`Not found: ${tildeSjpath}`)
+    process.exitCode = 1
+    return
+  }
+
+  if (!fs.lstatSync(sjpath).isFile()) {
+    logger.fail(
+      `This is not a regular file (maybe a directory?): ${tildeSjpath}`,
+    )
+    process.exitCode = 1
+    return
+  }
+
+  const data = fs.readFileSync(sjpath, 'utf8')
+
+  logger.success(`This is the contents of ${tildeSjpath}:`)
+  logger.error('')
+  logger.log(data)
+}

--- a/src/commands/json/cmd-json.mts
+++ b/src/commands/json/cmd-json.mts
@@ -1,12 +1,8 @@
-import fs from 'node:fs'
 import path from 'node:path'
 
-import { logger } from '@socketsecurity/registry/lib/logger'
-
-import constants from '../../constants.mts'
+import { handleCmdJson } from './handle-cmd-json.mts'
 import { commonFlags } from '../../flags.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
-import { tildify } from '../../utils/tildify.mts'
 
 import type { CliCommandConfig } from '../../utils/meow-with-subcommands.mts'
 
@@ -50,28 +46,5 @@ async function run(
   // If given path is absolute then cwd should not affect it.
   cwd = path.resolve(process.cwd(), cwd)
 
-  logger.info('Target cwd:', constants.ENV.VITEST ? '<redacted>' : tildify(cwd))
-
-  const sjpath = path.join(cwd, 'socket.json')
-  const tildeSjpath = constants.ENV.VITEST ? '<redacted>' : tildify(sjpath)
-
-  if (!fs.existsSync(sjpath)) {
-    logger.fail(`Not found: ${tildeSjpath}`)
-    process.exitCode = 1
-    return
-  }
-
-  if (!fs.lstatSync(sjpath).isFile()) {
-    logger.fail(
-      `This is not a regular file (maybe a directory?): ${tildeSjpath}`,
-    )
-    process.exitCode = 1
-    return
-  }
-
-  const data = fs.readFileSync(sjpath, 'utf8')
-
-  logger.success(`This is the contents of ${tildeSjpath}:`)
-  logger.error('')
-  logger.log(data)
+  await handleCmdJson(cwd)
 }

--- a/src/commands/json/cmd-json.test.mts
+++ b/src/commands/json/cmd-json.test.mts
@@ -112,7 +112,7 @@ describe('socket json', async () => {
     'should print a socket.json when found',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(binCliPath, cmd)
-      expect(stdout).toMatchInlineSnapshot(`
+      expect(stdout.replace(/\r\n/g, '\n')).toMatchInlineSnapshot(`
         "{
           " _____         _       _     ": "Local config file for Socket CLI tool ( https://npmjs.org/socket ), to work with https://socket.dev",
           "|   __|___ ___| |_ ___| |_   ": "     The config in this file is used to set as defaults for flags or cmmand args when using the CLI",

--- a/src/commands/json/cmd-json.test.mts
+++ b/src/commands/json/cmd-json.test.mts
@@ -112,7 +112,7 @@ describe('socket json', async () => {
     'should print a socket.json when found',
     async cmd => {
       const { code, stderr, stdout } = await invokeNpm(binCliPath, cmd)
-      expect(stdout.replace(/\r\n/g, '\n')).toMatchInlineSnapshot(`
+      expect(stdout.replace(/\r/g, '')).toMatchInlineSnapshot(`
         "{
           " _____         _       _     ": "Local config file for Socket CLI tool ( https://npmjs.org/socket ), to work with https://socket.dev",
           "|   __|___ ___| |_ ___| |_   ": "     The config in this file is used to set as defaults for flags or cmmand args when using the CLI",

--- a/src/commands/json/cmd-json.test.mts
+++ b/src/commands/json/cmd-json.test.mts
@@ -1,0 +1,148 @@
+import path from 'node:path'
+
+import { describe, expect } from 'vitest'
+
+import constants from '../../../src/constants.mts'
+import { cmdit, invokeNpm } from '../../../test/utils.mts'
+
+describe('socket json', async () => {
+  // Lazily access constants.binCliPath.
+  const { binCliPath } = constants
+
+  cmdit(
+    ['json', '--help', '--config', '{}'],
+    'should support --help',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(binCliPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(
+        `
+        "Display the \`socket.json\` that would be applied for target folder
+
+          Usage
+            $ socket json [CWD=.]
+
+          Display the \`socket.json\` file that would apply when running relevant commands
+          in the target directory."
+      `,
+      )
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket json\`, cwd: <redacted>"
+      `)
+
+      expect(code, 'explicit help should exit with code 0').toBe(0)
+      expect(stderr, 'banner includes base command').toContain('`socket json`')
+    },
+  )
+
+  cmdit(
+    ['json', '--dry-run', '--config', '{"apiToken":"anything"}'],
+    'should require args with just dry-run',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(binCliPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket json\`, cwd: <redacted>
+
+        \\x1b[34mi\\x1b[39m Target cwd: <redacted>
+        \\x1b[31m\\xd7\\x1b[39m Not found: <redacted>"
+      `)
+
+      expect(code, 'not found is failure').toBe(1)
+    },
+  )
+
+  cmdit(
+    ['json', '.', '--dry-run', '--config', '{"apiToken":"anything"}'],
+    'should print error when file does not exist in folder',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(binCliPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket json\`, cwd: <redacted>
+
+        \\x1b[34mi\\x1b[39m Target cwd: <redacted>
+        \\x1b[31m\\xd7\\x1b[39m Not found: <redacted>"
+      `)
+
+      expect(code, 'not found is failure').toBe(1)
+    },
+  )
+
+  cmdit(
+    [
+      'json',
+      './doesnotexist',
+      '--dry-run',
+      '--config',
+      '{"apiToken":"anything"}',
+    ],
+    'should print an error when the path to file does not exist',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(binCliPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`""`)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket json\`, cwd: <redacted>
+
+        \\x1b[34mi\\x1b[39m Target cwd: <redacted>
+        \\x1b[31m\\xd7\\x1b[39m Not found: <redacted>"
+      `)
+
+      expect(code, 'not found is failure').toBe(1)
+    },
+  )
+
+  cmdit(
+    ['json', './sjtest', '--dry-run', '--config', '{"apiToken":"anything"}'],
+    'should print a socket.json when found',
+    async cmd => {
+      const { code, stderr, stdout } = await invokeNpm(binCliPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`
+        "{
+          " _____         _       _     ": "Local config file for Socket CLI tool ( https://npmjs.org/socket ), to work with https://socket.dev",
+          "|   __|___ ___| |_ ___| |_   ": "     The config in this file is used to set as defaults for flags or cmmand args when using the CLI",
+          "|__   | . |  _| '_| -_|  _|  ": "     in this dir, often a repo root. You can choose commit or .ignore this file, both works.",
+          "|_____|___|___|_,_|___|_|.dev": "Warning: This file may be overwritten without warning by \`socket manifest setup\` or other commands",
+          "version": 1,
+          "defaults": {
+            "manifest": {
+              "sbt": {
+                "bin": "/bin/sbt",
+                "outfile": "sbt.pom.xml",
+                "stdout": false,
+                "verbose": true
+              }
+            }
+          }
+        }"
+      `)
+      expect(`\n   ${stderr}`).toMatchInlineSnapshot(`
+        "
+           _____         _       _        /---------------
+          |   __|___ ___| |_ ___| |_      | Socket.dev CLI ver <redacted>
+          |__   | * |  _| '_| -_|  _|     | Node: <redacted>, API token set: <redacted>
+          |_____|___|___|_,_|___|_|.dev   | Command: \`socket json\`, cwd: <redacted>
+
+        \\x1b[34mi\\x1b[39m Target cwd: <redacted>
+        \\x1b[32m\\u221a\\x1b[39m This is the contents of <redacted>:"
+      `)
+
+      expect(code, 'found is ok').toBe(0)
+    },
+  )
+})

--- a/src/commands/json/handle-cmd-json.mts
+++ b/src/commands/json/handle-cmd-json.mts
@@ -1,0 +1,5 @@
+import { outputCmdJson } from './output-cmd-json.mts'
+
+export async function handleCmdJson(cwd: string) {
+  await outputCmdJson(cwd)
+}

--- a/src/commands/json/output-cmd-json.mts
+++ b/src/commands/json/output-cmd-json.mts
@@ -1,0 +1,34 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { logger } from '@socketsecurity/registry/lib/logger'
+
+import constants from '../../constants.mts'
+import { tildify } from '../../utils/tildify.mts'
+
+export async function outputCmdJson(cwd: string) {
+  logger.info('Target cwd:', constants.ENV.VITEST ? '<redacted>' : tildify(cwd))
+
+  const sjpath = path.join(cwd, 'socket.json')
+  const tildeSjpath = constants.ENV.VITEST ? '<redacted>' : tildify(sjpath)
+
+  if (!fs.existsSync(sjpath)) {
+    logger.fail(`Not found: ${tildeSjpath}`)
+    process.exitCode = 1
+    return
+  }
+
+  if (!fs.lstatSync(sjpath).isFile()) {
+    logger.fail(
+      `This is not a regular file (maybe a directory?): ${tildeSjpath}`,
+    )
+    process.exitCode = 1
+    return
+  }
+
+  const data = fs.readFileSync(sjpath, 'utf8')
+
+  logger.success(`This is the contents of ${tildeSjpath}:`)
+  logger.error('')
+  logger.log(data)
+}

--- a/src/utils/meow-with-subcommands.mts
+++ b/src/utils/meow-with-subcommands.mts
@@ -1,5 +1,3 @@
-import path from 'node:path'
-
 import meow from 'meow'
 import semver from 'semver'
 import colors from 'yoctocolors-cjs'
@@ -7,7 +5,6 @@ import colors from 'yoctocolors-cjs'
 import { logger } from '@socketsecurity/registry/lib/logger'
 import { toSortedObject } from '@socketsecurity/registry/lib/objects'
 import { normalizePath } from '@socketsecurity/registry/lib/path'
-import { escapeRegExp } from '@socketsecurity/registry/lib/regexps'
 
 import {
   getConfigValueOrUndef,
@@ -20,6 +17,7 @@ import { getFlagListOutput, getHelpListOutput } from './output-formatting.mts'
 import constants from '../constants.mts'
 import { commonFlags } from '../flags.mts'
 import { getVisibleTokenPrefix } from './sdk.mts'
+import { tildify } from './tildify.mts'
 
 import type { MeowFlags } from '../flags.mts'
 import type { Options, Result } from 'meow'
@@ -496,19 +494,7 @@ function getAsciiHeader(command: string) {
       )
     : ''
   const shownToken = redacting ? REDACTED : getVisibleTokenPrefix() || 'no'
-  const relCwd = redacting
-    ? REDACTED
-    : normalizePath(
-        process
-          .cwd()
-          .replace(
-            new RegExp(
-              `^${escapeRegExp(constants.homePath)}(?:${path.sep}|$)`,
-              'i',
-            ),
-            '~/',
-          ),
-      )
+  const relCwd = redacting ? REDACTED : normalizePath(tildify(process.cwd()))
   let nodeVerWarn = ''
   if (semver.parse(constants.NODE_VERSION)!.major < 20) {
     nodeVerWarn += colors.bold(

--- a/src/utils/tildify.mts
+++ b/src/utils/tildify.mts
@@ -1,0 +1,14 @@
+import path from 'node:path'
+
+import { escapeRegExp } from '@socketsecurity/registry/lib/regexps'
+
+import constants from '../constants.mts'
+
+// Replace the start of a path with ~/ when it starts with your home dir.
+// A common way to abbreviate the user home dir (though not strictly posix).
+export function tildify(cwd: string) {
+  return cwd.replace(
+    new RegExp(`^${escapeRegExp(constants.homePath)}(?:${path.sep}|$)`, 'i'),
+    '~/',
+  )
+}

--- a/test/socket-npm-fixtures/sjtest/socket.json
+++ b/test/socket-npm-fixtures/sjtest/socket.json
@@ -1,0 +1,17 @@
+{
+  " _____         _       _     ": "Local config file for Socket CLI tool ( https://npmjs.org/socket ), to work with https://socket.dev",
+  "|   __|___ ___| |_ ___| |_   ": "     The config in this file is used to set as defaults for flags or cmmand args when using the CLI",
+  "|__   | . |  _| '_| -_|  _|  ": "     in this dir, often a repo root. You can choose commit or .ignore this file, both works.",
+  "|_____|___|___|_,_|___|_|.dev": "Warning: This file may be overwritten without warning by `socket manifest setup` or other commands",
+  "version": 1,
+  "defaults": {
+    "manifest": {
+      "sbt": {
+        "bin": "/bin/sbt",
+        "outfile": "sbt.pom.xml",
+        "stdout": false,
+        "verbose": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds `socket json [dir=.]` which will print the `socket.json` file that would be used if a supporting command worked on that directory.

We'll probably bring this under some subcommand sooner or later but for now we'll just hide it.
