### PR TITLE
Uncaught json

### DIFF
--- a/src/cli.mts
+++ b/src/cli.mts
@@ -2,10 +2,11 @@
 
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
+import meow from 'meow'
 import { messageWithCauses, stackWithCauses } from 'pony-cause'
 import updateNotifier from 'tiny-updater'
 
-import { debugLog } from '@socketsecurity/registry/lib/debug'
+import { debugFn, debugLog } from '@socketsecurity/registry/lib/debug'
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { cmdAnalytics } from './commands/analytics/cmd-analytics.mts'
@@ -41,6 +42,7 @@ import constants from './constants.mts'
 import { AuthError, InputError, captureException } from './utils/errors.mts'
 import { failMsgWithBadge } from './utils/fail-msg-with-badge.mts'
 import { meowWithSubcommands } from './utils/meow-with-subcommands.mts'
+import { serializeResultJson } from './utils/serialize-result-json.mts'
 
 const __filename = fileURLToPath(import.meta.url)
 
@@ -171,6 +173,23 @@ void (async () => {
     )
   } catch (e) {
     process.exitCode = 1
+    debugFn('Uncaught error (BAD!):')
+    debugFn(e)
+
+    // Try to parse the flags, find out if --json or --markdown is set
+    let isJson = false
+    try {
+      const cli = meow(``, {
+        argv: process.argv.slice(2),
+        importMeta: { url: `${pathToFileURL(__filename)}` } as ImportMeta,
+        flags: {},
+        // Do not strictly check for flags here.
+        allowUnknownFlags: true,
+        autoHelp: false,
+      })
+      isJson = !!cli.flags['json']
+    } catch {}
+
     let errorBody: string | undefined
     let errorTitle: string
     let errorMessage = ''
@@ -188,12 +207,24 @@ void (async () => {
     } else {
       errorTitle = 'Unexpected error with no details'
     }
-    logger.error('\n') // Any-spinner-newline
-    logger.fail(failMsgWithBadge(errorTitle, errorMessage))
-    if (errorBody) {
-      // Explicitly use debugLog here.
-      debugLog(errorBody)
+
+    if (isJson) {
+      logger.log(
+        serializeResultJson({
+          ok: false,
+          message: errorTitle,
+          cause: errorMessage,
+        }),
+      )
+    } else {
+      logger.error('\n') // Any-spinner-newline
+      logger.fail(failMsgWithBadge(errorTitle, errorMessage))
+      if (errorBody) {
+        // Explicitly use debugLog here.
+        debugLog(errorBody)
+      }
     }
+
     await captureException(e)
   }
 })()

--- a/src/commands/oops/cmd-oops.mts
+++ b/src/commands/oops/cmd-oops.mts
@@ -17,6 +17,12 @@ const config: CliCommandConfig = {
   flags: {
     ...commonFlags,
     ...outputFlags,
+    throw: {
+      type: 'boolean',
+      default: false,
+      description:
+        'Throw an explicit error even if --json or --markdown are set',
+    },
   },
   help: (parentName, config) => `
     Usage
@@ -44,14 +50,14 @@ async function run(
     parentName,
   })
 
-  const { json, markdown } = cli.flags
+  const { json, markdown, throw: justThrow } = cli.flags
 
   if (cli.flags['dryRun']) {
     logger.log(DRY_RUN_BAILING_NOW)
     return
   }
 
-  if (json) {
+  if (json && !justThrow) {
     process.exitCode = 1
     logger.log(
       serializeResultJson({
@@ -62,7 +68,7 @@ async function run(
     )
   }
 
-  if (markdown) {
+  if (markdown && !justThrow) {
     process.exitCode = 1
     logger.fail(
       failMsgWithBadge('Oops', 'This error was intentionally left blank'),


### PR DESCRIPTION
Improve how uncaught errors are presented to the user.

In particular, when the command uses a `--json` flag, try to respect it by emitting the CResult json rather than a plain text error message.