### PR TITLE
Add a shorthand for `socket <purl>` to get score

### DIFF
--- a/src/commands/cli.test.mts
+++ b/src/commands/cli.test.mts
@@ -80,39 +80,39 @@ describe('socket root command', async () => {
 
           Main commands
 
-            socket login             Setup the CLI with an API Token and defaults
-            socket scan create       Create a new Scan and report
-            socket package score     Request the (shallow) security score of a particular package
-            socket ci                Shorthand for CI; socket scan create --report --no-interactive
+            socket login              Setup the CLI with an API Token and defaults
+            socket scan create        Create a new Scan and report
+            socket npm/eslint@1.0.0   Request the security score of a particular package
+            socket ci                 Shorthand for CI; socket scan create --report --no-interactive
 
           Socket API
 
-            analytics                Look up analytics data
-            audit-log                Look up the audit log for an organization
-            organization             Manage organization account details
-            package                  Look up published package details
-            repository               Manage registered repositories
-            scan                     Manage Socket scans
-            threat-feed              [beta] View the threat feed
+            analytics                 Look up analytics data
+            audit-log                 Look up the audit log for an organization
+            organization              Manage organization account details
+            package                   Look up published package details
+            repository                Manage registered repositories
+            scan                      Manage Socket scans
+            threat-feed               [beta] View the threat feed
 
           Local tools
 
-            fix                      Update dependencies with "fixable" Socket alerts
-            manifest                 Generate a dependency manifest for certain languages
-            npm                      npm wrapper functionality
-            npx                      npx wrapper functionality
-            optimize                 Optimize dependencies with @socketregistry overrides
-            raw-npm                  Temporarily disable the Socket npm wrapper
-            raw-npx                  Temporarily disable the Socket npx wrapper
+            fix                       Update dependencies with "fixable" Socket alerts
+            manifest                  Generate a dependency manifest for certain languages
+            npm                       npm wrapper functionality
+            npx                       npx wrapper functionality
+            optimize                  Optimize dependencies with @socketregistry overrides
+            raw-npm                   Temporarily disable the Socket npm wrapper
+            raw-npx                   Temporarily disable the Socket npx wrapper
 
           CLI configuration
 
-            config                   Manage the CLI configuration directly
-            install                  Manually install CLI tab completion on your system
-            login                    Socket API login and CLI setup
-            logout                   Socket API logout
-            uninstall                Remove the CLI tab completion from your system
-            wrapper                  Enable or disable the Socket npm/npx wrapper
+            config                    Manage the CLI configuration directly
+            install                   Manually install CLI tab completion on your system
+            login                     Socket API login and CLI setup
+            logout                    Socket API logout
+            uninstall                 Remove the CLI tab completion from your system
+            wrapper                   Enable or disable the Socket npm/npx wrapper
 
           Options       (Note: all CLI commands have these flags even when not displayed in their help)
 

--- a/src/utils/meow-with-subcommands.mts
+++ b/src/utils/meow-with-subcommands.mts
@@ -99,6 +99,31 @@ export async function meowWithSubcommands(
     name === 'socket' &&
     (!commandOrAliasName || commandOrAliasName?.startsWith('-'))
 
+  // Try to support `socket <purl>` as a shorthand for `socket package score <purl>`
+  if (!isRootCommand) {
+    if (commandOrAliasName?.startsWith('pkg:')) {
+      logger.info('Note: Invoking `socket package score` now...')
+      return await meowWithSubcommands(subcommands, {
+        ...options,
+        argv: ['package', 'deep', ...argv],
+      })
+    }
+    // Support `socket npm/babel` or whatever as a shorthand, too.
+    // Accept any ecosystem and let the remote sort it out.
+    if (/^[a-z]+\//.test(commandOrAliasName || '')) {
+      logger.info('Note: Invoking `socket package score` now...')
+      return await meowWithSubcommands(subcommands, {
+        ...options,
+        argv: [
+          'package',
+          'deep',
+          `pkg:${commandOrAliasName}`,
+          ...rawCommandArgv,
+        ],
+      })
+    }
+  }
+
   if (isRootCommand) {
     flags['help'] = {
       type: 'boolean',
@@ -276,69 +301,71 @@ export async function meowWithSubcommands(
 
     const out = []
     out.push('All commands have their own --help page')
-    out.push('    ')
+    out.push('')
     out.push('    Main commands')
-    out.push('    ')
+    out.push('')
     out.push(
-      '      socket login             Setup the CLI with an API Token and defaults',
+      '      socket login              Setup the CLI with an API Token and defaults',
     )
-    out.push('      socket scan create       Create a new Scan and report')
+    out.push('      socket scan create        Create a new Scan and report')
     out.push(
-      '      socket package score     Request the (shallow) security score of a particular package',
+      '      socket npm/eslint@1.0.0   Request the security score of a particular package',
     )
     out.push(
-      '      socket ci                Shorthand for CI; socket scan create --report --no-interactive',
+      '      socket ci                 Shorthand for CI; socket scan create --report --no-interactive',
     )
-    out.push('    ')
+    out.push('')
     out.push('    Socket API')
-    out.push('    ')
-    out.push('      analytics                Look up analytics data')
+    out.push('')
+    out.push('      analytics                 Look up analytics data')
     out.push(
-      '      audit-log                Look up the audit log for an organization',
+      '      audit-log                 Look up the audit log for an organization',
     )
     out.push(
-      '      organization             Manage organization account details',
+      '      organization              Manage organization account details',
     )
-    out.push('      package                  Look up published package details')
-    out.push('      repository               Manage registered repositories')
-    out.push('      scan                     Manage Socket scans')
-    out.push('      threat-feed              [beta] View the threat feed')
-    out.push('    ')
+    out.push(
+      '      package                   Look up published package details',
+    )
+    out.push('      repository                Manage registered repositories')
+    out.push('      scan                      Manage Socket scans')
+    out.push('      threat-feed               [beta] View the threat feed')
+    out.push('')
     out.push('    Local tools')
-    out.push('    ')
+    out.push('')
     out.push(
-      '      fix                      Update dependencies with "fixable" Socket alerts',
+      '      fix                       Update dependencies with "fixable" Socket alerts',
     )
     out.push(
-      '      manifest                 Generate a dependency manifest for certain languages',
+      '      manifest                  Generate a dependency manifest for certain languages',
     )
-    out.push('      npm                      npm wrapper functionality')
-    out.push('      npx                      npx wrapper functionality')
+    out.push('      npm                       npm wrapper functionality')
+    out.push('      npx                       npx wrapper functionality')
     out.push(
-      '      optimize                 Optimize dependencies with @socketregistry overrides',
-    )
-    out.push(
-      '      raw-npm                  Temporarily disable the Socket npm wrapper',
+      '      optimize                  Optimize dependencies with @socketregistry overrides',
     )
     out.push(
-      '      raw-npx                  Temporarily disable the Socket npx wrapper',
+      '      raw-npm                   Temporarily disable the Socket npm wrapper',
     )
-    out.push('    ')
+    out.push(
+      '      raw-npx                   Temporarily disable the Socket npx wrapper',
+    )
+    out.push('')
     out.push('    CLI configuration')
-    out.push('    ')
+    out.push('')
     out.push(
-      '      config                   Manage the CLI configuration directly',
+      '      config                    Manage the CLI configuration directly',
     )
     out.push(
-      '      install                  Manually install CLI tab completion on your system',
+      '      install                   Manually install CLI tab completion on your system',
     )
-    out.push('      login                    Socket API login and CLI setup')
-    out.push('      logout                   Socket API logout')
+    out.push('      login                     Socket API login and CLI setup')
+    out.push('      logout                    Socket API logout')
     out.push(
-      '      uninstall                Remove the CLI tab completion from your system',
+      '      uninstall                 Remove the CLI tab completion from your system',
     )
     out.push(
-      '      wrapper                  Enable or disable the Socket npm/npx wrapper',
+      '      wrapper                   Enable or disable the Socket npm/npx wrapper',
     )
 
     return out.join('\n')


### PR DESCRIPTION
Added support for a shorthand for getting package score:

```
socket pkg:npm/babel
```

The `pkg:` is optional too, if the second arg is anything that starts with a-z followed by a forward slash then it will automatically run `socket package score <...args>` on it.

If you omit the `pkg:` then the CLI will prefix it for you, which is what `socket package` already does.
