### PR TITLE
Fix scan github not ensuring dirs exist

### DIFF
--- a/src/commands/scan/create-scan-from-github.mts
+++ b/src/commands/scan/create-scan-from-github.mts
@@ -467,6 +467,13 @@ async function streamDownloadWithFetch(
       }
     }
 
+    // Make sure the dir exists. It may be nested and we need to construct that
+    // before starting the download.
+    const dir = path.dirname(localPath)
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true })
+    }
+
     const fileStream = fs.createWriteStream(localPath)
 
     // Using stream.pipeline for better error handling and cleanup


### PR DESCRIPTION
The nested dirs didn't exist so the download failed because it couldn't store the files in the desired target.