### PR TITLE
Bump override for undici

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16652,9 +16652,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
+      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "side-channel": "npm:@socketregistry/side-channel@^1",
     "tiny-colors": "$yoctocolors-cjs",
     "typedarray": "npm:@socketregistry/typedarray@^1",
-    "undici": "6.21.1",
+    "undici": "6.21.2",
     "vite": "6.3.5",
     "xml2js": "0.5.0",
     "yaml": "2.8.0"


### PR DESCRIPTION
There's a vuln in .1 , bump to .2 looks non-breaking so let's do it.

![image](https://github.com/user-attachments/assets/5a931ab8-074e-4e37-9a1b-e80c2d1b5c39)
