### PR TITLE
Threat-feed; use new api endpoint, add search flags

### DIFF
--- a/src/commands/threat-feed/cmd-threat-feed.mts
+++ b/src/commands/threat-feed/cmd-threat-feed.mts
@@ -22,29 +22,6 @@ const config: CliCommandConfig = {
   flags: {
     ...commonFlags,
     ...outputFlags,
-    interactive: {
-      type: 'boolean',
-      default: true,
-      description:
-        'Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.',
-    },
-    org: {
-      type: 'string',
-      description:
-        'Force override the organization slug, overrides the default org from config',
-    },
-    perPage: {
-      type: 'number',
-      shortFlag: 'pp',
-      default: 30,
-      description: 'Number of items per page',
-    },
-    page: {
-      type: 'string',
-      shortFlag: 'p',
-      default: '1',
-      description: 'Page token',
-    },
     direction: {
       type: 'string',
       shortFlag: 'd',
@@ -62,6 +39,37 @@ const config: CliCommandConfig = {
       shortFlag: 'f',
       default: 'mal',
       description: 'Filter what type of threats to return',
+    },
+    interactive: {
+      type: 'boolean',
+      default: true,
+      description:
+        'Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.',
+    },
+    org: {
+      type: 'string',
+      description:
+        'Force override the organization slug, overrides the default org from config',
+    },
+    page: {
+      type: 'string',
+      shortFlag: 'p',
+      default: '1',
+      description: 'Page token',
+    },
+    perPage: {
+      type: 'number',
+      shortFlag: 'pp',
+      default: 30,
+      description: 'Number of items per page',
+    },
+    pkg: {
+      type: 'string',
+      description: 'Filter by this package name',
+    },
+    version: {
+      type: 'string',
+      description: 'Filter by this package version',
     },
   },
   help: (command, config) => `
@@ -102,6 +110,11 @@ const config: CliCommandConfig = {
       - nuget
       - pypi
 
+    Note: if you filter by package name or version, it will do so for anything
+          unless you also filter by that ecosystem and/or package name. When in
+          doubt, look at the threat-feed and see the names in the name/version
+          column. That's what you want to search for.
+
     Examples
       $ ${command}${isTestingV1() ? '' : ' FakeOrg'}
       $ ${command}${isTestingV1() ? '' : ' FakeOrg'} --perPage=5 --page=2 --direction=asc --filter=joke
@@ -126,7 +139,15 @@ async function run(
     parentName,
   })
 
-  const { dryRun, interactive, json, markdown, org: orgFlag } = cli.flags
+  const {
+    dryRun,
+    interactive,
+    json,
+    markdown,
+    org: orgFlag,
+    pkg,
+    version,
+  } = cli.flags
   const outputKind = getOutputKind(json, markdown)
 
   const [orgSlug] = await determineOrgSlug(
@@ -177,7 +198,10 @@ async function run(
     ecosystem: String(cli.flags['eco'] || ''),
     filter: String(cli.flags['filter'] || 'mal'),
     outputKind,
+    orgSlug,
     page: String(cli.flags['page'] || '1'),
     perPage: Number(cli.flags['perPage']) || 30,
+    pkg: String(pkg || ''),
+    version: String(version || ''),
   })
 }

--- a/src/commands/threat-feed/cmd-threat-feed.test.mts
+++ b/src/commands/threat-feed/cmd-threat-feed.test.mts
@@ -39,6 +39,8 @@ describe('socket threat-feed', async () => {
             --org             Force override the organization slug, overrides the default org from config
             --page            Page token
             --perPage         Number of items per page
+            --pkg             Filter by this package name
+            --version         Filter by this package version
 
           Valid filters:
 
@@ -62,6 +64,11 @@ describe('socket threat-feed', async () => {
             - npm
             - nuget
             - pypi
+
+          Note: if you filter by package name or version, it will do so for anything
+                unless you also filter by that ecosystem and/or package name. When in
+                doubt, look at the threat-feed and see the names in the name/version
+                column. That's what you want to search for.
 
           Examples
             $ socket threat-feed FakeOrg

--- a/src/commands/threat-feed/fetch-threat-feed.mts
+++ b/src/commands/threat-feed/fetch-threat-feed.mts
@@ -7,25 +7,33 @@ export async function fetchThreatFeed({
   direction,
   ecosystem,
   filter,
+  orgSlug,
   page,
   perPage,
+  pkg,
+  version,
 }: {
   direction: string
   ecosystem: string
   filter: string
+  orgSlug: string
   page: string
   perPage: number
+  pkg: string
+  version: string
 }): Promise<CResult<ThreadFeedResponse>> {
   const queryParams = new URLSearchParams([
     ['direction', direction],
     ['ecosystem', ecosystem],
-    ['filter', filter],
-    ['page', page],
+    filter ? ['filter', filter] : ['', ''],
+    ['page_cursor', page],
     ['per_page', String(perPage)],
+    pkg ? ['name', pkg] : ['', ''],
+    version ? ['version', version] : ['', ''],
   ])
 
   return await queryApiSafeJson(
-    `threat-feed?${queryParams}`,
+    `orgs/${orgSlug}/threat-feed?${queryParams}`,
     'the Threat Feed data',
   )
 }

--- a/src/commands/threat-feed/handle-threat-feed.mts
+++ b/src/commands/threat-feed/handle-threat-feed.mts
@@ -7,23 +7,32 @@ export async function handleThreatFeed({
   direction,
   ecosystem,
   filter,
+  orgSlug,
   outputKind,
   page,
   perPage,
+  pkg,
+  version,
 }: {
   direction: string
   ecosystem: string
   filter: string
   outputKind: OutputKind
+  orgSlug: string
   page: string
   perPage: number
+  pkg: string
+  version: string
 }): Promise<void> {
   const data = await fetchThreatFeed({
     direction,
     ecosystem,
     filter,
+    orgSlug,
     page,
     perPage,
+    pkg,
+    version,
   })
 
   await outputThreatFeed(data, outputKind)


### PR DESCRIPTION
This updates the threat-feed:

- switches over to the new org scoped threat-feed API endpoint (no real changes in CLI for that)
- adds support for filtering results by package name or version
- fixed an issue where having an empty default filter would result in the server rejecting it