### PR TITLE
Fix fix command when server rejects request

### DIFF
--- a/src/utils/alerts-map.mts
+++ b/src/utils/alerts-map.mts
@@ -1,8 +1,11 @@
 import { arrayUnique } from '@socketsecurity/registry/lib/arrays'
+import { debugFn } from '@socketsecurity/registry/lib/debug'
+import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { extractPurlsFromPnpmLockfile } from './pnpm.mts'
 import { getPublicToken, setupSdk } from './sdk.mts'
 import { addArtifactToAlertsMap } from './socket-package-alert.mts'
+import constants from '../constants.mts'
 
 import type { CompactSocketArtifact } from './alert/artifact.mts'
 import type {
@@ -11,6 +14,7 @@ import type {
 } from './socket-package-alert.mts'
 import type { LockfileObject } from '@pnpm/lockfile.fs'
 import type { Spinner } from '@socketsecurity/registry/lib/spinner'
+
 
 export type GetAlertsMapFromPnpmLockfileOptions = {
   consolidate?: boolean | undefined
@@ -117,6 +121,19 @@ export async function getAlertsMapFromPurls(
       throw new Error(
         `Socket API server error (${statusCode}): ${statusMessage}`,
       )
+    } else {
+      if (batchResult.status >= 300 && batchResult.status !== 400) {
+        const { spinner } = constants
+        spinner.stop()
+        debugFn('Received a result=false:', batchResult)
+        logger.fail(
+          `Received a ${batchResult.status} response from Socket API which we consider a permanent failure:`,
+          batchResult.error,
+          batchResult.cause ? `( ${batchResult.cause} )` : '',
+        )
+        break
+      }
+      debugFn('Received a result=false:', batchResult)
     }
     remaining -= 1
     if (spinner && remaining > 0) {


### PR DESCRIPTION
This requires https://github.com/SocketDev/socket-sdk-js/pull/325

That fix propagates an error response, which is returned as the generator's final (done:true) value. But this value was always ignored.

This PR will pick up the response and even when nothrow is set, when the response is 401 or 404 it will consider it a permanent failure.

(I think it should do this regardless but I'll leave that up to @jdalton to refine)