### PR TITLE
When selecting org, ask to persist it

### DIFF
--- a/src/commands/config/cmd-config-auto.test.mts
+++ b/src/commands/config/cmd-config-auto.test.mts
@@ -32,6 +32,7 @@ describe('socket config auto', async () => {
            - apiToken -- The API token required to access most API endpoints
            - defaultOrg -- The default org slug to use; usually the org your API token has access to. When set, all orgSlug arguments are implied to be this value.
            - enforcedOrgs -- Orgs in this list have their security policies enforced on this machine
+           - skipAskToPersistDefaultOrg -- This flag prevents the CLI from asking you to persist the org slug when you selected one interactively
            - org -- Alias for defaultOrg
 
           For certain keys it will request the value from server, for others it will
@@ -44,6 +45,7 @@ describe('socket config auto', async () => {
            - apiToken -- The API token required to access most API endpoints
            - defaultOrg -- The default org slug to use; usually the org your API token has access to. When set, all orgSlug arguments are implied to be this value.
            - enforcedOrgs -- Orgs in this list have their security policies enforced on this machine
+           - skipAskToPersistDefaultOrg -- This flag prevents the CLI from asking you to persist the org slug when you selected one interactively
            - org -- Alias for defaultOrg
 
           Examples

--- a/src/commands/config/cmd-config-get.test.mts
+++ b/src/commands/config/cmd-config-get.test.mts
@@ -34,6 +34,7 @@ describe('socket config get', async () => {
            - apiToken -- The API token required to access most API endpoints
            - defaultOrg -- The default org slug to use; usually the org your API token has access to. When set, all orgSlug arguments are implied to be this value.
            - enforcedOrgs -- Orgs in this list have their security policies enforced on this machine
+           - skipAskToPersistDefaultOrg -- This flag prevents the CLI from asking you to persist the org slug when you selected one interactively
            - org -- Alias for defaultOrg
 
           Examples

--- a/src/commands/config/cmd-config-set.test.mts
+++ b/src/commands/config/cmd-config-set.test.mts
@@ -41,6 +41,7 @@ describe('socket config get', async () => {
            - apiToken -- The API token required to access most API endpoints
            - defaultOrg -- The default org slug to use; usually the org your API token has access to. When set, all orgSlug arguments are implied to be this value.
            - enforcedOrgs -- Orgs in this list have their security policies enforced on this machine
+           - skipAskToPersistDefaultOrg -- This flag prevents the CLI from asking you to persist the org slug when you selected one interactively
            - org -- Alias for defaultOrg
 
           Examples

--- a/src/commands/config/cmd-config-unset.test.mts
+++ b/src/commands/config/cmd-config-unset.test.mts
@@ -35,6 +35,7 @@ describe('socket config unset', async () => {
            - apiToken -- The API token required to access most API endpoints
            - defaultOrg -- The default org slug to use; usually the org your API token has access to. When set, all orgSlug arguments are implied to be this value.
            - enforcedOrgs -- Orgs in this list have their security policies enforced on this machine
+           - skipAskToPersistDefaultOrg -- This flag prevents the CLI from asking you to persist the org slug when you selected one interactively
            - org -- Alias for defaultOrg
 
           Examples

--- a/src/commands/repository/output-list-repos.mts
+++ b/src/commands/repository/output-list-repos.mts
@@ -67,7 +67,9 @@ export async function outputListRepos(
     logger.info(
       `This is page ${page}. Server indicated there are more results available on page ${nextPage}...`,
     )
-    logger.info(`(Hint: you can use \`socket repos list --page ${nextPage}\`)`)
+    logger.info(
+      `(Hint: you can use \`socket repository list --page ${nextPage}\`)`,
+    )
   } else if (perPage === Infinity) {
     logger.info(`This should be the entire list available on the server.`)
   } else {

--- a/src/commands/scan/cmd-scan-create.mts
+++ b/src/commands/scan/cmd-scan-create.mts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleCreateNewScan } from './handle-create-new-scan.mts'
-import { outputCreateNewScan } from './output-create-new-scan.mjs'
+import { outputCreateNewScan } from './output-create-new-scan.mts'
 import { suggestOrgSlug } from './suggest-org-slug.mts'
 import { suggestTarget } from './suggest_target.mts'
 import constants from '../../constants.mts'

--- a/src/commands/scan/cmd-scan-github.mts
+++ b/src/commands/scan/cmd-scan-github.mts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { handleCreateGithubScan } from './handle-create-github-scan.mts'
-import { outputScanGithub } from './output-scan-github.mjs'
+import { outputScanGithub } from './output-scan-github.mts'
 import { suggestOrgSlug } from './suggest-org-slug.mts'
 import constants from '../../constants.mts'
 import { commonFlags, outputFlags } from '../../flags.mts'

--- a/src/commands/scan/suggest-to-persist-orgslug.mts
+++ b/src/commands/scan/suggest-to-persist-orgslug.mts
@@ -1,0 +1,54 @@
+import { logger } from '@socketsecurity/registry/lib/logger'
+import { select } from '@socketsecurity/registry/lib/prompts'
+
+import { getConfigValue, updateConfigValue } from '../../utils/config.mts'
+
+export async function suggestToPersistOrgSlug(orgSlug: string): Promise<void> {
+  const skipAsk = getConfigValue('skipAskToPersistDefaultOrg')
+  if (!skipAsk.ok || skipAsk.data) {
+    // Don't ask to store it when disabled before, or when reading config fails.
+    return
+  }
+
+  const result = await select<string>({
+    message: `Would you like to use this org (${orgSlug}) as the default org for future calls?`,
+    choices: [
+      {
+        name: 'Yes',
+        value: 'yes',
+        description: 'Stores it in your config',
+      },
+      {
+        name: 'No',
+        value: 'no',
+        description: 'Do not persist this org as default org',
+      },
+      {
+        name: "No and don't ask again",
+        value: 'sush',
+        description:
+          'Do not store as default org and do not ask again to persist it',
+      },
+    ],
+  })
+  if (result === 'yes') {
+    const updateResult = updateConfigValue('defaultOrg', orgSlug)
+    if (updateResult.ok) {
+      logger.success('Updated default org config to:', orgSlug)
+    } else {
+      logger.fail(
+        '(Non blocking) Failed to update default org in config:',
+        updateResult.cause,
+      )
+    }
+  } else if (result === 'sush') {
+    const updateResult = updateConfigValue('skipAskToPersistDefaultOrg', true)
+    if (updateResult.ok) {
+      logger.info('Default org not changed. Will not ask to persist again.')
+    } else {
+      logger.fail(
+        `(Non blocking) Failed to store preference; will ask to persist again next time. Reason: ${updateResult.cause}`,
+      )
+    }
+  }
+}

--- a/src/utils/determine-org-slug.mts
+++ b/src/utils/determine-org-slug.mts
@@ -2,6 +2,7 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { getConfigValueOrUndef } from './config.mts'
 import { suggestOrgSlug } from '../commands/scan/suggest-org-slug.mts'
+import { suggestToPersistOrgSlug } from '../commands/scan/suggest-to-persist-orgslug.mts'
 
 export async function determineOrgSlug(
   orgFlag: string,
@@ -55,6 +56,10 @@ export async function determineOrgSlug(
       logger.fail('Skipping auto-discovery of org in dry-run mode')
     } else {
       orgSlug = (await suggestOrgSlug()) || ''
+
+      if (orgSlug) {
+        await suggestToPersistOrgSlug(orgSlug)
+      }
     }
   }
 


### PR DESCRIPTION
This streamlines the flow where if you don't have a default org set, the CLI will interactively ask you to select one.

After selecting the org it will ask you if you want to store this setting as the default org.

If you say yes it will update the config with that org as the default org.

You can opt not to do so. You can even opt to not be asked this particular question again.
