### PR TITLE
upload all manifests files when running `socket scan create --reach`

### DIFF
--- a/src/commands/scan/handle-create-new-scan.mts
+++ b/src/commands/scan/handle-create-new-scan.mts
@@ -151,9 +151,14 @@ export async function handleCreateNewScan({
 
     logger.success('Reachability analysis completed successfully')
 
-    scanPaths = reachResult.data?.reachabilityReport
-      ? [reachResult.data.reachabilityReport]
-      : []
+    scanPaths = [
+      ...packagePaths.filter(
+        // Ensure the .socket.facts.json isn't duplicated in case it happened
+        // to be in the scan folder before the analysis was run.
+        p => !p.endsWith(constants.DOT_SOCKET_DOT_FACTS_JSON),
+      ),
+      reachResult.data?.reachabilityReport,
+    ]
     tier1ReachabilityScanId = reachResult.data?.tier1ReachabilityScanId
   }
 

--- a/src/commands/scan/perform-reachability-analysis.mts
+++ b/src/commands/scan/perform-reachability-analysis.mts
@@ -60,7 +60,8 @@ export async function performReachabilityAnalysis(
 
     const wasSpinning = !!spinner?.isSpinning
 
-    // Exclude .socket.facts.json from upload.
+    // Exclude any .socket.facts.json files that happen to be
+    // in the scan folder before the analysis was run.
     const filepathsToUpload = packagePaths.filter(
       p => !p.endsWith(constants.DOT_SOCKET_DOT_FACTS_JSON),
     )


### PR DESCRIPTION
Ensures that not only the .`socket.facts.json` but also all other manifest files are uploaded as part of `socket scan create --reach`. This change results in better UX since users can now easily link tier-1-related alerts to the manifest files responsible for introducing the CVE.