### PR TITLE
do not pass default branch and repo name to coana CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "socket",
-  "version": "1.0.104",
+  "version": "1.0.105",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "socket",
-      "version": "1.0.104",
+      "version": "1.0.105",
       "license": "MIT",
       "bin": {
         "socket": "bin/cli.js",
@@ -21,7 +21,7 @@
         "@babel/preset-typescript": "7.27.1",
         "@babel/runtime": "7.28.3",
         "@biomejs/biome": "2.2.2",
-        "@coana-tech/cli": "14.12.6",
+        "@coana-tech/cli": "14.12.10",
         "@cyclonedx/cdxgen": "11.6.0",
         "@dotenvx/dotenvx": "1.49.0",
         "@eslint/compat": "1.3.2",
@@ -898,9 +898,9 @@
       "optional": true
     },
     "node_modules/@coana-tech/cli": {
-      "version": "14.12.6",
-      "resolved": "https://registry.npmjs.org/@coana-tech/cli/-/cli-14.12.6.tgz",
-      "integrity": "sha512-vPxrDbcmqHTSdNlKGL76FvmkXzgJvhcuBTv6uxIBPcGEfUOD2poLDCE0pco4kGEEMfQKUotHXDvG4jyOXAP3xA==",
+      "version": "14.12.10",
+      "resolved": "https://registry.npmjs.org/@coana-tech/cli/-/cli-14.12.10.tgz",
+      "integrity": "sha512-h3JDAQ979bDm1DYftff4x6Mn3AUNDGzPUge1HKnGhe3IDqi++Soo/m0Hz2E4G8id0v1uGnaAHHq4sPotU31vUw==",
       "dev": true,
       "bin": {
         "cli": "cli-wrapper.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.0.104",
+  "version": "1.0.105",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT",
@@ -85,7 +85,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.3",
     "@biomejs/biome": "2.2.2",
-    "@coana-tech/cli": "14.12.6",
+    "@coana-tech/cli": "14.12.10",
     "@cyclonedx/cdxgen": "11.6.0",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/src/commands/scan/perform-reachability-analysis.mts
+++ b/src/commands/scan/perform-reachability-analysis.mts
@@ -167,7 +167,7 @@ export async function performReachabilityAnalysis(
   const env: NodeJS.ProcessEnv = {
     ...process.env,
   }
-  // do not pass default repo and branch name to coana to mixing
+  // do not pass default repo and branch name to coana to avoid mixing
   // buckets (cached configuration) from projects that are likely very different.
   if (repoName && repoName !== constants.SOCKET_DEFAULT_REPOSITORY) {
     env['SOCKET_REPO_NAME'] = repoName

--- a/src/commands/scan/perform-reachability-analysis.mts
+++ b/src/commands/scan/perform-reachability-analysis.mts
@@ -167,10 +167,12 @@ export async function performReachabilityAnalysis(
   const env: NodeJS.ProcessEnv = {
     ...process.env,
   }
-  if (repoName) {
+  // do not pass default repo and branch name to coana to mixing
+  // buckets (cached configuration) from projects that are likely very different.
+  if (repoName && repoName !== constants.SOCKET_DEFAULT_REPOSITORY) {
     env['SOCKET_REPO_NAME'] = repoName
   }
-  if (branchName) {
+  if (branchName && branchName !== constants.SOCKET_DEFAULT_BRANCH) {
     env['SOCKET_BRANCH_NAME'] = branchName
   }
 


### PR DESCRIPTION
This change ensures that Coana won't try to fetch cached analysis configuration for the default project. The default repo and branch are likely used for very different projects, so we shouldn't be using cached configuration.

- edit: Also upgrades Coana to 14.12.10 to fix various minor bugs related to the reachability analysis.