### PR TITLE
stdio:inherit when using Coana for fixes

### DIFF
--- a/src/commands/fix/coana-fix.mts
+++ b/src/commands/fix/coana-fix.mts
@@ -105,7 +105,7 @@ export async function coanaFix(
         ...fixConfig.unknownFlags,
       ],
       fixConfig.orgSlug,
-      { cwd, spinner },
+      { cwd, spinner, stdio: 'inherit' },
     )
     spinner?.stop()
     return fixCResult.ok ? { ok: true, data: { fixed: true } } : fixCResult
@@ -125,7 +125,7 @@ export async function coanaFix(
         ...fixConfig.unknownFlags,
       ],
       fixConfig.orgSlug,
-      { cwd, spinner },
+      { cwd, spinner, stdio: 'inherit' },
     )
     if (foundCResult.ok) {
       const foundIds = cmdFlagValueToArray(
@@ -178,7 +178,7 @@ export async function coanaFix(
         ...fixConfig.unknownFlags,
       ],
       fixConfig.orgSlug,
-      { cwd, spinner },
+      { cwd, spinner, stdio: 'inherit' },
     )
 
     if (!fixCResult.ok) {


### PR DESCRIPTION
Inherit `stdio` when running auto fixes using the Coana CLI. Made this change since it is otherwise difficult to tell if the Coana CLI is making progress.