### PR TITLE
Fixes error reading .parsed of undefined

### DIFF
--- a/src/utils/alerts-map.mts
+++ b/src/utils/alerts-map.mts
@@ -86,7 +86,7 @@ export async function getAlertsMapFromPurls(
   const sockSdk = sockSdkCResult.data
   const socketYmlResult = findSocketYmlSync()
   const socketYml = socketYmlResult.ok
-    ? (socketYmlResult.data as FoundSocketYml).parsed
+    ? socketYmlResult.data?.parsed
     : undefined
 
   const alertsMapOptions = {


### PR DESCRIPTION
Fixes https://linear.app/socketdev/issue/ENG-4065/npm-cli-cdxgen-error-for-free-customers-in-keeper-security and https://linear.app/socketdev/issue/SMO-306/cli-error-during-tier-1-scan-parsed-is-undefined