### PR TITLE
Socket fix and repo name adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.17](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.16) - 2025-09-18
+
+### Changed
+- Rename `--only-compute` flag to `--dont-apply-fixejs` for `socket fix`, but keep old flag as an alias.
+
+### Fixed
+- Sanitize extracted git repository names to be compatible with the Socket API.
+
 ## [1.1.16](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.16) - 2025-09-16
 
 ### Fixed

--- a/src/commands/fix/cmd-fix.mts
+++ b/src/commands/fix/cmd-fix.mts
@@ -83,7 +83,8 @@ Available styles:
   * preserve - Retain the existing version range style as-is
       `.trim(),
   },
-  onlyCompute: {
+  dontApplyFixes: {
+    aliases: ['onlyCompute'],
     type: 'boolean',
     default: false,
     description:

--- a/src/commands/fix/cmd-fix.test.mts
+++ b/src/commands/fix/cmd-fix.test.mts
@@ -157,6 +157,7 @@ describe('socket fix', async () => {
           Options
             --autopilot         Enable auto-merge for pull requests that Socket opens.
                                 See GitHub documentation (https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository) for managing auto-merge for pull requests in your repository.
+            --dont-apply-fixes  Compute fixes only, do not apply them. Logs what upgrades would be applied. If combined with --output-file, the output file will contain the upgrades that would be applied.
             --id                Provide a list of vulnerability identifiers to compute fixes for:
                                     - GHSA IDs (https://docs.github.com/en/code-security/security-advisories/working-with-global-security-advisories-from-the-github-advisory-database/about-the-github-advisory-database#about-ghsa-ids) (e.g., GHSA-xxxx-xxxx-xxxx)
                                     - CVE IDs (https://cve.mitre.org/cve/identifiers/) (e.g., CVE-2025-1234) - automatically converted to GHSA
@@ -165,7 +166,6 @@ describe('socket fix', async () => {
             --json              Output result as json
             --limit             The number of fixes to attempt at a time (default 10)
             --markdown          Output result as markdown
-            --only-compute      Compute fixes only, do not apply them. Logs what upgrades would be applied. If combined with --output-file, the output file will contain the upgrades that would be applied.
             --output-file       Path to store upgrades as a JSON file at this path.
             --range-style       Define how dependency version ranges are updated in package.json (default 'preserve').
                                 Available styles:

--- a/src/commands/npm/socket-npm-integration.test.mts
+++ b/src/commands/npm/socket-npm-integration.test.mts
@@ -106,7 +106,8 @@ for (const npmDir of [] as string[]) {
             'Expected Socket to detect typosquat, but command succeeded',
           )
         } catch (e) {
-          const errorMessage = (e as SpawnError)?.['stderr'] || (e as Error)?.['message'] || ''
+          const errorMessage =
+            (e as SpawnError)?.['stderr'] || (e as Error)?.['message'] || ''
 
           // Success cases: Socket detected an issue.
           if (

--- a/src/commands/optimize/cmd-optimize-pnpm-versions.test.mts
+++ b/src/commands/optimize/cmd-optimize-pnpm-versions.test.mts
@@ -22,223 +22,227 @@ const pnpm8FixtureDir = path.join(fixtureBaseDir, 'pnpm8')
 const pnpm9FixtureDir = path.join(fixtureBaseDir, 'pnpm9')
 
 // TODO: Revisit after socket-registry dep is updated.
-describe.skip('socket optimize - pnpm versions', { timeout: 60_000 }, async () => {
-  const { binCliPath } = constants
+describe.skip(
+  'socket optimize - pnpm versions',
+  { timeout: 60_000 },
+  async () => {
+    const { binCliPath } = constants
 
-  describe('pnpm v8', () => {
-    const pnpm8BinPath = path.join(pnpm8FixtureDir, 'node_modules/.bin')
+    describe('pnpm v8', () => {
+      const pnpm8BinPath = path.join(pnpm8FixtureDir, 'node_modules/.bin')
 
-    beforeEach(async () => {
-      // Ensure pnpm v8 is installed in the fixture
-      spawnSync('npm', ['install', '--silent'], {
-        cwd: pnpm8FixtureDir,
-        stdio: 'ignore',
-      })
-      // Clean up any modifications from previous runs
-      spawnSync('git', ['restore', '.'], {
-        cwd: pnpm8FixtureDir,
-        stdio: 'ignore',
-      })
-    })
-
-    afterEach(async () => {
-      // Restore fixture to original state
-      spawnSync('git', ['restore', '.'], {
-        cwd: pnpm8FixtureDir,
-        stdio: 'ignore',
-      })
-    })
-
-    it(
-      'should optimize packages with pnpm v8',
-      { timeout: 30_000 },
-      async () => {
-        // Ensure npm install completed for pnpm v8
-        const pnpmBin = path.join(pnpm8BinPath, 'pnpm')
-        const pnpmVersion = spawnSync(pnpmBin, ['--version'], {
-          encoding: 'utf8',
+      beforeEach(async () => {
+        // Ensure pnpm v8 is installed in the fixture
+        spawnSync('npm', ['install', '--silent'], {
+          cwd: pnpm8FixtureDir,
+          stdio: 'ignore',
         })
-        expect(pnpmVersion.stdout?.trim()).toMatch(/^8\.\d+\.\d+$/)
-
-        const packageJsonPath = path.join(pnpm8FixtureDir, 'package.json')
-        const pkgJsonBefore = await readPackageJson(packageJsonPath)
-
-        // Check lodash is vulnerable version (easter egg!)
-        expect(pkgJsonBefore.dependencies?.lodash).toBe('4.17.20')
-
-        const { code, stderr, stdout } = await spawnSocketCli(
-          binCliPath,
-          ['optimize', pnpm8FixtureDir, '--config', '{}'],
-          {
-            cwd: pnpm8FixtureDir,
-            env: {
-              ...process.env,
-              PATH: `${pnpm8BinPath}:${constants.ENV.PATH || process.env.PATH}`,
-            },
-          },
-        )
-
-        // stderr contains the Socket banner and info messages
-        expect(stderr, 'should show optimization message').toContain(
-          'Optimizing packages for pnpm',
-        )
-        expect(stdout, 'should show success message').toMatch(
-          /Socket\.dev optimized overrides/,
-        )
-        expect(code, 'exit code should be 0').toBe(0)
-
-        const pkgJsonAfter = await readPackageJson(packageJsonPath)
-        // Should have overrides added
-        expect(pkgJsonAfter.overrides).toBeDefined()
-        expect(pkgJsonAfter.resolutions).toBeDefined()
-
-        // Check that pnpm-lock.yaml exists and was modified
-        const lockPath = path.join(pnpm8FixtureDir, PNPM_LOCK_YAML)
-        expect(existsSync(lockPath)).toBe(true)
-      },
-    )
-
-    it(
-      'should handle --prod flag with pnpm v8',
-      { timeout: 30_000 },
-      async () => {
-        const packageJsonPath = path.join(pnpm8FixtureDir, 'package.json')
-
-        const { code, stderr, stdout } = await spawnSocketCli(
-          binCliPath,
-          ['optimize', pnpm8FixtureDir, '--prod', '--config', '{}'],
-          {
-            cwd: pnpm8FixtureDir,
-            env: {
-              ...process.env,
-              PATH: `${pnpm8BinPath}:${constants.ENV.PATH || process.env.PATH}`,
-            },
-          },
-        )
-
-        // stderr contains the Socket banner and info messages
-        expect(stderr, 'should show optimization message').toContain(
-          'Optimizing packages for pnpm',
-        )
-        expect(code, 'exit code should be 0').toBe(0)
-
-        const pkgJsonAfter = await readPackageJson(packageJsonPath)
-        // Should have overrides for production deps only
-        expect(pkgJsonAfter.overrides).toBeDefined()
-      },
-    )
-  })
-
-  describe('pnpm v9', () => {
-    const pnpm9BinPath = path.join(pnpm9FixtureDir, 'node_modules/.bin')
-
-    beforeEach(async () => {
-      // Ensure pnpm v9 is installed in the fixture
-      spawnSync('npm', ['install', '--silent'], {
-        cwd: pnpm9FixtureDir,
-        stdio: 'ignore',
+        // Clean up any modifications from previous runs
+        spawnSync('git', ['restore', '.'], {
+          cwd: pnpm8FixtureDir,
+          stdio: 'ignore',
+        })
       })
-      // Clean up any modifications from previous runs
-      spawnSync('git', ['restore', '.'], {
-        cwd: pnpm9FixtureDir,
-        stdio: 'ignore',
+
+      afterEach(async () => {
+        // Restore fixture to original state
+        spawnSync('git', ['restore', '.'], {
+          cwd: pnpm8FixtureDir,
+          stdio: 'ignore',
+        })
       })
+
+      it(
+        'should optimize packages with pnpm v8',
+        { timeout: 30_000 },
+        async () => {
+          // Ensure npm install completed for pnpm v8
+          const pnpmBin = path.join(pnpm8BinPath, 'pnpm')
+          const pnpmVersion = spawnSync(pnpmBin, ['--version'], {
+            encoding: 'utf8',
+          })
+          expect(pnpmVersion.stdout?.trim()).toMatch(/^8\.\d+\.\d+$/)
+
+          const packageJsonPath = path.join(pnpm8FixtureDir, 'package.json')
+          const pkgJsonBefore = await readPackageJson(packageJsonPath)
+
+          // Check lodash is vulnerable version (easter egg!)
+          expect(pkgJsonBefore.dependencies?.lodash).toBe('4.17.20')
+
+          const { code, stderr, stdout } = await spawnSocketCli(
+            binCliPath,
+            ['optimize', pnpm8FixtureDir, '--config', '{}'],
+            {
+              cwd: pnpm8FixtureDir,
+              env: {
+                ...process.env,
+                PATH: `${pnpm8BinPath}:${constants.ENV.PATH || process.env.PATH}`,
+              },
+            },
+          )
+
+          // stderr contains the Socket banner and info messages
+          expect(stderr, 'should show optimization message').toContain(
+            'Optimizing packages for pnpm',
+          )
+          expect(stdout, 'should show success message').toMatch(
+            /Socket\.dev optimized overrides/,
+          )
+          expect(code, 'exit code should be 0').toBe(0)
+
+          const pkgJsonAfter = await readPackageJson(packageJsonPath)
+          // Should have overrides added
+          expect(pkgJsonAfter.overrides).toBeDefined()
+          expect(pkgJsonAfter.resolutions).toBeDefined()
+
+          // Check that pnpm-lock.yaml exists and was modified
+          const lockPath = path.join(pnpm8FixtureDir, PNPM_LOCK_YAML)
+          expect(existsSync(lockPath)).toBe(true)
+        },
+      )
+
+      it(
+        'should handle --prod flag with pnpm v8',
+        { timeout: 30_000 },
+        async () => {
+          const packageJsonPath = path.join(pnpm8FixtureDir, 'package.json')
+
+          const { code, stderr, stdout } = await spawnSocketCli(
+            binCliPath,
+            ['optimize', pnpm8FixtureDir, '--prod', '--config', '{}'],
+            {
+              cwd: pnpm8FixtureDir,
+              env: {
+                ...process.env,
+                PATH: `${pnpm8BinPath}:${constants.ENV.PATH || process.env.PATH}`,
+              },
+            },
+          )
+
+          // stderr contains the Socket banner and info messages
+          expect(stderr, 'should show optimization message').toContain(
+            'Optimizing packages for pnpm',
+          )
+          expect(code, 'exit code should be 0').toBe(0)
+
+          const pkgJsonAfter = await readPackageJson(packageJsonPath)
+          // Should have overrides for production deps only
+          expect(pkgJsonAfter.overrides).toBeDefined()
+        },
+      )
     })
 
-    afterEach(async () => {
-      // Restore fixture to original state
-      spawnSync('git', ['restore', '.'], {
-        cwd: pnpm9FixtureDir,
-        stdio: 'ignore',
+    describe('pnpm v9', () => {
+      const pnpm9BinPath = path.join(pnpm9FixtureDir, 'node_modules/.bin')
+
+      beforeEach(async () => {
+        // Ensure pnpm v9 is installed in the fixture
+        spawnSync('npm', ['install', '--silent'], {
+          cwd: pnpm9FixtureDir,
+          stdio: 'ignore',
+        })
+        // Clean up any modifications from previous runs
+        spawnSync('git', ['restore', '.'], {
+          cwd: pnpm9FixtureDir,
+          stdio: 'ignore',
+        })
       })
+
+      afterEach(async () => {
+        // Restore fixture to original state
+        spawnSync('git', ['restore', '.'], {
+          cwd: pnpm9FixtureDir,
+          stdio: 'ignore',
+        })
+      })
+
+      it(
+        'should optimize packages with pnpm v9',
+        { timeout: 30_000 },
+        async () => {
+          // Ensure npm install completed for pnpm v9
+          const pnpmBin = path.join(pnpm9BinPath, 'pnpm')
+          const pnpmVersion = spawnSync(pnpmBin, ['--version'], {
+            encoding: 'utf8',
+          })
+          expect(pnpmVersion.stdout?.trim()).toMatch(/^9\.\d+\.\d+$/)
+
+          const packageJsonPath = path.join(pnpm9FixtureDir, 'package.json')
+          const pkgJsonBefore = await readPackageJson(packageJsonPath)
+
+          // Check lodash is vulnerable version (easter egg!)
+          expect(pkgJsonBefore.dependencies?.lodash).toBe('4.17.20')
+
+          const { code, stderr, stdout } = await spawnSocketCli(
+            binCliPath,
+            ['optimize', pnpm9FixtureDir, '--config', '{}'],
+            {
+              cwd: pnpm9FixtureDir,
+              env: {
+                ...process.env,
+                PATH: `${pnpm9BinPath}:${constants.ENV.PATH || process.env.PATH}`,
+              },
+            },
+          )
+
+          // stderr contains the Socket banner and info messages
+          expect(stderr, 'should show optimization message').toContain(
+            'Optimizing packages for pnpm',
+          )
+          expect(stdout, 'should show success message').toMatch(
+            /Socket\.dev optimized overrides/,
+          )
+          expect(code, 'exit code should be 0').toBe(0)
+
+          const pkgJsonAfter = await readPackageJson(packageJsonPath)
+          // Should have overrides added
+          expect(pkgJsonAfter.overrides).toBeDefined()
+          expect(pkgJsonAfter.resolutions).toBeDefined()
+
+          // Check that pnpm-lock.yaml exists and was modified
+          const lockPath = path.join(pnpm9FixtureDir, PNPM_LOCK_YAML)
+          expect(existsSync(lockPath)).toBe(true)
+        },
+      )
+
+      it(
+        'should handle --pin flag with pnpm v9',
+        { timeout: 30_000 },
+        async () => {
+          const packageJsonPath = path.join(pnpm9FixtureDir, 'package.json')
+
+          const { code, stderr, stdout } = await spawnSocketCli(
+            binCliPath,
+            ['optimize', pnpm9FixtureDir, '--pin', '--config', '{}'],
+            {
+              cwd: pnpm9FixtureDir,
+              env: {
+                ...process.env,
+                PATH: `${pnpm9BinPath}:${constants.ENV.PATH || process.env.PATH}`,
+              },
+            },
+          )
+
+          // stderr contains the Socket banner and info messages
+          expect(stderr, 'should show optimization message').toContain(
+            'Optimizing packages for pnpm',
+          )
+          expect(code, 'exit code should be 0').toBe(0)
+
+          const pkgJsonAfter = await readPackageJson(packageJsonPath)
+          // Should have overrides with pinned versions
+          expect(pkgJsonAfter.overrides).toBeDefined()
+
+          // Check that overrides use exact versions when pinned
+          const overrideValues = Object.values(pkgJsonAfter.overrides || {})
+          overrideValues.forEach(value => {
+            if (typeof value === 'string' && !value.startsWith('$')) {
+              // Should not have ^ or ~ when pinned
+              expect(value).not.toMatch(/[\^~]/)
+            }
+          })
+        },
+      )
     })
-
-    it(
-      'should optimize packages with pnpm v9',
-      { timeout: 30_000 },
-      async () => {
-        // Ensure npm install completed for pnpm v9
-        const pnpmBin = path.join(pnpm9BinPath, 'pnpm')
-        const pnpmVersion = spawnSync(pnpmBin, ['--version'], {
-          encoding: 'utf8',
-        })
-        expect(pnpmVersion.stdout?.trim()).toMatch(/^9\.\d+\.\d+$/)
-
-        const packageJsonPath = path.join(pnpm9FixtureDir, 'package.json')
-        const pkgJsonBefore = await readPackageJson(packageJsonPath)
-
-        // Check lodash is vulnerable version (easter egg!)
-        expect(pkgJsonBefore.dependencies?.lodash).toBe('4.17.20')
-
-        const { code, stderr, stdout } = await spawnSocketCli(
-          binCliPath,
-          ['optimize', pnpm9FixtureDir, '--config', '{}'],
-          {
-            cwd: pnpm9FixtureDir,
-            env: {
-              ...process.env,
-              PATH: `${pnpm9BinPath}:${constants.ENV.PATH || process.env.PATH}`,
-            },
-          },
-        )
-
-        // stderr contains the Socket banner and info messages
-        expect(stderr, 'should show optimization message').toContain(
-          'Optimizing packages for pnpm',
-        )
-        expect(stdout, 'should show success message').toMatch(
-          /Socket\.dev optimized overrides/,
-        )
-        expect(code, 'exit code should be 0').toBe(0)
-
-        const pkgJsonAfter = await readPackageJson(packageJsonPath)
-        // Should have overrides added
-        expect(pkgJsonAfter.overrides).toBeDefined()
-        expect(pkgJsonAfter.resolutions).toBeDefined()
-
-        // Check that pnpm-lock.yaml exists and was modified
-        const lockPath = path.join(pnpm9FixtureDir, PNPM_LOCK_YAML)
-        expect(existsSync(lockPath)).toBe(true)
-      },
-    )
-
-    it(
-      'should handle --pin flag with pnpm v9',
-      { timeout: 30_000 },
-      async () => {
-        const packageJsonPath = path.join(pnpm9FixtureDir, 'package.json')
-
-        const { code, stderr, stdout } = await spawnSocketCli(
-          binCliPath,
-          ['optimize', pnpm9FixtureDir, '--pin', '--config', '{}'],
-          {
-            cwd: pnpm9FixtureDir,
-            env: {
-              ...process.env,
-              PATH: `${pnpm9BinPath}:${constants.ENV.PATH || process.env.PATH}`,
-            },
-          },
-        )
-
-        // stderr contains the Socket banner and info messages
-        expect(stderr, 'should show optimization message').toContain(
-          'Optimizing packages for pnpm',
-        )
-        expect(code, 'exit code should be 0').toBe(0)
-
-        const pkgJsonAfter = await readPackageJson(packageJsonPath)
-        // Should have overrides with pinned versions
-        expect(pkgJsonAfter.overrides).toBeDefined()
-
-        // Check that overrides use exact versions when pinned
-        const overrideValues = Object.values(pkgJsonAfter.overrides || {})
-        overrideValues.forEach(value => {
-          if (typeof value === 'string' && !value.startsWith('$')) {
-            // Should not have ^ or ~ when pinned
-            expect(value).not.toMatch(/[\^~]/)
-          }
-        })
-      },
-    )
-  })
-})
+  },
+)

--- a/src/commands/pnpm/cmd-pnpm.test.mts
+++ b/src/commands/pnpm/cmd-pnpm.test.mts
@@ -140,50 +140,55 @@ describe.skip('socket pnpm', async () => {
     },
   )
 
-  it.skip('should work when invoked via pnpm dlx', { timeout: 90_000 }, async () => {
-    // Create a temporary directory for testing.
-    const tmpDir = path.join(tmpdir(), `pnpm-dlx-test-${Date.now()}`)
-    await fs.mkdir(tmpDir, { recursive: true })
+  it.skip(
+    'should work when invoked via pnpm dlx',
+    { timeout: 90_000 },
+    async () => {
+      // Create a temporary directory for testing.
+      const tmpDir = path.join(tmpdir(), `pnpm-dlx-test-${Date.now()}`)
+      await fs.mkdir(tmpDir, { recursive: true })
 
-    try {
-      // Create a minimal package.json.
-      await fs.writeFile(
-        path.join(tmpDir, 'package.json'),
-        JSON.stringify({ name: 'test-pnpm-dlx', version: '1.0.0' }),
-      )
+      try {
+        // Create a minimal package.json.
+        await fs.writeFile(
+          path.join(tmpDir, 'package.json'),
+          JSON.stringify({ name: 'test-pnpm-dlx', version: '1.0.0' }),
+        )
 
-      // Run socket pnpm via pnpm dlx.
-      const { code, stderr, stdout } = await spawn(
-        'pnpm',
-        [
-          'dlx',
-          '@socketsecurity/cli@latest',
+        // Run socket pnpm via pnpm dlx.
+        const { code, stderr, stdout } = await spawn(
           'pnpm',
-          'install',
-          '--config',
-          '{"apiToken":"fakeToken"}',
-        ],
-        {
-          cwd: tmpDir,
-          env: {
-            ...process.env,
-            SOCKET_CLI_ACCEPT_RISKS: '1',
+          [
+            'dlx',
+            '@socketsecurity/cli@latest',
+            'pnpm',
+            'install',
+            '--config',
+            '{"apiToken":"fakeToken"}',
+          ],
+          {
+            cwd: tmpDir,
+            env: {
+              ...process.env,
+              SOCKET_CLI_ACCEPT_RISKS: '1',
+            },
+            timeout: 60_000,
           },
-          timeout: 60_000,
-        },
-      )
+        )
 
-      // Check that the command succeeded.
-      expect(code, 'pnpm dlx socket pnpm should exit with code 0').toBe(0)
+        // Check that the command succeeded.
+        expect(code, 'pnpm dlx socket pnpm should exit with code 0').toBe(0)
 
-      // Verify pnpm-lock.yaml was created.
-      const lockfilePath = path.join(tmpDir, 'pnpm-lock.yaml')
-      expect(existsSync(lockfilePath), 'pnpm-lock.yaml should be created').toBe(
-        true,
-      )
-    } finally {
-      // Clean up the temporary directory.
-      await fs.rm(tmpDir, { recursive: true, force: true })
-    }
-  })
+        // Verify pnpm-lock.yaml was created.
+        const lockfilePath = path.join(tmpDir, 'pnpm-lock.yaml')
+        expect(
+          existsSync(lockfilePath),
+          'pnpm-lock.yaml should be created',
+        ).toBe(true)
+      } finally {
+        // Clean up the temporary directory.
+        await fs.rm(tmpDir, { recursive: true, force: true })
+      }
+    },
+  )
 })

--- a/src/utils/extract-names.mts
+++ b/src/utils/extract-names.mts
@@ -1,0 +1,55 @@
+import constants from '../constants.mts'
+
+/**
+ * Sanitizes a name to comply with repository naming constraints.
+ * Constraints: 100 or less A-Za-z0-9 characters only with non-repeating,
+ * non-leading or trailing ., _ or - only.
+ *
+ * @param name - The name to sanitize
+ * @returns Sanitized name that complies with repository naming rules, or empty string if no valid characters
+ */
+function sanitizeName(name: string): string {
+  if (!name) {
+    return ''
+  }
+
+  // Replace sequences of illegal characters with underscores.
+  const sanitized = name
+    // Replace any sequence of non-alphanumeric characters (except ., _, -) with underscore.
+    .replace(/[^A-Za-z0-9._-]+/g, '_')
+    // Replace sequences of multiple allowed special chars with single underscore.
+    .replace(/[._-]{2,}/g, '_')
+    // Remove leading special characters.
+    .replace(/^[._-]+/, '')
+    // Remove trailing special characters.
+    .replace(/[._-]+$/, '')
+    // Truncate to 100 characters max.
+    .slice(0, 100)
+
+  return sanitized
+}
+
+/**
+ * Extracts and sanitizes a repository name.
+ *
+ * @param name - The repository name to extract and sanitize
+ * @returns Sanitized repository name, or default repository name if empty
+ */
+export function extractName(name: string): string {
+  const sanitized = sanitizeName(name)
+  return sanitized || constants.SOCKET_DEFAULT_REPOSITORY
+}
+
+/**
+ * Extracts and sanitizes a repository owner name.
+ *
+ * @param owner - The repository owner name to extract and sanitize
+ * @returns Sanitized repository owner name, or undefined if input is empty
+ */
+export function extractOwner(owner: string): string | undefined {
+  if (!owner) {
+    return undefined
+  }
+  const sanitized = sanitizeName(owner)
+  return sanitized || undefined
+}

--- a/src/utils/extract-names.test.mts
+++ b/src/utils/extract-names.test.mts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import constants from '../constants.mts'
+import { extractName, extractOwner } from './extract-names.mts'
+
+describe('extractName', () => {
+  it('should return valid names unchanged', () => {
+    expect(extractName('myrepo')).toBe('myrepo')
+    expect(extractName('My-Repo_123')).toBe('My-Repo_123')
+    expect(extractName('repo.with.dots')).toBe('repo.with.dots')
+    expect(extractName('a1b2c3')).toBe('a1b2c3')
+  })
+
+  it('should replace sequences of illegal characters with underscore', () => {
+    expect(extractName('repo@#$%name')).toBe('repo_name')
+    expect(extractName('repo   name')).toBe('repo_name')
+    expect(extractName('repo!!!name')).toBe('repo_name')
+    expect(extractName('repo/\\|name')).toBe('repo_name')
+  })
+
+  it('should replace sequences of multiple allowed special chars with single underscore', () => {
+    expect(extractName('repo...name')).toBe('repo_name')
+    expect(extractName('repo---name')).toBe('repo_name')
+    expect(extractName('repo___name')).toBe('repo_name')
+    expect(extractName('repo.-_name')).toBe('repo_name')
+  })
+
+  it('should remove leading special characters', () => {
+    expect(extractName('...repo')).toBe('repo')
+    expect(extractName('---repo')).toBe('repo')
+    expect(extractName('___repo')).toBe('repo')
+    expect(extractName('.-_repo')).toBe('repo')
+  })
+
+  it('should remove trailing special characters', () => {
+    expect(extractName('repo...')).toBe('repo')
+    expect(extractName('repo---')).toBe('repo')
+    expect(extractName('repo___')).toBe('repo')
+    expect(extractName('repo.-_')).toBe('repo')
+  })
+
+  it('should truncate names longer than 100 characters', () => {
+    const longName = 'a'.repeat(150)
+    expect(extractName(longName)).toBe('a'.repeat(100))
+  })
+
+  it('should handle combined transformations', () => {
+    expect(extractName('---repo@#$name...')).toBe('repo_name')
+    expect(extractName('  ...my/repo\\name___  ')).toBe('my_repo_name')
+  })
+
+  it('should return default repository name for empty or invalid inputs', () => {
+    expect(extractName('')).toBe(constants.SOCKET_DEFAULT_REPOSITORY)
+    expect(extractName('...')).toBe(constants.SOCKET_DEFAULT_REPOSITORY)
+    expect(extractName('___')).toBe(constants.SOCKET_DEFAULT_REPOSITORY)
+    expect(extractName('---')).toBe(constants.SOCKET_DEFAULT_REPOSITORY)
+    expect(extractName('@#$%')).toBe(constants.SOCKET_DEFAULT_REPOSITORY)
+  })
+})
+
+describe('extractOwner', () => {
+  it('should return valid owner names unchanged', () => {
+    expect(extractOwner('myowner')).toBe('myowner')
+    expect(extractOwner('My-Owner_123')).toBe('My-Owner_123')
+    expect(extractOwner('owner.with.dots')).toBe('owner.with.dots')
+    expect(extractOwner('a1b2c3')).toBe('a1b2c3')
+  })
+
+  it('should replace sequences of illegal characters with underscore', () => {
+    expect(extractOwner('owner@#$%name')).toBe('owner_name')
+    expect(extractOwner('owner   name')).toBe('owner_name')
+    expect(extractOwner('owner!!!name')).toBe('owner_name')
+    expect(extractOwner('owner/\\|name')).toBe('owner_name')
+  })
+
+  it('should replace sequences of multiple allowed special chars with single underscore', () => {
+    expect(extractOwner('owner...name')).toBe('owner_name')
+    expect(extractOwner('owner---name')).toBe('owner_name')
+    expect(extractOwner('owner___name')).toBe('owner_name')
+    expect(extractOwner('owner.-_name')).toBe('owner_name')
+  })
+
+  it('should remove leading special characters', () => {
+    expect(extractOwner('...owner')).toBe('owner')
+    expect(extractOwner('---owner')).toBe('owner')
+    expect(extractOwner('___owner')).toBe('owner')
+    expect(extractOwner('.-_owner')).toBe('owner')
+  })
+
+  it('should remove trailing special characters', () => {
+    expect(extractOwner('owner...')).toBe('owner')
+    expect(extractOwner('owner---')).toBe('owner')
+    expect(extractOwner('owner___')).toBe('owner')
+    expect(extractOwner('owner.-_')).toBe('owner')
+  })
+
+  it('should truncate names longer than 100 characters', () => {
+    const longName = 'a'.repeat(150)
+    expect(extractOwner(longName)).toBe('a'.repeat(100))
+  })
+
+  it('should handle combined transformations', () => {
+    expect(extractOwner('---owner@#$name...')).toBe('owner_name')
+    expect(extractOwner('  ...my/owner\\name___  ')).toBe('my_owner_name')
+  })
+
+  it('should return undefined for empty or invalid inputs', () => {
+    expect(extractOwner('')).toBeUndefined()
+    expect(extractOwner('...')).toBeUndefined()
+    expect(extractOwner('___')).toBeUndefined()
+    expect(extractOwner('---')).toBeUndefined()
+    expect(extractOwner('@#$%')).toBeUndefined()
+  })
+
+  it('should handle edge cases with mixed valid and invalid characters', () => {
+    expect(extractOwner('a@b#c$d')).toBe('a_b_c_d')
+    expect(extractOwner('123...456')).toBe('123_456')
+    expect(extractOwner('---a---')).toBe('a')
+  })
+})

--- a/src/utils/git.mts
+++ b/src/utils/git.mts
@@ -3,6 +3,7 @@ import { normalizePath } from '@socketsecurity/registry/lib/path'
 import { isSpawnError, spawn } from '@socketsecurity/registry/lib/spawn'
 
 import constants from '../constants.mts'
+import { extractName, extractOwner } from './extract-names.mts'
 
 import type { CResult } from '../types.mts'
 import type { SpawnOptions } from '@socketsecurity/registry/lib/spawn'
@@ -77,14 +78,16 @@ export async function getRepoInfo(
 
 export async function getRepoName(cwd = process.cwd()): Promise<string> {
   const repoInfo = await getRepoInfo(cwd)
-  return repoInfo?.repo ?? constants.SOCKET_DEFAULT_REPOSITORY
+  return repoInfo?.repo
+    ? extractName(repoInfo.repo)
+    : constants.SOCKET_DEFAULT_REPOSITORY
 }
 
 export async function getRepoOwner(
   cwd = process.cwd(),
 ): Promise<string | undefined> {
   const repoInfo = await getRepoInfo(cwd)
-  return repoInfo?.owner
+  return repoInfo?.owner ? extractOwner(repoInfo.owner) : undefined
 }
 
 export async function gitBranch(


### PR DESCRIPTION
### Changed
- Rename `--only-compute` flag to `--dont-apply-fixejs` for `socket fix`, but keep old flag as an alias.

### Fixed
- Sanitize extracted git repository names to be compatible with the Socket API.

The Socket backend validates repository names to ensure they work with GitHub's naming rules. However, GitHub's constraints differ from other platforms like GitLab, so names that work on one platform may not work on another. The `sanitizeName` function modifies extracted repository names to be compatible with Socket/GitHub.