### PR TITLE
[typo] usage json example

### DIFF
--- a/src/commands/cli.test.mts
+++ b/src/commands/cli.test.mts
@@ -21,7 +21,7 @@ describe('socket root command', async () => {
 
           Usage
             $ socket <command>
-            $ socket scan create--json
+            $ socket scan create --json
             $ socket package score npm lodash --markdown
 
           Note: All commands have their own --help

--- a/src/utils/meow-with-subcommands.mts
+++ b/src/utils/meow-with-subcommands.mts
@@ -524,7 +524,7 @@ export async function meowWithSubcommands(
   const lines = ['', 'Usage', `  $ ${name} <command>`]
   if (isRootCommand) {
     lines.push(
-      `  $ ${name} scan create${FLAG_JSON}`,
+      `  $ ${name} scan create ${FLAG_JSON}`,
       `  $ ${name} package score ${NPM} lodash ${FLAG_MARKDOWN}`,
     )
   }


### PR DESCRIPTION
* Fixes a usage typo that was missing a space.
* It was one of the first items I copied (not a great first experience!) but trivial to fix it appears.