### PR TITLE
fix(optimize): correct backwards semver check of node version

### DIFF
--- a/src/commands/optimize/add-overrides.mts
+++ b/src/commands/optimize/add-overrides.mts
@@ -111,10 +111,8 @@ export async function addOverrides(
   const depEntries = getDependencyEntries(pkgEnvDetails)
   const manifestEntries = manifestNpmOverrides.filter(({ 1: data }) =>
     semver.satisfies(
-      // Roughly check Node range as semver.coerce will strip leading
-      // v's, carets (^), comparators (<,<=,>,>=,=), and tildes (~).
-      semver.coerce(data.engines.node)!,
-      pkgEnvDetails.pkgRequirements.node,
+      pkgEnvDetails.nodeVersion.version,
+      data.engines.node,
     ),
   )
 


### PR DESCRIPTION
I investigated why no packages was installed when using socket optimize. According to Copilot the issue is that the semver logic in `add-overrides.mts`is backwards. When applying the fix all packages is installed as expected. 
