### PR TITLE
fix(cli): correct tab completion script path resolution

### DIFF
--- a/packages/cli/src/commands/install/setup-tab-completion.mts
+++ b/packages/cli/src/commands/install/setup-tab-completion.mts
@@ -8,7 +8,7 @@ import { safeMkdirSync } from '@socketsecurity/lib/fs'
 
 import ENV from '../../constants/env.mts'
 import { homePath } from '../../constants/paths.mts'
-import { getBashrcDetails } from '../../utils/cli/completion.mjs'
+import { getBashrcDetails } from '../../utils/cli/completion.mts'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)

--- a/packages/cli/src/commands/uninstall/teardown-tab-completion.mts
+++ b/packages/cli/src/commands/uninstall/teardown-tab-completion.mts
@@ -5,7 +5,7 @@ import { homePath } from '../../constants/paths.mts'
 import {
   COMPLETION_CMD_PREFIX,
   getBashrcDetails,
-} from '../../utils/cli/completion.mjs'
+} from '../../utils/cli/completion.mts'
 
 import type { CResult } from '../../types.mts'
 

--- a/packages/cli/src/commands/wrapper/postinstall-wrapper.mts
+++ b/packages/cli/src/commands/wrapper/postinstall-wrapper.mts
@@ -7,7 +7,7 @@ import { confirm } from '@socketsecurity/lib/stdio/prompts'
 import { addSocketWrapper } from './add-socket-wrapper.mts'
 import { checkSocketWrapperSetup } from './check-socket-wrapper-setup.mts'
 import { getBashRcPath, getZshRcPath } from '../../constants/paths.mts'
-import { getBashrcDetails } from '../../utils/cli/completion.mjs'
+import { getBashrcDetails } from '../../utils/cli/completion.mts'
 import { getErrorCause } from '../../utils/error/errors.mjs'
 import { updateInstalledTabCompletionScript } from '../install/setup-tab-completion.mts'
 const logger = getDefaultLogger()

--- a/packages/cli/src/constants/paths.mts
+++ b/packages/cli/src/constants/paths.mts
@@ -38,12 +38,15 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 // Static Base Paths (eagerly computed)
-// In unified build, this file is bundled into dist/cli.js, so __dirname will be the dist directory.
+// In unified build, this file is bundled into dist/cli.js or build/cli.js, so __dirname will be the dist or build directory.
 // In normal build, this file stays in src/constants, so __dirname is src/constants.
 export const srcPath = path.resolve(__dirname, '..')
-// If srcPath ends with 'dist', we're in the bundled CLI, so rootPath is one level up from dist.
+// If __dirname ends with 'dist' or 'build', we're in the bundled CLI, so rootPath is srcPath (one level up from dist/build).
 // Otherwise, we're in source code where srcPath is 'src', so rootPath is one level up from src.
-export const rootPath = path.resolve(srcPath, '..')
+export const rootPath =
+  __dirname.endsWith('dist') || __dirname.endsWith('build')
+    ? srcPath
+    : path.resolve(srcPath, '..')
 export const distPath = path.join(rootPath, 'dist')
 export const configPath = path.join(rootPath, '.config')
 export const externalPath = path.join(rootPath, 'external')


### PR DESCRIPTION
## Summary

Fixes incorrect path to `socket-completion.bash` when running the CLI from built distribution.

**Before**: `/Users/jdalton/projects/socket-cli/packages/data/socket-completion.bash` ❌  
**After**: `/Users/jdalton/projects/socket-cli/packages/cli/data/socket-completion.bash` ✓

## Problem

When running `socket install completion`, the CLI failed with:
```
✗ Tab Completion script not found: Expected to find completion script at 
`/Users/jdalton/projects/socket-cli/packages/data/socket-completion.bash` but it was not there
```

The root cause was in `src/constants/paths.mts:46-48`. The `rootPath` calculation didn't account for code running from the `build/` directory (in addition to `dist/`), causing path resolution to go one level too high (`/packages/` instead of `/packages/cli/`).

## Solution

Updated path resolution logic to check if `__dirname` ends with either `'dist'` or `'build'`, correctly determining the root path in all execution contexts:
- Running from source: `src/constants/` → root is `packages/cli/`
- Running from build: `build/` → root is `packages/cli/`
- Running from dist: `dist/` → root is `packages/cli/`

## Changes

- Fixed `rootPath` calculation in `src/constants/paths.mts`
- Updated comments to reflect both `build/` and `dist/` directories
- Fixed import extensions from `.mjs` to `.mts` for consistency

## Test Plan

- [x] All 2,255 unit tests pass
- [x] `socket install completion` works correctly
- [x] `socket uninstall completion` works correctly
- [x] Paths resolve correctly from both source and built versions
- [x] Verified fix with `pnpm build && node dist/index.js install completion socket`

🤖 Generated with [Claude Code](https://claude.com/claude-code)