### PR TITLE
refactor(lib-internal): replace require() with ES module imports

### DIFF
--- a/packages/lib-internal/src/package-extensions.ts
+++ b/packages/lib-internal/src/package-extensions.ts
@@ -5,9 +5,9 @@
  * to fix compatibility issues, missing peer dependencies, etc.
  */
 
-const { freeze: ObjectFreeze } = Object
+import yarnPkgExtensions from '@yarnpkg/extensions'
 
-const yarnPkgExtensions = require('@yarnpkg/extensions')
+const { freeze: ObjectFreeze } = Object
 
 export default ObjectFreeze(
   [

--- a/packages/lib-internal/src/stdio/prompts.ts
+++ b/packages/lib-internal/src/stdio/prompts.ts
@@ -3,6 +3,11 @@
  * Provides inquirer.js integration with spinner support, context handling, and theming.
  */
 
+import confirm from '@inquirer/confirm'
+import input from '@inquirer/input'
+import password from '@inquirer/password'
+import search from '@inquirer/search'
+import select, { Separator } from '@inquirer/select'
 import { getAbortSignal, getSpinner } from '#constants/process'
 import type { ColorValue } from '../spinner'
 import { getTheme } from '../themes/context'
@@ -259,18 +264,13 @@ export function wrapPrompt<T = unknown>(
   }
 }
 
-// c8 ignore start - Third-party inquirer library requires and exports not testable in isolation.
-const confirmExport = /*@__PURE__*/ require('@inquirer/confirm')
-const inputExport = /*@__PURE__*/ require('@inquirer/input')
-const passwordExport = /*@__PURE__*/ require('@inquirer/password')
-const searchExport = /*@__PURE__*/ require('@inquirer/search')
-const selectExport = /*@__PURE__*/ require('@inquirer/select')
-const confirmRaw = confirmExport.default ?? confirmExport
-const inputRaw = inputExport.default ?? inputExport
-const passwordRaw = passwordExport.default ?? passwordExport
-const searchRaw = searchExport.default ?? searchExport
-const selectRaw = selectExport.default ?? selectExport
-const ActualSeparator = selectExport.Separator
+// c8 ignore start - Third-party inquirer library imports not testable in isolation.
+const confirmRaw = confirm
+const inputRaw = input
+const passwordRaw = password
+const searchRaw = search
+const selectRaw = select
+const ActualSeparator = Separator
 // c8 ignore stop
 
 /**


### PR DESCRIPTION
## Summary

Convert lazy `require()` calls to static ES module imports in lib-internal package for better bundling and tree-shaking.

## Changes

### `package-extensions.ts`
```typescript
// Before
const yarnPkgExtensions = require('@yarnpkg/extensions')

// After
import yarnPkgExtensions from '@yarnpkg/extensions'
```

### `prompts.ts`
```typescript
// Before
const confirmExport = /*@__PURE__*/ require('@inquirer/confirm')
const confirmRaw = confirmExport.default ?? confirmExport
// ... similar for input, password, search, select

// After
import confirm from '@inquirer/confirm'
import input from '@inquirer/input'
// ... etc
const confirmRaw = confirm
```

## Benefits

✅ Better bundling - static imports enable tree-shaking  
✅ Cleaner code - no more default ?? fallback patterns  
✅ Consistent style - aligns with ES module best practices  
✅ Improved performance - eliminates runtime require() resolution

## Test Plan

- [x] Type check passes
- [x] Security checks pass
- [ ] Verify prompt functionality in interactive commands
- [ ] Verify package extensions work correctly

## Impact

Low risk - Simple import conversion with no logic changes. The same modules are loaded, just with static imports instead of dynamic require().