### PR TITLE
Use npm 11 for publishing in provenance workflow

### DIFF
--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -29,9 +29,10 @@ jobs:
       - uses: SocketDev/socket-registry/.github/actions/setup@1543e937143cf84e5161ad18c04cbd99c8a4c6d8
         with:
           scope: '@socketsecurity'
+      - run: npm install -g npm@latest
       - run: pnpm install
       - run: INLINED_SOCKET_CLI_PUBLISHED_BUILD=1 pnpm run build:dist
-      - run: pnpm publish --provenance --access public --no-git-checks --tag ${{ inputs.dist-tag }}
+      - run: npm publish --provenance --access public --tag ${{ inputs.dist-tag }}
         continue-on-error: true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -39,7 +40,7 @@ jobs:
       - run: INLINED_SOCKET_CLI_PUBLISHED_BUILD=1 INLINED_SOCKET_CLI_LEGACY_BUILD=1 pnpm run build:dist
         env:
           SOCKET_CLI_DEBUG: ${{ inputs.debug }}
-      - run: pnpm publish --provenance --access public --no-git-checks --tag ${{ inputs.dist-tag }}
+      - run: npm publish --provenance --access public --tag ${{ inputs.dist-tag }}
         continue-on-error: true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -47,7 +48,7 @@ jobs:
       - run: INLINED_SOCKET_CLI_PUBLISHED_BUILD=1 INLINED_SOCKET_CLI_SENTRY_BUILD=1 pnpm run build:dist
         env:
           SOCKET_CLI_DEBUG: ${{ inputs.debug }}
-      - run: pnpm publish --provenance --access public --no-git-checks --tag ${{ inputs.dist-tag }}
+      - run: npm publish --provenance --access public --tag ${{ inputs.dist-tag }}
         continue-on-error: true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Switch from pnpm to npm for publishing to leverage npm 11's improved provenance support
- Install npm 11 globally in the workflow
- Continue using pnpm for builds to maintain existing build process
