### PR TITLE
Pin @coana-tech/cli to exact version

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.51",
+    "@coana-tech/cli": "14.12.88",
     "@cyclonedx/cdxgen": "11.7.0",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.51
-        version: 14.12.51
+        specifier: 14.12.88
+        version: 14.12.88
       '@cyclonedx/cdxgen':
         specifier: 11.7.0
         version: 11.7.0
@@ -653,8 +653,8 @@ packages:
   '@bufbuild/protobuf@2.6.3':
     resolution: {integrity: sha512-w/gJKME9mYN7ZoUAmSMAWXk4hkVpxRKvEJCb3dV5g9wwWdxTJJ0ayOJAVcNxtdqaxDyFuC0uz4RSGVacJ030PQ==}
 
-  '@coana-tech/cli@14.12.51':
-    resolution: {integrity: sha512-EyMo/RBN/qqH23UjiqP96xlv/C7J6MQ2KnxChssTU+1kaDnoVA8pZH2dzwdjecL82p6E2COWtQLtjQUIKCdWTA==}
+  '@coana-tech/cli@14.12.88':
+    resolution: {integrity: sha512-KxE6AOU3y4WutoQLerilgLqu4tEm3lZAe1CUFTRLxwM6ANhup7VM/el9bEY6oYzjfhpiOo7LQxMozowW/GSxyw==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5172,7 +5172,7 @@ snapshots:
   '@bufbuild/protobuf@2.6.3':
     optional: true
 
-  '@coana-tech/cli@14.12.51': {}
+  '@coana-tech/cli@14.12.88': {}
 
   '@colors/colors@1.5.0':
     optional: true

--- a/src/utils/dlx.mts
+++ b/src/utils/dlx.mts
@@ -235,7 +235,7 @@ export async function spawnCoanaDlx(
     const result = await spawnDlx(
       {
         name: '@coana-tech/cli',
-        version: `~${constants.ENV.INLINED_SOCKET_CLI_COANA_TECH_CLI_VERSION}`,
+        version: constants.ENV.INLINED_SOCKET_CLI_COANA_TECH_CLI_VERSION,
       },
       args,
       {

--- a/src/utils/dlx.test.mts
+++ b/src/utils/dlx.test.mts
@@ -80,7 +80,7 @@ describe('utils/dlx', () => {
       // Verify that --silent comes before dlx.
       expect(spawnArgs[0]).toBe('--silent')
       expect(spawnArgs[1]).toBe('dlx')
-      expect(spawnArgs[2]).toBe('@coana-tech/cli@~1.0.0')
+      expect(spawnArgs[2]).toBe('@coana-tech/cli@1.0.0')
       expect(spawnArgs[3]).toBe('run')
       expect(spawnArgs[4]).toBe('/some/path')
     })
@@ -139,7 +139,7 @@ describe('utils/dlx', () => {
       // For npm/npx, --yes comes first, then --silent.
       expect(spawnArgs[0]).toBe('--yes')
       expect(spawnArgs[1]).toBe('--silent')
-      expect(spawnArgs[2]).toBe('@coana-tech/cli@~1.0.0')
+      expect(spawnArgs[2]).toBe('@coana-tech/cli@1.0.0')
       expect(spawnArgs[3]).toBe('run')
       expect(spawnArgs[4]).toBe('/some/path')
     })


### PR DESCRIPTION
## Summary
Pin @coana-tech/cli to exact versions instead of using tilde ranges.

## Changes
- Update @coana-tech/cli from 14.12.51 to 14.12.88
- Remove tilde (~) prefix from version specification in dlx.mts
- Update test expectations to match exact version format

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pin `@coana-tech/cli` to an exact version and bump it to `14.12.88`, updating dlx usage and tests to remove tilde ranges.
> 
> - **Dependencies**:
>   - Update `@coana-tech/cli` from `14.12.51` to `14.12.88` in `package.json` (lockfile updated accordingly).
> - **Utils**:
>   - In `src/utils/dlx.mts`, use exact `constants.ENV.INLINED_SOCKET_CLI_COANA_TECH_CLI_VERSION` (remove `~` prefix) when spawning `@coana-tech/cli`.
> - **Tests**:
>   - Adjust expectations in `src/utils/dlx.test.mts` to assert `@coana-tech/cli@1.0.0` (no tilde) for pnpm and npm cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2043149e6314930242b0b3691cca01c186ed7385. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->