### PR TITLE
Fix duplicate packages in PR descriptions

### DIFF
--- a/src/commands/fix/git.mts
+++ b/src/commands/fix/git.mts
@@ -6,6 +6,19 @@ import type { GhsaDetails } from '../../utils/github.mts'
 
 const GITHUB_ADVISORIES_URL = 'https://github.com/advisories'
 
+/**
+ * Extract unique package names with ecosystems from vulnerability details.
+ */
+function getUniquePackages(details: GhsaDetails): string[] {
+  return [
+    ...new Set(
+      details.vulnerabilities.nodes.map(
+        v => `${v.package.name} (${v.package.ecosystem})`,
+      ),
+    ),
+  ]
+}
+
 export type SocketFixBranchParser = (
   branch: string,
 ) => SocketFixBranchParseResult | undefined
@@ -60,13 +73,7 @@ export function getSocketFixPullRequestBody(
     if (!details) {
       return body
     }
-    const packages = [
-      ...new Set(
-        details.vulnerabilities.nodes.map(
-          v => `${v.package.name} (${v.package.ecosystem})`,
-        ),
-      ),
-    ]
+    const packages = getUniquePackages(details)
     return [
       body,
       '',
@@ -86,13 +93,7 @@ export function getSocketFixPullRequestBody(
       const details = ghsaDetails?.get(id)
       const item = `- [${id}](${GITHUB_ADVISORIES_URL}/${id})`
       if (details) {
-        const packages = [
-          ...new Set(
-            details.vulnerabilities.nodes.map(
-              v => `${v.package.name} (${v.package.ecosystem})`,
-            ),
-          ),
-        ]
+        const packages = getUniquePackages(details)
         return `${item} - ${details.summary} (${joinAnd(packages)})`
       }
       return item


### PR DESCRIPTION
Removes duplicate package entries when same package appears multiple times in vulnerability data.
<img width="1076" height="328" alt="Screenshot" src="https://github.com/user-attachments/assets/54ead143-ae80-4626-a8d2-66b6c02afc83" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deduplicates affected packages in PR descriptions and appends package ecosystem to package names in both single and multi-GHSA sections.
> 
> - **PR body generation (`src/commands/fix/git.mts`)**:
>   - Deduplicate `**Affected Packages**` lists using `Set` for single- and multi-GHSA bodies.
>   - Include ecosystem alongside package name (e.g., `name (ecosystem)`) in listed packages across both paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff39f6c250d992341a6abfd77242a910591879ee. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->