### PR TITLE
Bump version to 1.1.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.31](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.31) - 2025-11-19
+
+### Fixed
+- Enhanced pull request descriptions to remove duplicate package listings for cleaner, more readable output
+
 ## [1.1.30](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.30) - 2025-11-18
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.30",
+  "version": "1.1.31",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",


### PR DESCRIPTION
Version bump to 1.1.31

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Release 1.1.31 with a fix to deduplicate package listings in generated PR descriptions.
> 
> - **Release `1.1.31`**:
>   - **Fixed**: Deduplicate package listings in generated pull request descriptions for cleaner output.
> - **Metadata**:
>   - Bump `package.json` version to `1.1.31`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2798a74197b96d3b8f4d69fa129aee0af7b8ea8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->