### PR TITLE
Bump version to v1.1.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.32](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.32) - 2025-11-20
+
+### Changed
+- Updated @coana-tech/cli to 14.12.90
+- Updated @cyclonedx/cdxgen to 11.11.0
+
+### Fixed
+- Resolved `--limit` flag behavior to correctly restrict vulnerability processing in `socket fix` local mode
+- Exclude `.socket.facts.json` files from `socket fix` manifest uploads
+
 ## [1.1.31](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.31) - 2025-11-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.31",
+  "version": "1.1.32",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",

--- a/src/commands/fix/coana-fix.mts
+++ b/src/commands/fix/coana-fix.mts
@@ -2,7 +2,6 @@ import { promises as fs } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import { DOT_SOCKET_DOT_FACTS_JSON } from '../../constants.mts'
 import { joinAnd } from '@socketsecurity/registry/lib/arrays'
 import { debugDir, debugFn } from '@socketsecurity/registry/lib/debug'
 import { readJsonSync } from '@socketsecurity/registry/lib/fs'
@@ -22,7 +21,11 @@ import {
 } from './env-helpers.mts'
 import { getSocketFixBranchName, getSocketFixCommitMessage } from './git.mts'
 import { getSocketFixPrs, openSocketFixPr } from './pull-request.mts'
-import { FLAG_DRY_RUN, GQL_PR_STATE_OPEN } from '../../constants.mts'
+import {
+  DOT_SOCKET_DOT_FACTS_JSON,
+  FLAG_DRY_RUN,
+  GQL_PR_STATE_OPEN,
+} from '../../constants.mts'
 import { handleApiCall } from '../../utils/api.mts'
 import { cmdFlagValueToArray } from '../../utils/cmd.mts'
 import { spawnCoanaDlx } from '../../utils/dlx.mts'


### PR DESCRIPTION
Release v1.1.32

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects `socket fix` local mode to respect `--limit` and excludes `.socket.facts.json` from manifest uploads; bumps deps and version to 1.1.32.
> 
> - **Fixes**:
>   - `socket fix` local mode now respects `--limit` when selecting GHSA IDs.
>   - Excludes `.socket.facts.json` from manifest uploads.
> - **Dependencies**:
>   - Update `@coana-tech/cli` to `14.12.90` and `@cyclonedx/cdxgen` to `11.11.0`.
> - **Release**:
>   - Bump version to `1.1.32` and update `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 745fb9df35e7601e61d0c0cc23b81dbafe1cd255. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->