### PR TITLE
fix: change error badge text from red to white

### DIFF
--- a/src/utils/fail-msg-with-badge.mts
+++ b/src/utils/fail-msg-with-badge.mts
@@ -5,7 +5,7 @@ export function failMsgWithBadge(
   message: string | undefined,
 ): string {
   const prefix = colors.bgRedBright(
-    colors.bold(colors.red(` ${badge}${message ? ': ' : ''}`)),
+    colors.bold(colors.white(` ${badge}${message ? ': ' : ''}`)),
   )
   const postfix = message ? ` ${colors.bold(message)}` : ''
   return `${prefix}${postfix}`


### PR DESCRIPTION
Fixes red-on-red readability issue in error messages.

Changed failMsgWithBadge to use white text on red background.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change badge text color from red to white in `src/utils/fail-msg-with-badge.mts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2b99dfaaf71eda4831ed8089297f808e1709104. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->