### PR TITLE
release v1.1.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.33](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.33) - 2025-11-20
+
+### Changed
+- Updated @coana-tech/cli to 14.12.94
+
+### Fixed
+- Enhanced error badge visibility with improved text color contrast
+
 ## [1.1.32](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.32) - 2025-11-20
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.32",
+  "version": "1.1.33",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",


### PR DESCRIPTION
Version bump to 1.1.33

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bump to 1.1.33 with changelog noting @coana-tech/cli 14.12.94 and improved error badge text contrast.
> 
> - **Release `1.1.33`**
>   - Bump `package.json` version to `1.1.33`.
>   - Update `CHANGELOG.md`:
>     - Changed: `@coana-tech/cli` to `14.12.94`.
>     - Fixed: Enhanced error badge text color contrast.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80ebeb322710613548b9f0fdca0cd47776fc4988. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->