### PR TITLE
Add `--reach-debug` flag

### DIFF
--- a/src/commands/analytics/output-analytics.test.mts
+++ b/src/commands/analytics/output-analytics.test.mts
@@ -22,76 +22,76 @@ describe('output-analytics', () => {
             "unmaintained": 133,
           },
           "total_critical_added": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
           "total_critical_alerts": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
           "total_critical_prevented": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
           "total_high_added": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
           "total_high_alerts": {
-            "Apr 18": 13,
             "Apr 19": 13,
             "Apr 20": 13,
-            "Apr 21": 10,
+            "Apr 21": 13,
+            "Apr 22": 10,
           },
           "total_high_prevented": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
           "total_low_added": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
           "total_low_alerts": {
-            "Apr 18": 1054,
-            "Apr 19": 1060,
-            "Apr 20": 1066,
-            "Apr 21": 1059,
+            "Apr 19": 1054,
+            "Apr 20": 1060,
+            "Apr 21": 1066,
+            "Apr 22": 1059,
           },
           "total_low_prevented": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
           "total_medium_added": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
           "total_medium_alerts": {
-            "Apr 18": 206,
-            "Apr 19": 207,
-            "Apr 20": 209,
-            "Apr 21": 206,
+            "Apr 19": 206,
+            "Apr 20": 207,
+            "Apr 21": 209,
+            "Apr 22": 206,
           },
           "total_medium_prevented": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
         }
       `)
@@ -110,76 +110,76 @@ describe('output-analytics', () => {
             "unmaintained": 532,
           },
           "total_critical_added": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
           "total_critical_alerts": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
           "total_critical_prevented": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
           "total_high_added": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
           "total_high_alerts": {
-            "Apr 18": 13,
             "Apr 19": 13,
             "Apr 20": 13,
-            "Apr 21": 10,
+            "Apr 21": 13,
+            "Apr 22": 10,
           },
           "total_high_prevented": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
           "total_low_added": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
           "total_low_alerts": {
-            "Apr 18": 1054,
-            "Apr 19": 1060,
-            "Apr 20": 1066,
-            "Apr 21": 1059,
+            "Apr 19": 1054,
+            "Apr 20": 1060,
+            "Apr 21": 1066,
+            "Apr 22": 1059,
           },
           "total_low_prevented": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
           "total_medium_added": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
           "total_medium_alerts": {
-            "Apr 18": 206,
-            "Apr 19": 207,
-            "Apr 20": 209,
-            "Apr 21": 206,
+            "Apr 19": 206,
+            "Apr 20": 207,
+            "Apr 21": 209,
+            "Apr 22": 206,
           },
           "total_medium_prevented": {
-            "Apr 18": 0,
             "Apr 19": 0,
             "Apr 20": 0,
             "Apr 21": 0,
+            "Apr 22": 0,
           },
         }
       `)
@@ -200,80 +200,80 @@ describe('output-analytics', () => {
 
         | Date   | Counts |
         | ------ | ------ |
-        | Apr 18 |      0 |
-        | Apr 20 |      0 |
         | Apr 19 |      0 |
         | Apr 21 |      0 |
+        | Apr 20 |      0 |
+        | Apr 22 |      0 |
         | ------ | ------ |
 
         ## Total high alerts
 
         | Date   | Counts |
         | ------ | ------ |
-        | Apr 18 |     13 |
-        | Apr 20 |     13 |
         | Apr 19 |     13 |
-        | Apr 21 |     10 |
+        | Apr 21 |     13 |
+        | Apr 20 |     13 |
+        | Apr 22 |     10 |
         | ------ | ------ |
 
         ## Total critical alerts added to the main branch
 
         | Date   | Counts |
         | ------ | ------ |
-        | Apr 18 |      0 |
-        | Apr 20 |      0 |
         | Apr 19 |      0 |
         | Apr 21 |      0 |
+        | Apr 20 |      0 |
+        | Apr 22 |      0 |
         | ------ | ------ |
 
         ## Total high alerts added to the main branch
 
         | Date   | Counts |
         | ------ | ------ |
-        | Apr 18 |      0 |
-        | Apr 20 |      0 |
         | Apr 19 |      0 |
         | Apr 21 |      0 |
+        | Apr 20 |      0 |
+        | Apr 22 |      0 |
         | ------ | ------ |
 
         ## Total critical alerts prevented from the main branch
 
         | Date   | Counts |
         | ------ | ------ |
-        | Apr 18 |      0 |
-        | Apr 20 |      0 |
         | Apr 19 |      0 |
         | Apr 21 |      0 |
+        | Apr 20 |      0 |
+        | Apr 22 |      0 |
         | ------ | ------ |
 
         ## Total high alerts prevented from the main branch
 
         | Date   | Counts |
         | ------ | ------ |
-        | Apr 18 |      0 |
-        | Apr 20 |      0 |
         | Apr 19 |      0 |
         | Apr 21 |      0 |
+        | Apr 20 |      0 |
+        | Apr 22 |      0 |
         | ------ | ------ |
 
         ## Total medium alerts prevented from the main branch
 
         | Date   | Counts |
         | ------ | ------ |
-        | Apr 18 |      0 |
-        | Apr 20 |      0 |
         | Apr 19 |      0 |
         | Apr 21 |      0 |
+        | Apr 20 |      0 |
+        | Apr 22 |      0 |
         | ------ | ------ |
 
         ## Total low alerts prevented from the main branch
 
         | Date   | Counts |
         | ------ | ------ |
-        | Apr 18 |      0 |
-        | Apr 20 |      0 |
         | Apr 19 |      0 |
         | Apr 21 |      0 |
+        | Apr 20 |      0 |
+        | Apr 22 |      0 |
         | ------ | ------ |
 
         ## Top 5 alert types

--- a/src/commands/ci/handle-ci.mts
+++ b/src/commands/ci/handle-ci.mts
@@ -54,6 +54,7 @@ export async function handleCi(autoManifest: boolean): Promise<void> {
       reachAnalysisTimeout: 0,
       reachAnalysisMemoryLimit: 0,
       reachConcurrency: 1,
+      reachDebug: false,
       reachDisableAnalytics: false,
       reachDisableAnalysisSplitting: false,
       reachEcosystems: [],

--- a/src/commands/scan/cmd-scan-create.mts
+++ b/src/commands/scan/cmd-scan-create.mts
@@ -239,6 +239,7 @@ async function run(
     reachAnalysisMemoryLimit,
     reachAnalysisTimeout,
     reachConcurrency,
+    reachDebug,
     reachDisableAnalysisSplitting,
     reachDisableAnalytics,
     reachSkipCache,
@@ -266,6 +267,7 @@ async function run(
     reachAnalysisTimeout: number
     reachAnalysisMemoryLimit: number
     reachConcurrency: number
+    reachDebug: boolean
     reachDisableAnalytics: boolean
     reachDisableAnalysisSplitting: boolean
     reachSkipCache: boolean
@@ -523,6 +525,7 @@ async function run(
       reachAnalysisTimeout: Number(reachAnalysisTimeout),
       reachAnalysisMemoryLimit: Number(reachAnalysisMemoryLimit),
       reachConcurrency: Number(reachConcurrency),
+      reachDebug: Boolean(reachDebug),
       reachDisableAnalysisSplitting: Boolean(reachDisableAnalysisSplitting),
       reachEcosystems,
       reachExcludePaths,

--- a/src/commands/scan/cmd-scan-create.test.mts
+++ b/src/commands/scan/cmd-scan-create.test.mts
@@ -57,6 +57,7 @@ describe('socket scan create', async () => {
             --reach-analysis-memory-limit  The maximum memory in MB to use for the reachability analysis. The default is 8192MB.
             --reach-analysis-timeout  Set timeout for the reachability analysis. Split analysis runs may cause the total scan time to exceed this timeout significantly.
             --reach-concurrency  Set the maximum number of concurrent reachability analysis runs. It is recommended to choose a concurrency level that ensures each analysis run has at least the --reach-analysis-memory-limit amount of memory available. NPM reachability analysis does not support concurrent execution, so the concurrency level is ignored for NPM.
+            --reach-debug       Enable debug mode for reachability analysis. Provides verbose logging from the reachability CLI.
             --reach-disable-analysis-splitting  Limits Coana to at most 1 reachability analysis run per workspace.
             --reach-disable-analytics  Disable reachability analytics sharing with Socket. Also disables caching-based optimizations.
             --reach-ecosystems  List of ecosystems to conduct reachability analysis on, as either a comma separated value or as multiple flags. Defaults to all ecosystems.

--- a/src/commands/scan/cmd-scan-reach.mts
+++ b/src/commands/scan/cmd-scan-reach.mts
@@ -112,6 +112,7 @@ async function run(
     reachAnalysisMemoryLimit,
     reachAnalysisTimeout,
     reachConcurrency,
+    reachDebug,
     reachDisableAnalysisSplitting,
     reachDisableAnalytics,
     reachSkipCache,
@@ -124,6 +125,7 @@ async function run(
     reachAnalysisTimeout: number
     reachAnalysisMemoryLimit: number
     reachConcurrency: number
+    reachDebug: boolean
     reachDisableAnalytics: boolean
     reachDisableAnalysisSplitting: boolean
     reachSkipCache: boolean
@@ -207,6 +209,7 @@ async function run(
       reachAnalysisTimeout: Number(reachAnalysisTimeout),
       reachAnalysisMemoryLimit: Number(reachAnalysisMemoryLimit),
       reachConcurrency: Number(reachConcurrency),
+      reachDebug: Boolean(reachDebug),
       reachDisableAnalytics: Boolean(reachDisableAnalytics),
       reachDisableAnalysisSplitting: Boolean(reachDisableAnalysisSplitting),
       reachEcosystems,

--- a/src/commands/scan/cmd-scan-reach.test.mts
+++ b/src/commands/scan/cmd-scan-reach.test.mts
@@ -39,6 +39,7 @@ describe('socket scan reach', async () => {
             --reach-analysis-memory-limit  The maximum memory in MB to use for the reachability analysis. The default is 8192MB.
             --reach-analysis-timeout  Set timeout for the reachability analysis. Split analysis runs may cause the total scan time to exceed this timeout significantly.
             --reach-concurrency  Set the maximum number of concurrent reachability analysis runs. It is recommended to choose a concurrency level that ensures each analysis run has at least the --reach-analysis-memory-limit amount of memory available. NPM reachability analysis does not support concurrent execution, so the concurrency level is ignored for NPM.
+            --reach-debug       Enable debug mode for reachability analysis. Provides verbose logging from the reachability CLI.
             --reach-disable-analysis-splitting  Limits Coana to at most 1 reachability analysis run per workspace.
             --reach-disable-analytics  Disable reachability analytics sharing with Socket. Also disables caching-based optimizations.
             --reach-ecosystems  List of ecosystems to conduct reachability analysis on, as either a comma separated value or as multiple flags. Defaults to all ecosystems.

--- a/src/commands/scan/create-scan-from-github.mts
+++ b/src/commands/scan/create-scan-from-github.mts
@@ -254,6 +254,7 @@ async function scanOneRepo(
       reachAnalysisTimeout: 0,
       reachAnalysisMemoryLimit: 0,
       reachConcurrency: 1,
+      reachDebug: false,
       reachDisableAnalysisSplitting: false,
       reachEcosystems: [],
       reachExcludePaths: [],

--- a/src/commands/scan/perform-reachability-analysis.mts
+++ b/src/commands/scan/perform-reachability-analysis.mts
@@ -17,6 +17,7 @@ export type ReachabilityOptions = {
   reachAnalysisTimeout: number
   reachAnalysisMemoryLimit: number
   reachConcurrency: number
+  reachDebug: boolean
   reachDisableAnalytics: boolean
   reachDisableAnalysisSplitting: boolean
   reachEcosystems: PURL_Type[]
@@ -151,6 +152,7 @@ export async function performReachabilityAnalysis(
     ...(reachabilityOptions.reachConcurrency
       ? ['--concurrency', `${reachabilityOptions.reachConcurrency}`]
       : []),
+    ...(reachabilityOptions.reachDebug ? ['--debug'] : []),
     ...(reachabilityOptions.reachDisableAnalytics
       ? ['--disable-analytics-sharing']
       : []),

--- a/src/commands/scan/reachability-flags.mts
+++ b/src/commands/scan/reachability-flags.mts
@@ -19,6 +19,12 @@ export const reachabilityFlags: MeowFlags = {
     description:
       'Set the maximum number of concurrent reachability analysis runs. It is recommended to choose a concurrency level that ensures each analysis run has at least the --reach-analysis-memory-limit amount of memory available. NPM reachability analysis does not support concurrent execution, so the concurrency level is ignored for NPM.',
   },
+  reachDebug: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Enable debug mode for reachability analysis. Provides verbose logging from the reachability CLI.',
+  },
   reachDisableAnalytics: {
     type: 'boolean',
     default: false,


### PR DESCRIPTION
Add the flag `--reach-debug` to `socket scan create` and `socket scan reach` to enable verbose debug logging when shelling out to the Coana/Reachability CLI.