### PR TITLE
upgrade coana to 14.12.101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.36](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.35) - 2025-11-26
+
+### Fixed
+- Fix a bug where the reachability analysis would hang on runs with analysis errors.
+
+### Changed
+- Updated `@coana-tech/cli` to 14.12.100
+
 ## [1.1.35](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.35) - 2025-11-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.100",
+    "@coana-tech/cli": "14.12.101",
     "@cyclonedx/cdxgen": "11.11.0",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.100
-        version: 14.12.100
+        specifier: 14.12.101
+        version: 14.12.101
       '@cyclonedx/cdxgen':
         specifier: 11.11.0
         version: 11.11.0
@@ -677,8 +677,8 @@ packages:
   '@bufbuild/protobuf@2.6.3':
     resolution: {integrity: sha512-w/gJKME9mYN7ZoUAmSMAWXk4hkVpxRKvEJCb3dV5g9wwWdxTJJ0ayOJAVcNxtdqaxDyFuC0uz4RSGVacJ030PQ==}
 
-  '@coana-tech/cli@14.12.100':
-    resolution: {integrity: sha512-/oD3WVpOIMjgE/JaIQuZNi9q3/dvqGFYvlotfRPAUhRn8837BfDHcz2izkaxF8r6m7EyE8tKMK5VXNZ3DnaHXg==}
+  '@coana-tech/cli@14.12.101':
+    resolution: {integrity: sha512-rlqJaGNBzgYGd7/2NoabD1FpBzpX6csq3JRIOvBK+8MpRsC1I0VESN6s71AAvheMQb2/e/9HnbZR/koKqjTzog==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5315,7 +5315,7 @@ snapshots:
   '@bufbuild/protobuf@2.6.3':
     optional: true
 
-  '@coana-tech/cli@14.12.100': {}
+  '@coana-tech/cli@14.12.101': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
Upgrade the Coana CLI to v14.12.101

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps Coana CLI to 14.12.101 and updates CHANGELOG with a 1.1.36 fix note.
> 
> - **Dependencies**:
>   - Upgrade `@coana-tech/cli` to `14.12.101` in `package.json` and `pnpm-lock.yaml`.
> - **Docs**:
>   - Add `CHANGELOG.md` entry for `1.1.36` noting a fix for reachability analysis hanging with analysis errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a5826dea9a4f6840ba75aa5c68ba815bacb43ae. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->