### PR TITLE
fix(api): improve CVE to GHSA conversion caching and error messaging

### DIFF
--- a/src/utils/cve-to-ghsa.mts
+++ b/src/utils/cve-to-ghsa.mts
@@ -14,8 +14,7 @@ export async function convertCveToGhsa(
     const cacheKey = `cve-to-ghsa-${cveId}`
     const octokit = getOctokit()
 
-    // CVE to GHSA mappings don't change, cache for 30 days (in milliseconds).
-    const THIRTY_DAYS_MS = 2_592_000_000
+    const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000
 
     const response = await cacheFetch(
       cacheKey,
@@ -40,16 +39,18 @@ export async function convertCveToGhsa(
     }
   } catch (e) {
     const errorCause = getErrorCause(e)
-    // Detect GitHub API rate limit errors.
-    const isGitHubRateLimit =
-      errorCause.includes('rate limit') ||
-      errorCause.includes('EPIPE') ||
-      errorCause.includes('ECONNRESET') ||
-      errorCause.includes('403')
+    const errorLower = errorCause.toLowerCase()
+    // Detect GitHub API rate limit and network errors.
+    const isRateLimitOrNetworkError =
+      errorLower.includes('rate limit') ||
+      errorLower.includes('epipe') ||
+      errorLower.includes('econnreset') ||
+      errorLower.includes('status: 403') ||
+      errorLower.includes('status code 403')
 
     return {
       ok: false,
-      message: isGitHubRateLimit
+      message: isRateLimitOrNetworkError
         ? 'GitHub API rate limit exceeded while converting CVE to GHSA. Wait an hour or set SOCKET_CLI_GITHUB_TOKEN environment variable with a personal access token for higher limits.'
         : `Failed to convert CVE to GHSA: ${errorCause}`,
     }


### PR DESCRIPTION
Backport of 1eb38d0e to v1.x.

Improves CVE to GHSA conversion caching and error messaging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Caches CVE-to-GHSA lookups for 30 days and adds explicit GitHub rate-limit detection with clearer error messaging.
> 
> - **Utils**:
>   - `src/utils/cve-to-ghsa.mts`:
>     - Cache `convertCveToGhsa` results for 30 days via `cacheFetch` TTL.
>     - Add GitHub rate-limit detection (`rate limit`, `EPIPE`, `ECONNRESET`, `403`) with specific guidance; otherwise return concise error cause.
>     - Return early when no advisories found and extract `ghsa_id` from first result.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efe226f740e19c1c98dc45a27942a153dc23cadb. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->