### PR TITLE
Upgrade coana to v14.12.112

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.42](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.40) - 2025-12-04
+
+### Changed
+- Updated the Coana CLI to v `14.12.112`.
+
 ## [1.1.41](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.40) - 2025-12-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.41",
+  "version": "1.1.42",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -94,7 +94,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.110",
+    "@coana-tech/cli": "14.12.112",
     "@cyclonedx/cdxgen": "11.11.0",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.110
-        version: 14.12.110
+        specifier: 14.12.112
+        version: 14.12.112
       '@cyclonedx/cdxgen':
         specifier: 11.11.0
         version: 11.11.0
@@ -677,8 +677,8 @@ packages:
   '@bufbuild/protobuf@2.6.3':
     resolution: {integrity: sha512-w/gJKME9mYN7ZoUAmSMAWXk4hkVpxRKvEJCb3dV5g9wwWdxTJJ0ayOJAVcNxtdqaxDyFuC0uz4RSGVacJ030PQ==}
 
-  '@coana-tech/cli@14.12.110':
-    resolution: {integrity: sha512-I+SAm9VKoZpLsI0yz4qTIKJIGkN5qbTtp/fxhWaOgjC01riCcAdm0cIqsJZJZgp6xYlR401G86efeauIsSlQsA==}
+  '@coana-tech/cli@14.12.112':
+    resolution: {integrity: sha512-Qo41FPqDFr+fuxRpGGNWahcqBhxkgJ5qw3ODFm2jsh/alFtQW3iIJ1/vgKSRbC07Dz6CJZWFoHZbKqJaTNpnhQ==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5315,7 +5315,7 @@ snapshots:
   '@bufbuild/protobuf@2.6.3':
     optional: true
 
-  '@coana-tech/cli@14.12.110': {}
+  '@coana-tech/cli@14.12.112': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
Updates the Coana CLI to [v14.12.112](https://docs.coana.tech/changelogs/cli#1412112-dec-4-2025):
- The concurrency option now works for JavaScript projects
- A new summary is written to stdout when the reachability analysis completes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade Coana CLI to 14.12.112 and release version 1.1.42 with a changelog update.
> 
> - **Dependencies**:
>   - Update `@coana-tech/cli` to `14.12.112` in `package.json`.
> - **Release**:
>   - Bump version to `1.1.42` and add changelog entry in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dd8b32fcf15701c5cad7dedc2ae547a880a3a12. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->