### PR TITLE
add `--all` flag for `socket fix` and make it incompatible with `--id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.43](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.43) - 2025-12-08
+
+### Added
+- Added `--all` flag to `socket fix` for explicitly processing all vulnerabilities in local mode. Cannot be used with `--id`.
+
+### Deprecated
+- Running `socket fix` in local mode without `--all` or `--id` is deprecated. A warning is shown when neither flag is provided. In a future release, one of these flags will be required.
+
 ## [1.1.42](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.42) - 2025-12-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.42",
+  "version": "1.1.43",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",

--- a/src/commands/fix/cmd-fix.integration.test.mts
+++ b/src/commands/fix/cmd-fix.integration.test.mts
@@ -164,6 +164,7 @@ describe('socket fix', async () => {
             - Permissions: full-scans:create and packages:list
 
           Options
+            --all               Process all discovered vulnerabilities in local mode. Cannot be used with --id.
             --autopilot         Enable auto-merge for pull requests that Socket opens.
                                 See GitHub documentation (https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository) for managing auto-merge for pull requests in your repository.
             --ecosystems        Limit fix analysis to specific ecosystems. Can be provided as comma separated values or as multiple flags. Defaults to all ecosystems.
@@ -173,7 +174,7 @@ describe('socket fix', async () => {
                                     - GHSA IDs (https://docs.github.com/en/code-security/security-advisories/working-with-global-security-advisories-from-the-github-advisory-database/about-the-github-advisory-database#about-ghsa-ids) (e.g., GHSA-xxxx-xxxx-xxxx)
                                     - CVE IDs (https://cve.mitre.org/cve/identifiers/) (e.g., CVE-2025-1234) - automatically converted to GHSA
                                     - PURLs (https://github.com/package-url/purl-spec) (e.g., pkg:npm/package@1.0.0) - automatically converted to GHSA
-                                    Can be provided as comma separated values or as multiple flags
+                                    Can be provided as comma separated values or as multiple flags. Cannot be used with --all.
             --include           Include workspaces matching these glob patterns. Can be provided as comma separated values or as multiple flags
             --json              Output as JSON
             --markdown          Output as Markdown
@@ -1123,6 +1124,55 @@ describe('socket fix', async () => {
         const output = stdout + stderr
         expect(output).toContain('Invalid ecosystem')
         expect(code, 'should exit with non-zero code').not.toBe(0)
+      },
+    )
+  })
+
+  describe('--all flag behavior', () => {
+    cmdit(
+      ['fix', FLAG_DRY_RUN, '--all', FLAG_CONFIG, '{"apiToken":"fakeToken"}'],
+      'should accept --all flag',
+      async cmd => {
+        const { code, stdout } = await spawnSocketCli(binCliPath, cmd)
+        expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Not saving"`)
+        expect(code, 'should exit with code 0').toBe(0)
+      },
+    )
+
+    cmdit(
+      [
+        'fix',
+        FLAG_DRY_RUN,
+        '--all',
+        FLAG_ID,
+        'GHSA-1234-5678-9abc',
+        FLAG_CONFIG,
+        '{"apiToken":"fakeToken"}',
+      ],
+      'should fail when --all and --id are used together',
+      async cmd => {
+        const { code, stderr, stdout } = await spawnSocketCli(binCliPath, cmd)
+        const output = stdout + stderr
+        expect(output).toContain('--all and --id flags cannot be used together')
+        expect(code, 'should exit with non-zero code').not.toBe(0)
+      },
+    )
+
+    cmdit(
+      [
+        'fix',
+        FLAG_DRY_RUN,
+        '--all',
+        '--ecosystems',
+        'npm',
+        FLAG_CONFIG,
+        '{"apiToken":"fakeToken"}',
+      ],
+      'should accept --all with --ecosystems',
+      async cmd => {
+        const { code, stdout } = await spawnSocketCli(binCliPath, cmd)
+        expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Not saving"`)
+        expect(code, 'should exit with code 0').toBe(0)
       },
     )
   })

--- a/src/commands/fix/coana-fix.mts
+++ b/src/commands/fix/coana-fix.mts
@@ -107,6 +107,7 @@ export async function coanaFix(
   fixConfig: FixConfig,
 ): Promise<CResult<{ data?: unknown; fixed: boolean }>> {
   const {
+    all,
     applyFixes,
     autopilot,
     coanaVersion,
@@ -173,11 +174,18 @@ export async function coanaFix(
     }
   }
 
-  const shouldDiscoverGhsaIds = !ghsas.length
+  const shouldDiscoverGhsaIds = all || !ghsas.length
 
   const shouldOpenPrs = fixEnv.isCi && fixEnv.repoInfo
 
   if (!shouldOpenPrs) {
+    // In local mode, if neither --all nor --id is provided, show deprecation warning.
+    if (shouldDiscoverGhsaIds && !all) {
+      logger.warn(
+        'Implicit --all is deprecated in local mode and will be removed in a future release. Please use --all explicitly.',
+      )
+    }
+
     // Inform user about local mode when fixes will be applied.
     if (applyFixes && ghsas.length) {
       const envCheck = checkCiEnvVars()

--- a/src/commands/fix/handle-fix-limit.test.mts
+++ b/src/commands/fix/handle-fix-limit.test.mts
@@ -72,6 +72,7 @@ vi.mock('./branch-cleanup.mts', () => ({
 
 describe('socket fix --pr-limit behavior verification', () => {
   const baseConfig: FixConfig = {
+    all: false,
     applyFixes: true,
     autopilot: false,
     coanaVersion: undefined,

--- a/src/commands/fix/handle-fix.mts
+++ b/src/commands/fix/handle-fix.mts
@@ -97,6 +97,7 @@ export async function convertIdsToGhsas(ids: string[]): Promise<string[]> {
 }
 
 export async function handleFix({
+  all,
   applyFixes,
   autopilot,
   coanaVersion,
@@ -120,6 +121,7 @@ export async function handleFix({
 }: HandleFixConfig) {
   debugFn('notice', `Starting fix command for ${orgSlug}`)
   debugDir('inspect', {
+    all,
     applyFixes,
     autopilot,
     coanaVersion,
@@ -142,6 +144,7 @@ export async function handleFix({
 
   await outputFixResult(
     await coanaFix({
+      all,
       applyFixes,
       autopilot,
       coanaVersion,

--- a/src/commands/fix/types.mts
+++ b/src/commands/fix/types.mts
@@ -3,6 +3,7 @@ import type { RangeStyle } from '../../utils/semver.mts'
 import type { Spinner } from '@socketsecurity/registry/lib/spinner'
 
 export type FixConfig = {
+  all: boolean
   applyFixes: boolean
   autopilot: boolean
   coanaVersion: string | undefined


### PR DESCRIPTION
implicitly use `--all` if no `--id` but warn that this is deprecated in local mode


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `--all` to `socket fix` (cannot be combined with `--id`), warns in local mode when neither is provided, and threads the flag through CLI, logic, types, and tests.
> 
> - **`socket fix` CLI**
>   - Add `--all` flag to process all discovered vulnerabilities in local mode; update help text.
>   - Enforce mutual exclusivity between `--all` and `--id` with input validation.
>   - In local mode, continue discovering when no `--id`, but log deprecation warning if `--all` not provided.
> - **Implementation**
>   - Thread `all` through `cmd-fix.mts` → `handle-fix.mts` → `coana-fix.mts` and `types.mts`.
>   - Update discovery logic to use `all || !ghsas.length`.
> - **Tests**
>   - Add integration tests for `--all` acceptance, incompatibility with `--id`, and use with `--ecosystems`.
> - **Release**
>   - Bump version to `1.1.43` and update `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5494efbcb3caf35d41f83787a542321dbdf62421. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->