### PR TITLE
update coana to 14.12.130: Avoid full dependency install when finaliz…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.48](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.48) - 2025-12-16
+
+### Changed
+- Updated the Coana CLI to v `14.12.130`.
+
 ## [1.1.47](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.47) - 2025-12-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.47",
+  "version": "1.1.48",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -94,7 +94,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.127",
+    "@coana-tech/cli": "14.12.130",
     "@cyclonedx/cdxgen": "11.11.0",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.127
-        version: 14.12.127
+        specifier: 14.12.130
+        version: 14.12.130
       '@cyclonedx/cdxgen':
         specifier: 11.11.0
         version: 11.11.0
@@ -677,8 +677,8 @@ packages:
   '@bufbuild/protobuf@2.6.3':
     resolution: {integrity: sha512-w/gJKME9mYN7ZoUAmSMAWXk4hkVpxRKvEJCb3dV5g9wwWdxTJJ0ayOJAVcNxtdqaxDyFuC0uz4RSGVacJ030PQ==}
 
-  '@coana-tech/cli@14.12.127':
-    resolution: {integrity: sha512-Qqur01VrS788uCzSTLhcfL9De/IqccIi8FkJFaAEusew/gVDL/1g3mKI2dy5t64JuF3eIK0aWt50CXlFcb+J0w==}
+  '@coana-tech/cli@14.12.130':
+    resolution: {integrity: sha512-enz640WOF+fcileMtYBZsYxvQh8q9ZVjCT/YT7SqbjiZoGmSQ8KKeofNzFjgiWCUlqfJZklDkChJOzY32BZOAQ==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5315,7 +5315,7 @@ snapshots:
   '@bufbuild/protobuf@2.6.3':
     optional: true
 
-  '@coana-tech/cli@14.12.127': {}
+  '@coana-tech/cli@14.12.130': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
…ing npm fixes.

The updated version of coana should hopefully alleviate the long npm lockfile finalization step encountered by Figma:
https://socketdev.slack.com/archives/C03K8A9S9HV/p1765830403443619?thread_ts=1765561894.894809&cid=C03K8A9S9HV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps the CLI to v1.1.48 and updates dev dependency `@coana-tech/cli` to `14.12.130`.
> 
> - **Release**:
>   - Bump package version to `1.1.48`.
>   - Update `CHANGELOG.md` for `1.1.48`.
> - **Dependencies**:
>   - Update dev dependency `@coana-tech/cli` from `14.12.127` to `14.12.130`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07d6163b000e9d376995465ea887391410eb5406. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->