### PR TITLE
fix error being rethrown when npm finalize fix failed in `socket fix`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.49](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.49) - 2025-12-16
+
+### Changed
+- Updated the Coana CLI to v `14.12.134`.
+
 ## [1.1.48](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.48) - 2025-12-16
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.130",
+    "@coana-tech/cli": "14.12.134",
     "@cyclonedx/cdxgen": "11.11.0",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.130
-        version: 14.12.130
+        specifier: 14.12.134
+        version: 14.12.134
       '@cyclonedx/cdxgen':
         specifier: 11.11.0
         version: 11.11.0
@@ -677,8 +677,8 @@ packages:
   '@bufbuild/protobuf@2.6.3':
     resolution: {integrity: sha512-w/gJKME9mYN7ZoUAmSMAWXk4hkVpxRKvEJCb3dV5g9wwWdxTJJ0ayOJAVcNxtdqaxDyFuC0uz4RSGVacJ030PQ==}
 
-  '@coana-tech/cli@14.12.130':
-    resolution: {integrity: sha512-enz640WOF+fcileMtYBZsYxvQh8q9ZVjCT/YT7SqbjiZoGmSQ8KKeofNzFjgiWCUlqfJZklDkChJOzY32BZOAQ==}
+  '@coana-tech/cli@14.12.134':
+    resolution: {integrity: sha512-Nr+BNFL8hS0qymGhm2kAmq4O/gUCWp4kK4wqa2YBkrb3I07IQABJvvHvIpjHwjWtzZ/t8UFfBISUBr2FKNF9MA==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5315,7 +5315,7 @@ snapshots:
   '@bufbuild/protobuf@2.6.3':
     optional: true
 
-  '@coana-tech/cli@14.12.130': {}
+  '@coana-tech/cli@14.12.134': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps `@coana-tech/cli` to 14.12.134 and documents it in the changelog.
> 
> - **Dependencies**:
>   - Update devDependency `@coana-tech/cli` from `14.12.130` to `14.12.134` and refresh `pnpm-lock.yaml`.
> - **Changelog**:
>   - Add `1.1.49` entry noting the Coana CLI update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d725c0247f76114d28a10a52f8764d7c98bedd51. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->