### PR TITLE
Bump to v1.1.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [1.1.49](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.49) - 2025-12-16
+## [1.1.49](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.49) - 2025-12-17
+
+### Added
+- Added initial telemetry functionality to track CLI usage and help improve the Socket experience.
+
+### Fixed
+- Fixed error propagation when npm package finalization failed in `socket fix`.
 
 ### Changed
 - Updated the Coana CLI to v `14.12.134`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.48",
+  "version": "1.1.49",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Release 1.1.49 introducing initial telemetry, fixing `socket fix` error propagation, and updating Coana CLI to 14.12.134.
> 
> - **Release 1.1.49**:
>   - **Added**: Initial telemetry to track CLI usage.
>   - **Fixed**: Error propagation when npm package finalization fails in `socket fix`.
>   - **Changed**: Update `@coana-tech/cli` to `14.12.134`.
> - **Packaging**:
>   - Bump `package.json` version to `1.1.49`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28d77b8bc4c82db5b584f5644b47c4f66df57a09. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->