### PR TITLE
Return non-zero exit code when scan report data is not healthy.

### DIFF
--- a/src/commands/scan/output-scan-report.mts
+++ b/src/commands/scan/output-scan-report.mts
@@ -87,6 +87,11 @@ export async function outputScanReport(
     return
   }
 
+  if (!scanReport.data.healthy) {
+    // When report contains healthy: false, process should exit with non-zero code.
+    process.exitCode = 1
+  }
+
   // I don't think we emit the default error message with banner for an unhealthy report, do we?
   // if (!scanReport.data.healthy) {
   //   logger.fail(failMsgWithBadge(scanReport.message, scanReport.cause))


### PR DESCRIPTION
Fixes the issue where socket ci would exit with code 0 even when
blocking alerts were found.

This is the expected behaviour based on our docs: https://docs.socket.dev/docs/socket-ci#non-zero-exit-code