### PR TITLE
Bump to v1.1.50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.50](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.50) - 2025-12-19
+
+### Fixed
+- Fixed exit code when blocking alerts are found
+
 ## [1.1.49](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.49) - 2025-12-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.49",
+  "version": "1.1.50",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps to v1.1.50 and fixes the exit code when blocking alerts are found.
> 
> - **Release**:
>   - Bump version in `package.json` to `1.1.50`.
> - **Changelog**:
>   - Add `1.1.50` entry noting fix to exit code when blocking alerts are found.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5205621772e3cf5540603c01d85b3d961fa55886. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->