### PR TITLE
bump coana version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.54](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.54) - 2026-01-08
+
+### Changed
+- Updated the Coana CLI to v `14.12.143`.
+
 ## [1.1.53](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.53) - 2026-01-06
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.53",
+  "version": "1.1.54",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -94,7 +94,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.139",
+    "@coana-tech/cli": "14.12.143",
     "@cyclonedx/cdxgen": "11.11.0",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.139
-        version: 14.12.139
+        specifier: 14.12.143
+        version: 14.12.143
       '@cyclonedx/cdxgen':
         specifier: 11.11.0
         version: 11.11.0
@@ -680,8 +680,8 @@ packages:
   '@bufbuild/protobuf@2.6.3':
     resolution: {integrity: sha512-w/gJKME9mYN7ZoUAmSMAWXk4hkVpxRKvEJCb3dV5g9wwWdxTJJ0ayOJAVcNxtdqaxDyFuC0uz4RSGVacJ030PQ==}
 
-  '@coana-tech/cli@14.12.139':
-    resolution: {integrity: sha512-oI9nwrPYN1j40Li3LACTxe+PH6WxrJbcHOOY2mYGgyeW4FGgW3jjR9PRzUFetI2sRasAe7G9x5902cxOgAsAVg==}
+  '@coana-tech/cli@14.12.143':
+    resolution: {integrity: sha512-DHblCAPsVR3TZ+z0B3pYUDlXsRr9zGzCccmRDT9effzrccTeHqoTdmop4LZky62jWGUlneQzxlPVh85mfWaSBQ==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5323,7 +5323,7 @@ snapshots:
   '@bufbuild/protobuf@2.6.3':
     optional: true
 
-  '@coana-tech/cli@14.12.139': {}
+  '@coana-tech/cli@14.12.143': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Preps a patch release and updates Coana CLI.
> 
> - Bumps package version to `1.1.54` in `package.json`
> - Updates `@coana-tech/cli` to `14.12.143` and syncs `pnpm-lock.yaml`
> - Adds `CHANGELOG.md` entry for `1.1.54` noting the Coana CLI update
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 904f1cce29d0ca68376a10b0d94271962bca043a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->