### PR TITLE
upgrade Coana

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [1.1.54](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.54) - 2026-01-08
+## [1.1.55](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.55) - 2026-01-09
+
+### Changed
+- Updated the Coana CLI to v `14.12.148`.
+
+## [1.1.54](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.54) - 2026-01-09
 
 ### Changed
 - Updated the Coana CLI to v `14.12.143`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.54",
+  "version": "1.1.55",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -94,7 +94,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.143",
+    "@coana-tech/cli": "14.12.148",
     "@cyclonedx/cdxgen": "11.11.0",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.143
-        version: 14.12.143
+        specifier: 14.12.148
+        version: 14.12.148
       '@cyclonedx/cdxgen':
         specifier: 11.11.0
         version: 11.11.0
@@ -680,8 +680,8 @@ packages:
   '@bufbuild/protobuf@2.6.3':
     resolution: {integrity: sha512-w/gJKME9mYN7ZoUAmSMAWXk4hkVpxRKvEJCb3dV5g9wwWdxTJJ0ayOJAVcNxtdqaxDyFuC0uz4RSGVacJ030PQ==}
 
-  '@coana-tech/cli@14.12.143':
-    resolution: {integrity: sha512-DHblCAPsVR3TZ+z0B3pYUDlXsRr9zGzCccmRDT9effzrccTeHqoTdmop4LZky62jWGUlneQzxlPVh85mfWaSBQ==}
+  '@coana-tech/cli@14.12.148':
+    resolution: {integrity: sha512-UUUKFCa4KVpbuBrsyjK/bfgaP0ERSgPkA8BmklGxfjFGQKakTqQCW+OEQa4cJ4OWcmDFtGPNSO97jg0g2TcOIg==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5323,7 +5323,7 @@ snapshots:
   '@bufbuild/protobuf@2.6.3':
     optional: true
 
-  '@coana-tech/cli@14.12.143': {}
+  '@coana-tech/cli@14.12.148': {}
 
   '@colors/colors@1.5.0':
     optional: true

--- a/src/commands/scan/fetch-supported-scan-file-names.mts
+++ b/src/commands/scan/fetch-supported-scan-file-names.mts
@@ -17,8 +17,8 @@ export async function fetchSupportedScanFileNames(
 ): Promise<CResult<SocketSdkSuccessResult<'getReportSupportedFiles'>['data']>> {
   const {
     sdkOpts,
-    spinner,
     silence = false,
+    spinner,
   } = {
     __proto__: null,
     ...options,

--- a/src/utils/api.mts
+++ b/src/utils/api.mts
@@ -138,8 +138,8 @@ export async function handleApiCall<T extends SocketSdkOperations>(
   const {
     commandPath,
     description,
-    spinner,
     silence = false,
+    spinner,
   } = {
     __proto__: null,
     ...options,


### PR DESCRIPTION
Upgrade Coana to version 14.12.148. 
More details in the [Coana changelog](https://docs.coana.tech/changelogs/cli).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades Coana tooling and publishes a new patch release.
> 
> - **Deps:** Upgrade `@coana-tech/cli` 14.12.143 → `14.12.148` and update `pnpm-lock.yaml`
> - **Release:** Bump `package.json` version to `1.1.55` and update `CHANGELOG.md`
> - **Refactor:** Minor option destructuring reorder in `src/commands/scan/fetch-supported-scan-file-names.mts` and `src/utils/api.mts` (no behavior change)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4e82f67d8126c239fe1fc444e73e7a2de013eaa. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->