### PR TITLE
Bump to v1.1.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.56](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.56) - 2026-01-10
+
+### Fixed
+- Fixed heap overflow when scanning large monorepos with 100k+ files by implementing streaming-based filtering.
+
 ## [1.1.55](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.55) - 2026-01-09
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.55",
+  "version": "1.1.56",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",


### PR DESCRIPTION
## Summary
- Version bump to v1.1.56
- Changelog entry for heap overflow fix in large monorepo scans (https://github.com/SocketDev/socket-cli/pull/1026)

## Test plan
- [x] Version updated in package.json
- [x] Changelog updated with new entry
- [x] Tag v1.1.56 already pushed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release 1.1.56**
> 
> - Update `CHANGELOG.md` with a fix for heap overflow when scanning 100k+ file monorepos using streaming-based filtering
> - Bump `package.json` version to `1.1.56`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6ba58ab1f18939f6cf8e088f1dc35e73efba961. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->