### PR TITLE
feat: update @socketsecurity/socket-patch to v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.57](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.57) - 2026-01-10
+
+### Changed
+- Updated `@socketsecurity/socket-patch` to v1.2.0, which includes:
+  - Progress spinner for scan command
+  - Improved test coverage
+
 ## [1.1.56](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.56) - 2026-01-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.56",
+  "version": "1.1.57",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -123,7 +123,7 @@
     "@socketsecurity/config": "3.0.1",
     "@socketsecurity/registry": "1.1.17",
     "@socketsecurity/sdk": "1.4.95",
-    "@socketsecurity/socket-patch": "1.0.0",
+    "@socketsecurity/socket-patch": "1.2.0",
     "@types/blessed": "0.1.25",
     "@types/cmd-shim": "5.0.2",
     "@types/js-yaml": "4.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,8 +211,8 @@ importers:
         specifier: 1.4.95
         version: 1.4.95
       '@socketsecurity/socket-patch':
-        specifier: 1.0.0
-        version: 1.0.0
+        specifier: 1.2.0
+        version: 1.2.0
       '@types/blessed':
         specifier: 0.1.25
         version: 0.1.25
@@ -1748,8 +1748,8 @@ packages:
     resolution: {integrity: sha512-rUqo8UYHsH8MQxO8EKnIAsU8AhArz0A3H2hfDgZPrfpY2O7ligUUBaLkk/zEm9DP6k8JjWSR6gxdvnY6KgWQJQ==}
     engines: {node: '>=18'}
 
-  '@socketsecurity/socket-patch@1.0.0':
-    resolution: {integrity: sha512-B8kT5DEF7rD97N8UohenFGuqGVlS82RlUwF31yWzzi8bw2YEUM0vxdYE1pZveByd+fexj2zpY8nXK0cKF6+eeQ==}
+  '@socketsecurity/socket-patch@1.2.0':
+    resolution: {integrity: sha512-VIuDVRRN5V7iyM+OHK4mYrqHPEHbB0J41gPx8iouivvfERwvhPPjDFm+CNjQ1gmYZd1RaqPG3MLT7fKPyMkddA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -6387,7 +6387,7 @@ snapshots:
     dependencies:
       '@socketsecurity/registry': 1.1.17
 
-  '@socketsecurity/socket-patch@1.0.0':
+  '@socketsecurity/socket-patch@1.2.0':
     dependencies:
       yargs: 17.7.2
       zod: 3.25.76


### PR DESCRIPTION
## Summary
- Update socket-patch dependency from v1.0.0 to v1.2.0
- Add changelog entry for v1.1.57 documenting the socket-patch update
- Bump socket-cli version to 1.1.57

## Context
This PR addresses reviewer feedback in depscan PR #16387 regarding the socket-patch version mismatch. The depscan repo updated the socket-patch submodule to v1.2.0, but socket-cli was still depending on v1.0.0.

### socket-patch v1.2.0 changes include:
- Progress spinner for scan command
- Improved test coverage

## Test plan
- [x] Lint passes (`pnpm run lint`)
- [x] Type check passes (`pnpm run check:tsc`)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes the CLI repo with a full Rollup/Babel/TypeScript build, new binary wrappers, and comprehensive project tooling.
> 
> - **Build/packaging:** Add `.config/rollup.*` and Babel configs, SEA bootstrap, external bundling/patches, and env/TS base; generate `dist/**` outputs
> - **Binaries:** Introduce `bin/{cli,npm-cli,npx-cli,pnpm-cli,yarn-cli}.js` entry points
> - **Project config/tooling:** Add PNPM/Biome/ESLint/Oxlint/Husky/lint-staged, EditorConfig, git attrs/ignore, Knip; numerous GitHub Actions (lint, tests, E2E, provenance, auto-PR, Claude)
> - **Package overhaul:** Replace old `package.json` with exports, types, scripts, overrides/patches; rename to `socket` v1.1.57 and update deps (incl. `@socketsecurity/socket-patch` v1.2.0)
> - **Docs/meta:** Add extensive README, CHANGELOG (incl. 1.1.57), CLAUDE.md; update LICENSE
> - **Cleanup:** Remove legacy `cli.js` and `lib/**` implementation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 518651792122aaa49f01f884c54a31cae104be58. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->