### PR TITLE
feat: update @socketsecurity/socket-patch to v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.57](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.57) - 2026-01-10
+
+### Changed
+- Updated `@socketsecurity/socket-patch` to v1.2.0, which includes:
+  - Progress spinner for scan command
+  - Improved test coverage
+
 ## [1.1.56](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.56) - 2026-01-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.56",
+  "version": "1.1.57",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -123,7 +123,7 @@
     "@socketsecurity/config": "3.0.1",
     "@socketsecurity/registry": "1.1.17",
     "@socketsecurity/sdk": "1.4.95",
-    "@socketsecurity/socket-patch": "1.0.0",
+    "@socketsecurity/socket-patch": "1.2.0",
     "@types/blessed": "0.1.25",
     "@types/cmd-shim": "5.0.2",
     "@types/js-yaml": "4.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,8 +211,8 @@ importers:
         specifier: 1.4.95
         version: 1.4.95
       '@socketsecurity/socket-patch':
-        specifier: 1.0.0
-        version: 1.0.0
+        specifier: 1.2.0
+        version: 1.2.0
       '@types/blessed':
         specifier: 0.1.25
         version: 0.1.25
@@ -1748,8 +1748,8 @@ packages:
     resolution: {integrity: sha512-rUqo8UYHsH8MQxO8EKnIAsU8AhArz0A3H2hfDgZPrfpY2O7ligUUBaLkk/zEm9DP6k8JjWSR6gxdvnY6KgWQJQ==}
     engines: {node: '>=18'}
 
-  '@socketsecurity/socket-patch@1.0.0':
-    resolution: {integrity: sha512-B8kT5DEF7rD97N8UohenFGuqGVlS82RlUwF31yWzzi8bw2YEUM0vxdYE1pZveByd+fexj2zpY8nXK0cKF6+eeQ==}
+  '@socketsecurity/socket-patch@1.2.0':
+    resolution: {integrity: sha512-VIuDVRRN5V7iyM+OHK4mYrqHPEHbB0J41gPx8iouivvfERwvhPPjDFm+CNjQ1gmYZd1RaqPG3MLT7fKPyMkddA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -6387,7 +6387,7 @@ snapshots:
     dependencies:
       '@socketsecurity/registry': 1.1.17
 
-  '@socketsecurity/socket-patch@1.0.0':
+  '@socketsecurity/socket-patch@1.2.0':
     dependencies:
       yargs: 17.7.2
       zod: 3.25.76


### PR DESCRIPTION
Update socket-patch dependency from v1.0.0 to v1.2.0, which includes:
- Progress spinner for scan command
- Improved test coverage

This update addresses reviewer feedback in depscan PR #16387 regarding the socket-patch version mismatch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Publishes a new release with dependency update.
> 
> - Bumps `@socketsecurity/socket-patch` from `1.0.0` to `1.2.0` (adds progress spinner for scan command; improved test coverage)
> - Updates `package.json` version to `1.1.57` and adds corresponding entry to `CHANGELOG.md`
> - Syncs `pnpm-lock.yaml` to reflect the new dependency version
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcb8fd033a62e7d1ba2d0c133a979f0b8901d08c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->