### PR TITLE
chore(deps): update Coana CLI to v14.12.148

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+- Updated Coana CLI to v14.12.148.
+
 ## [2.1.0](https://github.com/SocketDev/socket-cli/releases/tag/v2.1.0) - 2025-11-02
 
 ### Added

--- a/packages/cli/external-tools.json
+++ b/packages/cli/external-tools.json
@@ -3,7 +3,7 @@
     "description": "Coana CLI for static analysis and reachability detection",
     "type": "npm",
     "package": "@coana-tech/cli",
-    "version": "14.12.139"
+    "version": "14.12.148"
   },
   "@cyclonedx/cdxgen": {
     "description": "CycloneDX SBOM generator for software bill of materials",


### PR DESCRIPTION
## Summary
- Updated Coana CLI from v14.12.139 to v14.12.148

## Changes
- Updated `@coana-tech/cli` version in external-tools.json
- Updated CHANGELOG.md

## Test plan
- [ ] Verify Coana CLI version is correctly updated
- [ ] Test `socket scan` commands with reachability analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Bumps `@coana-tech/cli` from `14.12.139` to `14.12.148` in `packages/cli/external-tools.json`
> - Adds an Unreleased changelog entry noting the Coana CLI version update
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d69e195fbec0b373598e429a0a1335afc4d6f9dd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->