### PR TITLE
upgrading coana to version 14.12.162

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.59](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.59) - 2026-01-19
+
+### Changed
+- Updated the Coana CLI to v `14.12.162`.
+
 ## [1.1.58](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.58) - 2026-01-14
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -94,7 +94,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.154",
+    "@coana-tech/cli": "14.12.162",
     "@cyclonedx/cdxgen": "11.11.0",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.154
-        version: 14.12.154
+        specifier: 14.12.162
+        version: 14.12.162
       '@cyclonedx/cdxgen':
         specifier: 11.11.0
         version: 11.11.0
@@ -680,8 +680,8 @@ packages:
   '@bufbuild/protobuf@2.6.3':
     resolution: {integrity: sha512-w/gJKME9mYN7ZoUAmSMAWXk4hkVpxRKvEJCb3dV5g9wwWdxTJJ0ayOJAVcNxtdqaxDyFuC0uz4RSGVacJ030PQ==}
 
-  '@coana-tech/cli@14.12.154':
-    resolution: {integrity: sha512-cksXLHZjn1dxgggq6YadiD/o9XCtx7WBAxyKYHBG4o9ALa8g1FYQrItIqTLl2AAizJhmmwfDQkZhGJ+S+8mQyw==}
+  '@coana-tech/cli@14.12.162':
+    resolution: {integrity: sha512-SV0uoiOW7WndmHVuOYLfSfLa2wbKrDKB0S+Be3ClFRSAh4/Vz/qh9GugJ3bCJpkKzELgSP/ucnIJWb5GoCRRyg==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5323,7 +5323,7 @@ snapshots:
   '@bufbuild/protobuf@2.6.3':
     optional: true
 
-  '@coana-tech/cli@14.12.154': {}
+  '@coana-tech/cli@14.12.162': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
Updated the Coana CLI to v `14.12.162`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Releases `v1.1.59` with dependency update.
> 
> - Bumps `version` to `1.1.59` in `package.json` and adds changelog entry
> - Updates `@coana-tech/cli` dev dependency to `14.12.162` and refreshes `pnpm-lock.yaml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96aeaffbb5cf1450fa4eefb98bb82c535c77d8b1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->