### PR TITLE
upgrading coana to version 14.12.174

### DIFF
--- a/.claude/skills/bump-coana.md
+++ b/.claude/skills/bump-coana.md
@@ -1,77 +1,122 @@
 ---
-description: Bump @coana-tech/cli to a new version, update changelog, and create a PR
+name: bump-coana
+description: Bump @coana-tech/cli to a new version, update changelog, and create a PR. Use when user wants to upgrade Coana CLI, bump Coana version, or says "bump coana" with a version number.
 allowed-tools: Read, Edit, Write, Bash, Glob
+user-invocable: true
 ---
 
 # Bump Coana CLI Version
 
-Automates the process of upgrading the @coana-tech/cli dependency to a new version.
+Automates the process of upgrading the @coana-tech/cli dependency to a new version, including package.json updates, changelog entry, and PR creation.
 
-## Usage
+## Input
 
+- **Version**: The Coana version to upgrade to (e.g., `14.12.173`)
+- Passed via `$ARGUMENTS` (e.g., `/bump-coana 14.12.173`)
+
+If no version is provided, ask the user for the Coana version to upgrade to.
+
+## Workflow
+
+### Step 1: Parse and Validate Input
+
+Extract the version number from `$ARGUMENTS`:
+
+```bash
+COANA_VERSION="$ARGUMENTS"
+
+# Validate version format (should be semver-like: X.Y.Z)
+if [[ ! "$COANA_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "ERROR: Invalid version format. Expected X.Y.Z (e.g., 14.12.173)"
+  exit 1
+fi
 ```
-/bump-coana <version>
-```
 
-Where `<version>` is the Coana version number (e.g., `14.12.173`).
+### Step 2: Update package.json
 
-## Instructions
+1. Read `package.json` in the repository root.
+2. Find the current `@coana-tech/cli` version in `devDependencies` and note it as `CURRENT_VERSION`.
+3. Update `@coana-tech/cli` to the new version.
+4. Bump the patch version of the package (e.g., `1.1.59` → `1.1.60`).
+5. Write the updated `package.json`.
 
-When this command is invoked with a version argument ($ARGUMENTS), perform the following steps:
+**Values to extract**:
+- `CURRENT_VERSION`: The old @coana-tech/cli version (for PR body)
+- `NEW_PKG_VERSION`: The bumped package.json version (for changelog)
 
-### 1. Validate Input
-- Extract the version from $ARGUMENTS (e.g., "14.12.173").
-- If no version is provided, ask the user for the Coana version to upgrade to.
+### Step 3: Update CHANGELOG.md
 
-### 2. Update package.json
-- Read `package.json` in the repository root.
-- Find the current `@coana-tech/cli` version in devDependencies and note it for the PR body.
-- Update the `@coana-tech/cli` version to the provided version.
-- Bump the patch version of the package (e.g., `1.1.59` becomes `1.1.60`).
-- Write the updated package.json.
+1. Read `CHANGELOG.md` in the repository root.
+2. Add a new version entry after the header section (which ends with "The format is based on...").
+3. Use today's date in `YYYY-MM-DD` format.
 
-### 3. Update CHANGELOG.md
-- Read `CHANGELOG.md` in the repository root.
-- Add a new version entry at the top (after the header section that ends with "The format is based on..."), using today's date in YYYY-MM-DD format.
-- The new version should match the bumped package.json version.
-- Use this exact format for the new entry:
-
+**Entry format**:
 ```markdown
-## [NEW_VERSION](https://github.com/SocketDev/socket-cli/releases/tag/vNEW_VERSION) - YYYY-MM-DD
+## [NEW_PKG_VERSION](https://github.com/SocketDev/socket-cli/releases/tag/vNEW_PKG_VERSION) - YYYY-MM-DD
 
 ### Changed
 - Updated the Coana CLI to v `COANA_VERSION`.
 
 ```
 
-Note: Include the blank line after the changelog entry.
+**Note**: Include a blank line after the entry.
 
-### 4. Update Lock File
-- Run `pnpm install` to update pnpm-lock.yaml with the new dependency version.
+### Step 4: Update Lock File
 
-### 5. Create Branch and Commit
-- Create a new branch named `coana-COANA_VERSION` (e.g., `coana-14.12.173`) from the current branch.
-- Stage the changes: package.json, CHANGELOG.md, and pnpm-lock.yaml.
-- Create a commit with the message: `upgrading coana to version COANA_VERSION`.
-- Use the `-n` flag to skip pre-commit hooks.
-
-### 6. Push and Create PR
-- Push the branch to origin with `-u` flag.
-- Create a PR using `gh pr create` targeting the `v1.x` branch with:
-  - Title: `upgrading coana to version COANA_VERSION`
-  - Body using the format below.
-
-Use this PR body format (use a HEREDOC for proper formatting):
+```bash
+pnpm install
 ```
+
+This updates `pnpm-lock.yaml` with the new dependency version.
+
+### Step 5: Create Branch and Commit
+
+```bash
+# Create branch
+git checkout -b "coana-$COANA_VERSION"
+
+# Stage changes
+git add package.json CHANGELOG.md pnpm-lock.yaml
+
+# Commit (skip pre-commit hooks with -n)
+git commit -n -m "upgrading coana to version $COANA_VERSION"
+```
+
+### Step 6: Push and Create PR
+
+```bash
+# Push branch
+git push -u origin "coana-$COANA_VERSION"
+
+# Create PR targeting v1.x branch
+gh pr create --base v1.x --title "upgrading coana to version $COANA_VERSION" --body "$(cat <<'EOF'
 ## Summary
 - Upgrades @coana-tech/cli from CURRENT_VERSION to COANA_VERSION
 
 ## Coana Changelog
 For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).
+EOF
+)"
 ```
 
-Replace CURRENT_VERSION with the old version found in step 2, and COANA_VERSION with the new version.
+Replace `CURRENT_VERSION` and `COANA_VERSION` with actual values.
 
-### Important Notes
+## Output
+
+- Branch: `coana-<VERSION>` pushed to origin
+- PR: Created targeting `v1.x` branch
+- Files modified: `package.json`, `CHANGELOG.md`, `pnpm-lock.yaml`
+
+Report the PR URL to the user when complete.
+
+## Error Handling
+
+- **No version provided**: Ask user for the version number
+- **Invalid version format**: Report error with expected format
+- **pnpm install fails**: Check network connectivity and npm registry access
+- **PR creation fails**: Verify `gh` CLI is authenticated
+
+## Important Notes
+
 - Do NOT add any AI/Claude co-authorship or attribution to the commit message or PR.
 - Do NOT include "Generated with Claude Code" or similar text anywhere.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.61](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.61) - 2026-01-29
+
+### Changed
+- Updated the Coana CLI to v `14.12.174`.
+
 ## [1.1.60](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.60) - 2026-01-28
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.60",
+  "version": "1.1.61",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -94,7 +94,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.173",
+    "@coana-tech/cli": "14.12.174",
     "@cyclonedx/cdxgen": "11.11.0",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.173
-        version: 14.12.173
+        specifier: 14.12.174
+        version: 14.12.174
       '@cyclonedx/cdxgen':
         specifier: 11.11.0
         version: 11.11.0
@@ -680,8 +680,8 @@ packages:
   '@bufbuild/protobuf@2.6.3':
     resolution: {integrity: sha512-w/gJKME9mYN7ZoUAmSMAWXk4hkVpxRKvEJCb3dV5g9wwWdxTJJ0ayOJAVcNxtdqaxDyFuC0uz4RSGVacJ030PQ==}
 
-  '@coana-tech/cli@14.12.173':
-    resolution: {integrity: sha512-F04hJKDogxsbY1KdKm4wHEwuAue7PZ/XlXSRMmyLmTc/ll01rAvKwzh/OoNnvQnpBVRfYoCt8dHj0YSaCi9LMw==}
+  '@coana-tech/cli@14.12.174':
+    resolution: {integrity: sha512-3VZ57i2QNgwaAnQjn0KQGeZp8r3YXFb3dPcGLzxWcouCyQR6PbCJVjkUSyEkWr96Ivjwsq0Z/CCzh8pYJ6PJPg==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5323,7 +5323,7 @@ snapshots:
   '@bufbuild/protobuf@2.6.3':
     optional: true
 
-  '@coana-tech/cli@14.12.173': {}
+  '@coana-tech/cli@14.12.174': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 14.12.173 to 14.12.174
  - Fixes a bug in the nuget/.NET `socket fix` logic.
- Various improvements to the upgrade Coana skill

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a dependency/version bump with corresponding lockfile and changelog updates; minimal risk beyond any behavioral changes introduced by the new Coana CLI release.
> 
> **Overview**
> Bumps the bundled Coana CLI dependency from `14.12.173` to `14.12.174`, updating `pnpm-lock.yaml` accordingly.
> 
> Also increments the package version to `1.1.61` and adds a matching `CHANGELOG.md` entry. The internal `.claude/skills/bump-coana` runbook is expanded to be user-invocable and to include input validation plus a more explicit end-to-end upgrade/PR workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3d15ebe197986231882e9477d9fe9520e5b7853. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->