### PR TITLE
upgrading coana to version 14.12.178

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.62](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.62) - 2026-01-30
+
+### Changed
+- Updated the Coana CLI to v `14.12.178`.
+
 ## [1.1.61](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.61) - 2026-01-29
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.61",
+  "version": "1.1.62",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -94,7 +94,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.174",
+    "@coana-tech/cli": "14.12.178",
     "@cyclonedx/cdxgen": "11.11.0",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.174
-        version: 14.12.174
+        specifier: 14.12.178
+        version: 14.12.178
       '@cyclonedx/cdxgen':
         specifier: 11.11.0
         version: 11.11.0
@@ -680,8 +680,8 @@ packages:
   '@bufbuild/protobuf@2.6.3':
     resolution: {integrity: sha512-w/gJKME9mYN7ZoUAmSMAWXk4hkVpxRKvEJCb3dV5g9wwWdxTJJ0ayOJAVcNxtdqaxDyFuC0uz4RSGVacJ030PQ==}
 
-  '@coana-tech/cli@14.12.174':
-    resolution: {integrity: sha512-3VZ57i2QNgwaAnQjn0KQGeZp8r3YXFb3dPcGLzxWcouCyQR6PbCJVjkUSyEkWr96Ivjwsq0Z/CCzh8pYJ6PJPg==}
+  '@coana-tech/cli@14.12.178':
+    resolution: {integrity: sha512-vCF7SxwagY2VS/s1LxkpE07kZ4JXjvWneXTf0mNmjOEN4/BBuuTvNJieYDK4z6n2SQXmJe7Fq1PiDkgzS9p1Zw==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5323,7 +5323,7 @@ snapshots:
   '@bufbuild/protobuf@2.6.3':
     optional: true
 
-  '@coana-tech/cli@14.12.174': {}
+  '@coana-tech/cli@14.12.178': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 14.12.174 to 14.12.178

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency/version bump only; risk is limited to any behavior changes introduced by the new `@coana-tech/cli` release.
> 
> **Overview**
> Bumps `@coana-tech/cli` from `14.12.174` to `14.12.178` (including lockfile updates).
> 
> Updates the Socket CLI package version to `1.1.62` and adds a corresponding `CHANGELOG.md` entry for the Coana CLI upgrade.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab352a23b7c0c03a7f6ec29077471c13348ea1a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->