### PR TITLE
feat: include request URL in API error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.65](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.65) - 2026-02-26
+
+### Changed
+- Improved API error messages to include the request URL, making it easier to debug which endpoint failed
+
 ## [1.1.64](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.64) - 2026-02-25
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.64",
+  "version": "1.1.65",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -122,7 +122,7 @@
     "@socketregistry/packageurl-js": "1.0.9",
     "@socketsecurity/config": "3.0.1",
     "@socketsecurity/registry": "1.1.17",
-    "@socketsecurity/sdk": "1.4.95",
+    "@socketsecurity/sdk": "1.4.96",
     "@socketsecurity/socket-patch": "1.2.0",
     "@types/blessed": "0.1.25",
     "@types/cmd-shim": "5.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,8 +208,8 @@ importers:
         specifier: 1.1.17
         version: 1.1.17
       '@socketsecurity/sdk':
-        specifier: 1.4.95
-        version: 1.4.95
+        specifier: 1.4.96
+        version: 1.4.96
       '@socketsecurity/socket-patch':
         specifier: 1.2.0
         version: 1.2.0
@@ -1744,8 +1744,8 @@ packages:
     resolution: {integrity: sha512-5j0eH6JaBZlcvnbdu+58Sw8c99AK25PTp0Z/lwP7HknHdJ0TMMoTzNIBbp7WCTZKoGrPgBWchi0udN1ObZ53VQ==}
     engines: {node: '>=18'}
 
-  '@socketsecurity/sdk@1.4.95':
-    resolution: {integrity: sha512-rUqo8UYHsH8MQxO8EKnIAsU8AhArz0A3H2hfDgZPrfpY2O7ligUUBaLkk/zEm9DP6k8JjWSR6gxdvnY6KgWQJQ==}
+  '@socketsecurity/sdk@1.4.96':
+    resolution: {integrity: sha512-yZn50KLeCerKQRYTUfMzB5m7mraH1Rhr01WDLgzgaw3Do3qEsHy7sdoHI5o1FvyIWd8ebBspK3PJ2xqyrdQejw==}
     engines: {node: '>=18'}
 
   '@socketsecurity/socket-patch@1.2.0':
@@ -6384,7 +6384,7 @@ snapshots:
 
   '@socketsecurity/registry@1.1.17': {}
 
-  '@socketsecurity/sdk@1.4.95':
+  '@socketsecurity/sdk@1.4.96':
     dependencies:
       '@socketsecurity/registry': 1.1.17
 

--- a/src/utils/api.mts
+++ b/src/utils/api.mts
@@ -195,8 +195,11 @@ export async function handleApiCall<T extends SocketSdkOperations>(
     const errStr = errCResult.error ? String(errCResult.error).trim() : ''
     const message = errStr || NO_ERROR_MESSAGE
     const reason = errCResult.cause || NO_ERROR_MESSAGE
-    const cause =
+    const baseCause =
       reason && message !== reason ? `${message} (reason: ${reason})` : message
+    const cause = errCResult.url
+      ? `${baseCause} (url: ${errCResult.url})`
+      : baseCause
     const socketSdkErrorResult: ApiCallResult<T> = {
       ok: false,
       message: 'Socket API error',
@@ -254,8 +257,11 @@ export async function handleApiCallNoSpinner<T extends SocketSdkOperations>(
       : ''
     const message = errStr || NO_ERROR_MESSAGE
     const reason = sdkErrorResult.cause || NO_ERROR_MESSAGE
-    const cause =
+    const baseCause =
       reason && message !== reason ? `${message} (reason: ${reason})` : message
+    const cause = sdkErrorResult.url
+      ? `${baseCause} (url: ${sdkErrorResult.url})`
+      : baseCause
 
     return {
       ok: false,
@@ -348,12 +354,13 @@ export async function queryApiSafeText(
     const errStr = e ? String(e).trim() : ''
     const message = 'API request failed'
     const rawCause = errStr || NO_ERROR_MESSAGE
-    const cause = message !== rawCause ? rawCause : ''
+    const baseCause = message !== rawCause ? rawCause : ''
+    const cause = baseCause ? `${baseCause} (path: ${path})` : `(path: ${path})`
 
     return {
       ok: false,
       message,
-      ...(cause ? { cause } : {}),
+      cause,
     }
   }
 
@@ -366,7 +373,7 @@ export async function queryApiSafeText(
     return {
       ok: false,
       message: 'Socket API error',
-      cause: `${result.statusText} (reason: ${await getErrorMessageForHttpStatusCode(status)})`,
+      cause: `${result.statusText} (reason: ${await getErrorMessageForHttpStatusCode(status)}) (path: ${path})`,
       data: {
         code: status,
       },
@@ -386,7 +393,7 @@ export async function queryApiSafeText(
     return {
       ok: false,
       message: 'API request failed',
-      cause: 'Unexpected error reading response text',
+      cause: `Unexpected error reading response text (path: ${path})`,
     }
   }
 }
@@ -495,12 +502,13 @@ export async function sendApiRequest<T>(
     const errStr = e ? String(e).trim() : ''
     const message = 'API request failed'
     const rawCause = errStr || NO_ERROR_MESSAGE
-    const cause = message !== rawCause ? rawCause : ''
+    const baseCause = message !== rawCause ? rawCause : ''
+    const cause = baseCause ? `${baseCause} (path: ${path})` : `(path: ${path})`
 
     return {
       ok: false,
       message,
-      ...(cause ? { cause } : {}),
+      cause,
     }
   }
 
@@ -513,7 +521,7 @@ export async function sendApiRequest<T>(
     return {
       ok: false,
       message: 'Socket API error',
-      cause: `${result.statusText} (reason: ${await getErrorMessageForHttpStatusCode(status)})`,
+      cause: `${result.statusText} (reason: ${await getErrorMessageForHttpStatusCode(status)}) (path: ${path})`,
       data: {
         code: status,
       },
@@ -532,7 +540,7 @@ export async function sendApiRequest<T>(
     return {
       ok: false,
       message: 'API request failed',
-      cause: 'Unexpected error parsing response JSON',
+      cause: `Unexpected error parsing response JSON (path: ${path})`,
     }
   }
 }


### PR DESCRIPTION
## Problem

When a Socket API request fails, the CLI displays an error like:

```
✖  Socket API error:  Socket API POST request failed (400):
```

This lacks the request URL, making it difficult to debug which endpoint failed — especially when multiple API calls are involved in a single command.

## Solution

Surface the failing endpoint URL in all API error messages. Two complementary approaches:

**SDK-routed calls** (`handleApiCall`, `handleApiCallNoSpinner`): Read the new `url` field from `SocketSdkErrorResult` (added in `@socketsecurity/sdk` 1.4.96, [SocketDev/socket-sdk-js#483](https://github.com/SocketDev/socket-sdk-js/pull/483)) and append it to the cause string.

**Direct-fetch calls** (`queryApiSafeText`, `sendApiRequest`): Append the request `path` to all error cause strings — the catch block, the `!result.ok` branch, and the response parsing error.

### Example output after this change

```
✖  Socket API error:  Socket API POST request failed (404): Not Found (reason: Organization not found) (url: https://api.socket.dev/v0/orgs/badorg/full-scans?branch=main&scan_type=socket&repo=my-repo)
```

### Changes

- `src/utils/api.mts`: Updated `handleApiCall`, `handleApiCallNoSpinner`, `queryApiSafeText`, and `sendApiRequest` to include URL/path in error messages
- `package.json`: Bumped `@socketsecurity/sdk` to `1.4.96`, version to `1.1.65`
- `CHANGELOG.md`: Added entry for `1.1.65`

## Test plan

- [x] Build passes (`pnpm build:dist:src`)
- [x] Type check passes (`pnpm check:tsc`)
- [x] Lint passes (`pnpm check:lint`)
- [x] Manually verified with `socket scan create --org nonexistent-org` — URL appears in error output

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to error-message formatting and a minor `@socketsecurity/sdk` patch bump; main potential impact is downstream tests/log parsing expecting the old `cause` strings.
> 
> **Overview**
> Improves CLI debuggability by appending the failing endpoint to **all Socket API error causes**: SDK-routed failures now include `errCResult.url`, and direct `fetch` helpers (`queryApiSafeText`, `sendApiRequest`) always include the request `path` in catch, non-OK response, and parse/read failures.
> 
> Bumps the CLI version to `1.1.65`, updates `@socketsecurity/sdk` to `1.4.96`, and adds a `CHANGELOG.md` entry for the release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52f0463a8fe3d56e7ed60f3ad7d337c912aeaac1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->