### PR TITLE
upgrading coana to version 14.12.189

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.66](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.66) - 2026-03-02
+
+### Changed
+- Updated the Coana CLI to v `14.12.189`.
+
 ## [1.1.65](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.65) - 2026-02-26
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.65",
+  "version": "1.1.66",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -94,7 +94,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.183",
+    "@coana-tech/cli": "14.12.189",
     "@cyclonedx/cdxgen": "11.11.0",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.183
-        version: 14.12.183
+        specifier: 14.12.189
+        version: 14.12.189
       '@cyclonedx/cdxgen':
         specifier: 11.11.0
         version: 11.11.0
@@ -680,8 +680,8 @@ packages:
   '@bufbuild/protobuf@2.6.3':
     resolution: {integrity: sha512-w/gJKME9mYN7ZoUAmSMAWXk4hkVpxRKvEJCb3dV5g9wwWdxTJJ0ayOJAVcNxtdqaxDyFuC0uz4RSGVacJ030PQ==}
 
-  '@coana-tech/cli@14.12.183':
-    resolution: {integrity: sha512-D/HxbQi275A6eVLO0jV1ZEZ/r1hjC/cs2QjV27y+EPNfOsq6AaXhkn7yCoOeyyVfpXx9ds/6ujFNHrqdviRzuQ==}
+  '@coana-tech/cli@14.12.189':
+    resolution: {integrity: sha512-CbailGhglvPJK9DZLB8RsuMYE2SwFLB0MiC0ZdY2VIiSibXTsqdumqWMKDUbfq4gbe5ZlO1eSEAJIXc2H+RacQ==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5324,7 +5324,7 @@ snapshots:
   '@bufbuild/protobuf@2.6.3':
     optional: true
 
-  '@coana-tech/cli@14.12.183': {}
+  '@coana-tech/cli@14.12.189': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 14.12.183 to 14.12.189

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump and version/changelog update; functional impact is limited to whatever behavior changes come from the newer `@coana-tech/cli` release.
> 
> **Overview**
> Updates `@coana-tech/cli` from `14.12.183` to `14.12.189` (including lockfile changes).
> 
> Bumps the package version to `1.1.66` and records the change in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c4afd4487624d831ed1182b36c389a7dcd0baa2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->