### PR TITLE
upgrading coana to version 14.12.192

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.69](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.69) - 2026-03-10
+
+### Changed
+- Updated the Coana CLI to v `14.12.192`.
+
 ## [1.1.68](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.68) - 2026-03-09
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.68",
+  "version": "1.1.69",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -97,7 +97,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.191",
+    "@coana-tech/cli": "14.12.192",
     "@cyclonedx/cdxgen": "11.11.0",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.191
-        version: 14.12.191
+        specifier: 14.12.192
+        version: 14.12.192
       '@cyclonedx/cdxgen':
         specifier: 11.11.0
         version: 11.11.0
@@ -681,8 +681,8 @@ packages:
   '@bufbuild/protobuf@2.6.3':
     resolution: {integrity: sha512-w/gJKME9mYN7ZoUAmSMAWXk4hkVpxRKvEJCb3dV5g9wwWdxTJJ0ayOJAVcNxtdqaxDyFuC0uz4RSGVacJ030PQ==}
 
-  '@coana-tech/cli@14.12.191':
-    resolution: {integrity: sha512-mc/cMEraWCi4Ox98CZV5kqYMQr+7Za4wyCq7XgM65AuBx7DKeCj0pqFsz4VmnbL/RbVm3tlYCg4961Kx330WTw==}
+  '@coana-tech/cli@14.12.192':
+    resolution: {integrity: sha512-l7YrnVhnzkB4iGmg20y7TrXADoveF3GTcLErLXr91z/d8JvZAC2vrLHEzHoOkFbpJZe9rYYeXH6ATpET3jTarA==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5375,7 +5375,7 @@ snapshots:
   '@bufbuild/protobuf@2.6.3':
     optional: true
 
-  '@coana-tech/cli@14.12.191': {}
+  '@coana-tech/cli@14.12.192': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 14.12.191 to 14.12.192

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and version/lockfile-only changes; risk is limited to behavior changes introduced by the upstream `@coana-tech/cli` update.
> 
> **Overview**
> Updates the bundled Coana CLI dependency from `14.12.191` to `14.12.192` and bumps the `socket` package version to `1.1.69`.
> 
> Refreshes release metadata by adding a `CHANGELOG.md` entry for `1.1.69` and updating `pnpm-lock.yaml` to match the new Coana version/integrity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3075dba8c58e8afe98bed6b57f24ea9e43b53a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->