### PR TITLE
upgrading coana to version 14.12.195

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.71](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.71) - 2026-03-11
+
+### Changed
+- Updated the Coana CLI to v `14.12.195`.
+
 ## [1.1.70](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.70) - 2026-03-11
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.70",
+  "version": "1.1.71",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -97,7 +97,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.194",
+    "@coana-tech/cli": "14.12.195",
     "@cyclonedx/cdxgen": "11.11.0",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.194
-        version: 14.12.194
+        specifier: 14.12.195
+        version: 14.12.195
       '@cyclonedx/cdxgen':
         specifier: 11.11.0
         version: 11.11.0
@@ -681,8 +681,8 @@ packages:
   '@bufbuild/protobuf@2.6.3':
     resolution: {integrity: sha512-w/gJKME9mYN7ZoUAmSMAWXk4hkVpxRKvEJCb3dV5g9wwWdxTJJ0ayOJAVcNxtdqaxDyFuC0uz4RSGVacJ030PQ==}
 
-  '@coana-tech/cli@14.12.194':
-    resolution: {integrity: sha512-hQqt0f0eGNNL8hsaBqMKbcvVQ5xK+cgk9Wuyk921h+3jHjKGqxSbvHjlx1bAU5oi9chYsz5aCmztc+dgSIO8hg==}
+  '@coana-tech/cli@14.12.195':
+    resolution: {integrity: sha512-hW2/GzslQCAzhGB4xrYa/yuaaVw6UBMSokRofpcLD/4lyUWRQVJB8xC0ExALnB4WD7pj2U3EBB4xdDQCGX0pLg==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5375,7 +5375,7 @@ snapshots:
   '@bufbuild/protobuf@2.6.3':
     optional: true
 
-  '@coana-tech/cli@14.12.194': {}
+  '@coana-tech/cli@14.12.195': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 14.12.194 to 14.12.195

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump: only updates the bundled Coana CLI dependency and related metadata, with no application logic changes. Main risk is behavioral differences introduced by the upstream Coana release.
> 
> **Overview**
> Bumps the bundled Coana CLI dependency to `@coana-tech/cli@14.12.195` and updates `pnpm-lock.yaml` accordingly.
> 
> Also increments the Socket CLI version to `1.1.71` and adds a corresponding `CHANGELOG.md` entry noting the Coana update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebbf4bd2092abddd9cbf619512e9935b8d33b0a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->