### PR TITLE
upgrading coana to version 14.12.196

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.72](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.72) - 2026-03-12
+
+### Changed
+- Updated the Coana CLI to v `14.12.196`.
+
 ## [1.1.71](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.71) - 2026-03-11
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.71",
+  "version": "1.1.72",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -97,7 +97,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.195",
+    "@coana-tech/cli": "14.12.196",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.195
-        version: 14.12.195
+        specifier: 14.12.196
+        version: 14.12.196
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -740,8 +740,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@14.12.195':
-    resolution: {integrity: sha512-hW2/GzslQCAzhGB4xrYa/yuaaVw6UBMSokRofpcLD/4lyUWRQVJB8xC0ExALnB4WD7pj2U3EBB4xdDQCGX0pLg==}
+  '@coana-tech/cli@14.12.196':
+    resolution: {integrity: sha512-QjIQX7NjtrD/vPjrxeerLgpE7FhM6zUJ38MIeuJWiOTYRjb/KFDCD4Eo6OWUUCOqU9PaUFf574jdHrCXAd5VOw==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5345,7 +5345,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@14.12.195': {}
+  '@coana-tech/cli@14.12.196': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 14.12.195 to 14.12.196

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency/version bump only; behavior changes are limited to whatever upstream `@coana-tech/cli` introduces and should be covered by existing CLI workflows/tests.
> 
> **Overview**
> Bumps the Socket CLI release from `1.1.71` to `1.1.72` and updates the bundled `@coana-tech/cli` devDependency from `14.12.195` to `14.12.196`.
> 
> Updates `CHANGELOG.md` and `pnpm-lock.yaml` to reflect the new Coana version and lockfile integrity entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7438a7c032fd36e7aba5f2019d957408940f698c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->