### PR TITLE
fix: properly disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,10 @@
 # Dependabot disabled - we manage dependencies manually
+# Using open-pull-requests-limit: 0 to disable version updates
+# See: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
 version: 2
-updates: []
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: yearly
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary
- Properly disable Dependabot using `open-pull-requests-limit: 0` instead of empty `updates: []`

## Details
The previous `updates: []` approach caused GitHub to fail validation. Using `open-pull-requests-limit: 0` with `interval: yearly` effectively disables Dependabot while satisfying the schema.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to Dependabot settings; no runtime code paths or production behavior affected.
> 
> **Overview**
> Fixes `.github/dependabot.yml` schema by replacing the invalid empty `updates: []` config with a minimal npm update entry that uses `open-pull-requests-limit: 0` (and a yearly schedule) to effectively disable Dependabot while keeping GitHub validation happy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9d863aa818625fb66b4315fe6f87ea4c13fdef7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->