### PR TITLE
chore(ci): add GPG commit signing to weekly-update workflow

### DIFF
--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -118,7 +118,7 @@ jobs:
           set +e
           pnpm exec claude --print \
             --allowedTools "Bash(pnpm:*)" "Bash(git:*)" "Read" "Write" "Edit" "Glob" "Grep" \
-            --model haiku \
+            --model sonnet \
             --max-turns 25 \
             "$(cat <<'PROMPT'
           /updating

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -96,11 +96,19 @@ jobs:
 
       - name: Run updating skill with Claude Code
         id: claude
-        timeout-minutes: 30
+        timeout-minutes: 15
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_ACTIONS: 'true'
         run: |
+          # Wrap pnpm through Socket firewall for all subprocesses (not just this shell).
+          if [ -n "$SFW_BIN" ]; then
+            mkdir -p /tmp/sfw-bin
+            printf '#!/bin/bash\nexec "%s" pnpm "$@"\n' "$SFW_BIN" > /tmp/sfw-bin/pnpm
+            chmod +x /tmp/sfw-bin/pnpm
+            export PATH="/tmp/sfw-bin:$PATH"
+          fi
+
           if [ -z "$ANTHROPIC_API_KEY" ]; then
             echo "ANTHROPIC_API_KEY not set - skipping automated update"
             echo "success=false" >> $GITHUB_OUTPUT
@@ -108,8 +116,10 @@ jobs:
           fi
 
           set +e
-          pnpm exec claude --print --dangerously-skip-permissions \
-            --model sonnet \
+          pnpm exec claude --print \
+            --allowedTools "Bash(pnpm:*)" "Bash(git:*)" "Read" "Write" "Edit" "Glob" "Grep" \
+            --model haiku \
+            --max-turns 25 \
             "$(cat <<'PROMPT'
           /updating
 
@@ -142,6 +152,25 @@ jobs:
             echo "success=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Validate changes
+        id: validate
+        if: steps.claude.outputs.success == 'true'
+        run: |
+          # Only allow changes to dependency-related files.
+          UNEXPECTED=""
+          for file in $(git diff --name-only origin/main..HEAD); do
+            case "$file" in
+              package.json|*/package.json|pnpm-lock.yaml|*/pnpm-lock.yaml|.npmrc|pnpm-workspace.yaml) ;;
+              *) UNEXPECTED="$UNEXPECTED $file" ;;
+            esac
+          done
+          if [ -n "$UNEXPECTED" ]; then
+            echo "::error::Unexpected files modified by Claude:$UNEXPECTED"
+            echo "valid=false" >> $GITHUB_OUTPUT
+          else
+            echo "valid=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Check for changes
         id: changes
         run: |
@@ -152,13 +181,13 @@ jobs:
           fi
 
       - name: Push branch
-        if: steps.claude.outputs.success == 'true' && steps.changes.outputs.has-changes == 'true'
+        if: steps.claude.outputs.success == 'true' && steps.validate.outputs.valid == 'true' && steps.changes.outputs.has-changes == 'true'
         env:
           BRANCH_NAME: ${{ steps.branch.outputs.branch }}
         run: git push origin "$BRANCH_NAME"
 
       - name: Create Pull Request
-        if: steps.claude.outputs.success == 'true' && steps.changes.outputs.has-changes == 'true'
+        if: steps.claude.outputs.success == 'true' && steps.validate.outputs.valid == 'true' && steps.changes.outputs.has-changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           BRANCH_NAME: ${{ steps.branch.outputs.branch }}
@@ -187,7 +216,7 @@ jobs:
             --base main
 
       - name: Add job summary
-        if: steps.claude.outputs.success == 'true' && steps.changes.outputs.has-changes == 'true'
+        if: steps.claude.outputs.success == 'true' && steps.validate.outputs.valid == 'true' && steps.changes.outputs.has-changes == 'true'
         env:
           BRANCH_NAME: ${{ steps.branch.outputs.branch }}
         run: |

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -86,11 +86,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           BRANCH_NAME="weekly-update-$(date +%Y%m%d)"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git checkout -b "$BRANCH_NAME"
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@6096b06b1790f411714c89c40f72aade2eeaab7c # main
+        with:
+          gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
       - name: Run updating skill with Claude Code
         id: claude
@@ -181,6 +183,9 @@ jobs:
           name: claude-output-${{ github.run_id }}
           path: claude-output.log
           retention-days: 7
+
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@6096b06b1790f411714c89c40f72aade2eeaab7c # main
+        if: always()
 
   notify:
     name: Notify results

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -94,14 +94,13 @@ jobs:
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
-      - name: Run updating skill with Claude Code
-        id: claude
-        timeout-minutes: 15
+      - name: Update dependencies (haiku — fast, cheap)
+        id: update
+        timeout-minutes: 10
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_ACTIONS: 'true'
         run: |
-          # Wrap pnpm through Socket firewall for all subprocesses (not just this shell).
           if [ -n "$SFW_BIN" ]; then
             mkdir -p /tmp/sfw-bin
             printf '#!/bin/bash\nexec "%s" pnpm "$@"\n' "$SFW_BIN" > /tmp/sfw-bin/pnpm
@@ -117,9 +116,9 @@ jobs:
 
           set +e
           pnpm exec claude --print \
-            --allowedTools "Bash(pnpm:*)" "Bash(git:*)" "Read" "Write" "Edit" "Glob" "Grep" \
-            --model sonnet \
-            --max-turns 25 \
+            --allowedTools "Bash(pnpm:*)" "Bash(git add:*)" "Bash(git commit:*)" "Bash(git status:*)" "Bash(git diff:*)" "Bash(git log:*)" "Bash(git rev-parse:*)" "Read" "Write" "Edit" "Glob" "Grep" \
+            --model haiku \
+            --max-turns 15 \
             "$(cat <<'PROMPT'
           /updating
 
@@ -132,7 +131,7 @@ jobs:
           Update all dependencies to their latest versions.
           Create one atomic commit per dependency update with a conventional commit message.
           Leave all changes local — the workflow handles pushing and PR creation.
-          Skip running builds, tests, and type checks — CI runs those separately.
+          Do not run builds or tests — the next step handles that.
           </instructions>
 
           <success_criteria>
@@ -142,7 +141,7 @@ jobs:
           </success_criteria>
           PROMPT
           )" \
-            2>&1 | tee claude-output.log
+            2>&1 | tee claude-update.log
           CLAUDE_EXIT=${PIPESTATUS[0]}
           set -e
 
@@ -152,15 +151,112 @@ jobs:
             echo "success=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Run tests
+        id: tests
+        if: steps.update.outputs.success == 'true'
+        run: |
+          if [ -n "$SFW_BIN" ]; then
+            mkdir -p /tmp/sfw-bin
+            printf '#!/bin/bash\nexec "%s" pnpm "$@"\n' "$SFW_BIN" > /tmp/sfw-bin/pnpm
+            chmod +x /tmp/sfw-bin/pnpm
+            export PATH="/tmp/sfw-bin:$PATH"
+          fi
+
+          set +e
+          pnpm build 2>&1 | tee build.log
+          BUILD_EXIT=${PIPESTATUS[0]}
+
+          pnpm test 2>&1 | tee test.log
+          TEST_EXIT=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$BUILD_EXIT" -eq 0 ] && [ "$TEST_EXIT" -eq 0 ]; then
+            echo "tests-passed=true" >> $GITHUB_OUTPUT
+          else
+            echo "tests-passed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Fix test failures (sonnet — smarter, escalated)
+        id: claude
+        if: steps.update.outputs.success == 'true' && steps.tests.outputs.tests-passed == 'false'
+        timeout-minutes: 15
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_ACTIONS: 'true'
+        run: |
+          if [ -n "$SFW_BIN" ]; then
+            mkdir -p /tmp/sfw-bin
+            printf '#!/bin/bash\nexec "%s" pnpm "$@"\n' "$SFW_BIN" > /tmp/sfw-bin/pnpm
+            chmod +x /tmp/sfw-bin/pnpm
+            export PATH="/tmp/sfw-bin:$PATH"
+          fi
+
+          FAILURE_LOG="$(cat build.log test.log 2>/dev/null)"
+
+          set +e
+          pnpm exec claude --print \
+            --allowedTools "Bash(pnpm:*)" "Bash(git add:*)" "Bash(git commit:*)" "Bash(git status:*)" "Bash(git diff:*)" "Bash(git log:*)" "Bash(git rev-parse:*)" "Read" "Write" "Edit" "Glob" "Grep" \
+            --model sonnet \
+            --max-turns 25 \
+            "$(cat <<PROMPT
+          <context>
+          You are an automated CI agent in a weekly dependency update workflow.
+          Git is configured with GPG signing. A branch has been created for you.
+          Dependencies were updated in the previous step but build/tests failed.
+          </context>
+
+          <failure_log>
+          $FAILURE_LOG
+          </failure_log>
+
+          <instructions>
+          The dependency updates above caused build or test failures.
+          Diagnose the failures from the logs and fix the code so it builds and tests pass.
+          Create one atomic commit per fix with a conventional commit message.
+          Run pnpm build && pnpm test to verify your fixes.
+          Leave all changes local — the workflow handles pushing and PR creation.
+          </instructions>
+
+          <success_criteria>
+          pnpm build succeeds.
+          pnpm test succeeds.
+          Each fix has its own commit.
+          No uncommitted changes remain in the working tree.
+          </success_criteria>
+          PROMPT
+          )" \
+            2>&1 | tee claude-fix.log
+          CLAUDE_EXIT=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$CLAUDE_EXIT" -eq 0 ]; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set final status
+        id: final
+        if: always()
+        run: |
+          if [ "${{ steps.update.outputs.success }}" = "true" ] && [ "${{ steps.tests.outputs.tests-passed }}" = "true" ]; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          elif [ "${{ steps.update.outputs.success }}" = "true" ] && [ "${{ steps.claude.outputs.success }}" = "true" ]; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Validate changes
         id: validate
-        if: steps.claude.outputs.success == 'true'
+        if: steps.final.outputs.success == 'true'
         run: |
-          # Only allow changes to dependency-related files.
           UNEXPECTED=""
           for file in $(git diff --name-only origin/main..HEAD); do
             case "$file" in
               package.json|*/package.json|pnpm-lock.yaml|*/pnpm-lock.yaml|.npmrc|pnpm-workspace.yaml) ;;
+              src/*|test/*) ;;
+              *.ts|*.mts|*.js|*.mjs) ;;
               *) UNEXPECTED="$UNEXPECTED $file" ;;
             esac
           done
@@ -181,13 +277,13 @@ jobs:
           fi
 
       - name: Push branch
-        if: steps.claude.outputs.success == 'true' && steps.validate.outputs.valid == 'true' && steps.changes.outputs.has-changes == 'true'
+        if: steps.final.outputs.success == 'true' && steps.validate.outputs.valid == 'true' && steps.changes.outputs.has-changes == 'true'
         env:
           BRANCH_NAME: ${{ steps.branch.outputs.branch }}
         run: git push origin "$BRANCH_NAME"
 
       - name: Create Pull Request
-        if: steps.claude.outputs.success == 'true' && steps.validate.outputs.valid == 'true' && steps.changes.outputs.has-changes == 'true'
+        if: steps.final.outputs.success == 'true' && steps.validate.outputs.valid == 'true' && steps.changes.outputs.has-changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           BRANCH_NAME: ${{ steps.branch.outputs.branch }}
@@ -216,7 +312,7 @@ jobs:
             --base main
 
       - name: Add job summary
-        if: steps.claude.outputs.success == 'true' && steps.validate.outputs.valid == 'true' && steps.changes.outputs.has-changes == 'true'
+        if: steps.final.outputs.success == 'true' && steps.validate.outputs.valid == 'true' && steps.changes.outputs.has-changes == 'true'
         env:
           BRANCH_NAME: ${{ steps.branch.outputs.branch }}
         run: |
@@ -231,7 +327,11 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: claude-output-${{ github.run_id }}
-          path: claude-output.log
+          path: |
+            claude-update.log
+            claude-fix.log
+            build.log
+            test.log
           retention-days: 7
 
       - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@6096b06b1790f411714c89c40f72aade2eeaab7c # main

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -110,7 +110,28 @@ jobs:
           set +e
           pnpm exec claude --print --dangerously-skip-permissions \
             --model sonnet \
-            "/updating - Run the updating skill to update all dependencies. Create atomic commits for each update. You are running in CI mode - skip builds and tests. Do not push or create a PR." \
+            "$(cat <<'PROMPT'
+          /updating
+
+          <context>
+          You are an automated CI agent in a weekly dependency update workflow.
+          Git is configured with GPG signing. A branch has been created for you.
+          </context>
+
+          <instructions>
+          Update all dependencies to their latest versions.
+          Create one atomic commit per dependency update with a conventional commit message.
+          Leave all changes local — the workflow handles pushing and PR creation.
+          Skip running builds, tests, and type checks — CI runs those separately.
+          </instructions>
+
+          <success_criteria>
+          Each updated dependency has its own commit.
+          The lockfile is consistent with package.json changes.
+          No uncommitted changes remain in the working tree.
+          </success_criteria>
+          PROMPT
+          )" \
             2>&1 | tee claude-output.log
           CLAUDE_EXIT=${PIPESTATUS[0]}
           set -e

--- a/.npmrc
+++ b/.npmrc
@@ -6,9 +6,8 @@ link-workspace-packages=false
 loglevel=error
 prefer-workspace-packages=false
 
-# Minimum release age - wait 7 days before installing newly published packages
-# pnpm uses minimum-release-age (minutes), npm v11+ uses min-release-age (days)
-minimum-release-age=10080
+# Minimum release age for npm v11+ (days).
+# pnpm equivalent is in pnpm-workspace.yaml (minimumReleaseAge).
 min-release-age=7
 
 # Trust policy - prevent downgrade attacks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ All shared standards (git, testing, code style, cross-platform, CI) defined in s
 - Backward Compatibility: 🚨 FORBIDDEN to maintain - actively remove when encountered (see canonical CLAUDE.md)
 - Work Safeguards: MANDATORY commit + backup branch before bulk changes
 - Safe Deletion: Use `safeDelete()` from `@socketsecurity/lib/fs` (NEVER `fs.rm/rmSync` or `rm -rf`)
+- HTTP Requests: Use `httpJson`/`httpText`/`httpRequest` from `@socketsecurity/lib/http-request` (NEVER `fetch()`)
 
 ### Documentation Policy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ All shared standards (git, testing, code style, cross-platform, CI) defined in s
 - Backward Compatibility: 🚨 FORBIDDEN to maintain - actively remove when encountered (see canonical CLAUDE.md)
 - Work Safeguards: MANDATORY commit + backup branch before bulk changes
 - Safe Deletion: Use `safeDelete()` from `@socketsecurity/lib/fs` (NEVER `fs.rm/rmSync` or `rm -rf`)
-- HTTP Requests: Use `httpJson`/`httpText`/`httpRequest` from `@socketsecurity/lib/http-request` (NEVER `fetch()`)
+- HTTP Requests: NEVER use `fetch()` — use `httpJson`/`httpText`/`httpRequest` from `@socketsecurity/lib/http-request`
 
 ### Documentation Policy
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "fix:all": "node scripts/fix.mjs --all",
     "lint": "node scripts/lint.mjs",
     "lint:all": "node scripts/lint.mjs --all",
+    "format": "oxfmt --write .",
+    "format:check": "oxfmt .",
     "// Claude": "",
     "claude": "pnpm --filter @socketsecurity/cli run claude --",
     "// Type Checking": "",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+settings:
+  # Wait 7 days (10080 minutes) before installing newly published packages.
+  minimumReleaseAge: 10080
+
 packages:
   - packages/*
   - '!packages/package-builder/build'


### PR DESCRIPTION
## Summary
- Replace `github-actions[bot]` git config with `setup-git-signing` / `cleanup-git-signing` composite actions from socket-registry
- Uses org-level `BOT_GPG_PRIVATE_KEY` secret for signed commits

## Test plan
- [ ] Trigger workflow_dispatch to verify GPG signing works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes GitHub Actions behavior around git/GPG signing and introduces reliance on a new secret, which could break automated dependency PR creation if misconfigured.
> 
> **Overview**
> The weekly dependency update workflow now signs its automated commits by invoking `setup-git-signing` (fed by `secrets.BOT_GPG_PRIVATE_KEY`) instead of setting the `github-actions[bot]` git identity, and ensures signing state is torn down via an `always()` `cleanup-git-signing` step.
> 
> Separately, `package.json` adds `format` and `format:check` scripts that run `oxfmt` across the repo.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 477e5acb1b70dbd043aab2144732957160c75c1d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->