### PR TITLE
fix(ci): remove npm upgrade hack from provenance workflow

### DIFF
--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -166,13 +166,6 @@ jobs:
 
       - uses: SocketDev/socket-registry/.github/actions/install@6096b06b1790f411714c89c40f72aade2eeaab7c # main
 
-      - name: Upgrade npm for trusted publishing
-        run: |
-          # Avoid npm self-upgrade (corrupts deps mid-install on Node 22).
-          NPM_DIR="$(npm config get prefix)/lib/node_modules/npm"
-          curl -sL https://registry.npmjs.org/npm/-/npm-11.12.1.tgz | tar xz -C "$NPM_DIR" --strip-components=1
-          echo "npm version: $(npm --version)"
-
       # Get versions for lock-stepped and independent packages.
       - name: Get versions
         id: version


### PR DESCRIPTION
Node 25.8.2 (.node-version) ships npm 11.11+. The curl+tar npm upgrade step is unnecessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only removes a CI workaround step and relies on the Node-provided npm during the publish workflow. Main risk is publish failures if the runner’s bundled npm lacks required trusted publishing/provenance behavior.
> 
> **Overview**
> Removes the custom `curl | tar` npm self-upgrade step from the `provenance.yml` publish workflow, so publishing now uses the npm version bundled with the Node version from `.node-version`.
> 
> This simplifies the build/publish jobs and avoids mutating the global npm installation mid-workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cd7b27da763ac0d4034008056d551e9046a785f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->