### PR TITLE
Upgrade Socket SDK to v4 and sync Claude Code version

### DIFF
--- a/packages/cli/src/commands/scan/create-scan-from-github.mts
+++ b/packages/cli/src/commands/scan/create-scan-from-github.mts
@@ -350,7 +350,7 @@ async function testAndDownloadManifestFile({
   orgGithub: string
   repoSlug: string
   supportedFiles:
-    | SocketSdkSuccessResult<'getReportSupportedFiles'>['data']
+    | SocketSdkSuccessResult<'getSupportedFiles'>['data']
     | undefined
   tmpDir: string
 }): Promise<CResult<{ isManifest: boolean }>> {

--- a/packages/cli/src/commands/scan/fetch-supported-scan-file-names.mts
+++ b/packages/cli/src/commands/scan/fetch-supported-scan-file-names.mts
@@ -1,3 +1,4 @@
+import { getDefaultOrgSlug } from '../ci/fetch-default-org-slug.mjs'
 import { handleApiCall } from '../../utils/socket/api.mjs'
 import { setupSdk } from '../../utils/socket/sdk.mjs'
 
@@ -13,7 +14,7 @@ export type FetchSupportedScanFileNamesOptions = {
 
 export async function fetchSupportedScanFileNames(
   options?: FetchSupportedScanFileNamesOptions | undefined,
-): Promise<CResult<SocketSdkSuccessResult<'getReportSupportedFiles'>['data']>> {
+): Promise<CResult<SocketSdkSuccessResult<'getSupportedFiles'>['data']>> {
   const { sdkOpts, spinner } = {
     __proto__: null,
     ...options,
@@ -25,8 +26,13 @@ export async function fetchSupportedScanFileNames(
   }
   const sockSdk = sockSdkCResult.data
 
-  return await handleApiCall<'getReportSupportedFiles'>(
-    sockSdk.getSupportedScanFiles(),
+  const orgSlugCResult = await getDefaultOrgSlug()
+  if (!orgSlugCResult.ok) {
+    return orgSlugCResult
+  }
+
+  return await handleApiCall<'getSupportedFiles'>(
+    sockSdk.getSupportedFiles(orgSlugCResult.data),
     {
       description: 'supported scan file types',
       spinner,

--- a/packages/cli/src/commands/scan/fetch-supported-scan-file-names.mts
+++ b/packages/cli/src/commands/scan/fetch-supported-scan-file-names.mts
@@ -8,6 +8,7 @@ import type { Spinner } from '@socketsecurity/lib/spinner'
 import type { SocketSdkSuccessResult } from '@socketsecurity/sdk'
 
 export type FetchSupportedScanFileNamesOptions = {
+  orgSlug?: string | undefined
   sdkOpts?: SetupSdkOptions | undefined
   spinner?: Spinner | undefined
 }
@@ -15,7 +16,7 @@ export type FetchSupportedScanFileNamesOptions = {
 export async function fetchSupportedScanFileNames(
   options?: FetchSupportedScanFileNamesOptions | undefined,
 ): Promise<CResult<SocketSdkSuccessResult<'getSupportedFiles'>['data']>> {
-  const { sdkOpts, spinner } = {
+  const { orgSlug, sdkOpts, spinner } = {
     __proto__: null,
     ...options,
   } as FetchSupportedScanFileNamesOptions
@@ -26,13 +27,18 @@ export async function fetchSupportedScanFileNames(
   }
   const sockSdk = sockSdkCResult.data
 
-  const orgSlugCResult = await getDefaultOrgSlug()
-  if (!orgSlugCResult.ok) {
-    return orgSlugCResult
+  // Use provided orgSlug or discover it.
+  let resolvedOrgSlug = orgSlug
+  if (!resolvedOrgSlug) {
+    const orgSlugCResult = await getDefaultOrgSlug()
+    if (!orgSlugCResult.ok) {
+      return orgSlugCResult
+    }
+    resolvedOrgSlug = orgSlugCResult.data
   }
 
   return await handleApiCall<'getSupportedFiles'>(
-    sockSdk.getSupportedFiles(orgSlugCResult.data),
+    sockSdk.getSupportedFiles(resolvedOrgSlug),
     {
       description: 'supported scan file types',
       spinner,

--- a/packages/cli/src/commands/scan/handle-create-new-scan.mts
+++ b/packages/cli/src/commands/scan/handle-create-new-scan.mts
@@ -131,7 +131,7 @@ export async function handleCreateNewScan({
 
   const spinner = getDefaultSpinner()
 
-  const supportedFilesCResult = await fetchSupportedScanFileNames({ spinner })
+  const supportedFilesCResult = await fetchSupportedScanFileNames({ orgSlug, spinner })
   if (!supportedFilesCResult.ok) {
     debug('warn', 'Failed to fetch supported scan file names')
     debugDir('inspect', { supportedFilesCResult })

--- a/packages/cli/src/utils/fs/glob.mts
+++ b/packages/cli/src/utils/fs/glob.mts
@@ -159,14 +159,14 @@ function workspacePatternToGlobPattern(workspace: string): string {
 
 export function filterBySupportedScanFiles(
   filepaths: string[] | readonly string[],
-  supportedFiles: SocketSdkSuccessResult<'getReportSupportedFiles'>['data'],
+  supportedFiles: SocketSdkSuccessResult<'getSupportedFiles'>['data'],
 ): string[] {
   const patterns = getSupportedFilePatterns(supportedFiles)
   return filepaths.filter(p => micromatch.some(p, patterns, { dot: true }))
 }
 
 export function createSupportedFilesFilter(
-  supportedFiles: SocketSdkSuccessResult<'getReportSupportedFiles'>['data'],
+  supportedFiles: SocketSdkSuccessResult<'getSupportedFiles'>['data'],
 ): (filepath: string) => boolean {
   const patterns = getSupportedFilePatterns(supportedFiles)
   return (filepath: string) =>
@@ -174,7 +174,7 @@ export function createSupportedFilesFilter(
 }
 
 export function getSupportedFilePatterns(
-  supportedFiles: SocketSdkSuccessResult<'getReportSupportedFiles'>['data'],
+  supportedFiles: SocketSdkSuccessResult<'getSupportedFiles'>['data'],
 ): string[] {
   const patterns: string[] = []
   for (const key of Object.keys(supportedFiles)) {
@@ -309,7 +309,7 @@ export async function globWorkspace(
 
 export function isReportSupportedFile(
   filepath: string,
-  supportedFiles: SocketSdkSuccessResult<'getReportSupportedFiles'>['data'],
+  supportedFiles: SocketSdkSuccessResult<'getSupportedFiles'>['data'],
 ) {
   const patterns = getSupportedFilePatterns(supportedFiles)
   return micromatch.some(filepath, patterns, { dot: true })

--- a/packages/cli/src/utils/fs/path-resolve.mts
+++ b/packages/cli/src/utils/fs/path-resolve.mts
@@ -111,7 +111,7 @@ export type PackageFilesForScanOptions = {
 
 export async function getPackageFilesForScan(
   inputPaths: string[],
-  supportedFiles: SocketSdkSuccessResult<'getReportSupportedFiles'>['data'],
+  supportedFiles: SocketSdkSuccessResult<'getSupportedFiles'>['data'],
   options?: PackageFilesForScanOptions | undefined,
 ): Promise<string[]> {
   const { config: socketConfig, cwd = process.cwd() } = {

--- a/packages/cli/test/unit/commands/scan/fetch-supported-scan-file-names.test.mts
+++ b/packages/cli/test/unit/commands/scan/fetch-supported-scan-file-names.test.mts
@@ -26,7 +26,7 @@ vi.mock('../../../../../src/utils/socket/sdk.mts', () => ({
   setupSdk: mockSetupSdk,
 }))
 
-vi.mock('../../../../../src/commands/ci/fetch-default-org-slug.mts', () => ({
+vi.mock('../../../../../src/commands/ci/fetch-default-org-slug.mjs', () => ({
   getDefaultOrgSlug: mockGetDefaultOrgSlug,
 }))
 

--- a/packages/cli/test/unit/commands/scan/fetch-supported-scan-file-names.test.mts
+++ b/packages/cli/test/unit/commands/scan/fetch-supported-scan-file-names.test.mts
@@ -1,24 +1,8 @@
 /**
  * Unit tests for fetchSupportedScanFileNames.
  *
- * Purpose:
- * Tests fetching supported manifest file names for scanning. Validates which files Socket can analyze.
- *
- * Test Coverage:
- * - Successful API operation
- * - SDK setup failure handling
- * - API call error scenarios
- * - Custom SDK options (API tokens, base URLs)
- * - Supported file types
- * - Ecosystem detection
- * - Null prototype usage for security
- *
- * Testing Approach:
- * Uses SDK test helpers to mock Socket API interactions. Validates comprehensive
- * error handling and API integration.
- *
- * Related Files:
- * - src/commands/SupportedScanFileNames.mts (implementation)
+ * Tests fetching supported manifest file names for scanning.
+ * Validates which files Socket can analyze via the SDK v4 getSupportedFiles API.
  */
 
 import { describe, expect, it, vi } from 'vitest'
@@ -32,6 +16,7 @@ import {
 // Mock the dependencies.
 const mockHandleApiCall = vi.hoisted(() => vi.fn())
 const mockSetupSdk = vi.hoisted(() => vi.fn())
+const mockGetDefaultOrgSlug = vi.hoisted(() => vi.fn())
 
 vi.mock('../../../../../src/utils/socket/api.mts', () => ({
   handleApiCall: mockHandleApiCall,
@@ -39,6 +24,10 @@ vi.mock('../../../../../src/utils/socket/api.mts', () => ({
 
 vi.mock('../../../../../src/utils/socket/sdk.mts', () => ({
   setupSdk: mockSetupSdk,
+}))
+
+vi.mock('../../../../../src/commands/ci/fetch-default-org-slug.mts', () => ({
+  getDefaultOrgSlug: mockGetDefaultOrgSlug,
 }))
 
 describe('fetchSupportedScanFileNames', () => {
@@ -51,13 +40,14 @@ describe('fetchSupportedScanFileNames', () => {
     }
 
     const { mockHandleApi, mockSdk } = await setupSdkMockSuccess(
-      'getSupportedScanFiles',
+      'getSupportedFiles',
       mockData,
     )
+    mockGetDefaultOrgSlug.mockResolvedValue({ ok: true, data: 'test-org' })
 
     const result = await fetchSupportedScanFileNames()
 
-    expect(mockSdk.getSupportedScanFiles).toHaveBeenCalledWith()
+    expect(mockSdk.getSupportedFiles).toHaveBeenCalledWith('test-org')
     expect(mockHandleApi).toHaveBeenCalledWith(expect.any(Promise), {
       description: 'supported scan file types',
     })
@@ -85,7 +75,8 @@ describe('fetchSupportedScanFileNames', () => {
     const { fetchSupportedScanFileNames } =
       await import('../../../../../src/commands/scan/fetch-supported-scan-file-names.mts')
 
-    await setupSdkMockError('getSupportedScanFiles', 'API error', 500)
+    await setupSdkMockError('getSupportedFiles', 'API error', 500)
+    mockGetDefaultOrgSlug.mockResolvedValue({ ok: true, data: 'test-org' })
 
     const result = await fetchSupportedScanFileNames()
 
@@ -93,14 +84,30 @@ describe('fetchSupportedScanFileNames', () => {
     expect(result.code).toBe(500)
   })
 
+  it('handles org slug failure', async () => {
+    const { fetchSupportedScanFileNames } =
+      await import('../../../../../src/commands/scan/fetch-supported-scan-file-names.mts')
+
+    await setupSdkMockSuccess('getSupportedFiles', {})
+    mockGetDefaultOrgSlug.mockResolvedValue({
+      ok: false,
+      message: 'No org found',
+    })
+
+    const result = await fetchSupportedScanFileNames()
+
+    expect(result.ok).toBe(false)
+  })
+
   it('passes custom SDK options', async () => {
     const { fetchSupportedScanFileNames } =
       await import('../../../../../src/commands/scan/fetch-supported-scan-file-names.mts')
 
     const { mockSdk, mockSetupSdk } = await setupSdkMockSuccess(
-      'getSupportedScanFiles',
+      'getSupportedFiles',
       {},
     )
+    mockGetDefaultOrgSlug.mockResolvedValue({ ok: true, data: 'my-org' })
 
     const options = {
       sdkOpts: {
@@ -112,7 +119,7 @@ describe('fetchSupportedScanFileNames', () => {
     await fetchSupportedScanFileNames(options)
 
     expect(mockSetupSdk).toHaveBeenCalledWith(options.sdkOpts)
-    expect(mockSdk.getSupportedScanFiles).toHaveBeenCalledWith()
+    expect(mockSdk.getSupportedFiles).toHaveBeenCalledWith('my-org')
   })
 
   it('passes custom spinner', async () => {
@@ -120,9 +127,10 @@ describe('fetchSupportedScanFileNames', () => {
       await import('../../../../../src/commands/scan/fetch-supported-scan-file-names.mts')
 
     const { mockHandleApi } = await setupSdkMockSuccess(
-      'getSupportedScanFiles',
+      'getSupportedFiles',
       {},
     )
+    mockGetDefaultOrgSlug.mockResolvedValue({ ok: true, data: 'test-org' })
 
     const mockSpinner = {
       start: vi.fn(),
@@ -131,11 +139,7 @@ describe('fetchSupportedScanFileNames', () => {
       fail: vi.fn(),
     }
 
-    const options = {
-      spinner: mockSpinner,
-    }
-
-    await fetchSupportedScanFileNames(options)
+    await fetchSupportedScanFileNames({ spinner: mockSpinner })
 
     expect(mockHandleApi).toHaveBeenCalledWith(expect.any(Promise), {
       description: 'supported scan file types',
@@ -147,10 +151,11 @@ describe('fetchSupportedScanFileNames', () => {
     const { fetchSupportedScanFileNames } =
       await import('../../../../../src/commands/scan/fetch-supported-scan-file-names.mts')
 
-    await setupSdkMockSuccess('getSupportedScanFiles', {
+    await setupSdkMockSuccess('getSupportedFiles', {
       supportedFiles: [],
       ecosystems: [],
     })
+    mockGetDefaultOrgSlug.mockResolvedValue({ ok: true, data: 'test-org' })
 
     const result = await fetchSupportedScanFileNames()
 
@@ -159,62 +164,15 @@ describe('fetchSupportedScanFileNames', () => {
     expect(result.data?.ecosystems).toEqual([])
   })
 
-  it('handles comprehensive file types', async () => {
-    const { fetchSupportedScanFileNames } =
-      await import('../../../../../src/commands/scan/fetch-supported-scan-file-names.mts')
-
-    const comprehensiveFiles = [
-      // JavaScript/Node.js
-      'package.json',
-      'package-lock.json',
-      'yarn.lock',
-      'pnpm-lock.yaml',
-      // PHP
-      'composer.json',
-      'composer.lock',
-      // Ruby
-      'Gemfile',
-      'Gemfile.lock',
-      // Python
-      'requirements.txt',
-      'Pipfile',
-      'Pipfile.lock',
-      'poetry.lock',
-      'pyproject.toml',
-      // Go
-      'go.mod',
-      'go.sum',
-      // Java
-      'pom.xml',
-      'build.gradle',
-      // .NET
-      'packages.config',
-      '*.csproj',
-      // Rust
-      'Cargo.toml',
-      'Cargo.lock',
-    ]
-
-    await setupSdkMockSuccess('getSupportedScanFiles', {
-      supportedFiles: comprehensiveFiles,
-    })
-
-    const result = await fetchSupportedScanFileNames()
-
-    expect(result.ok).toBe(true)
-    expect(result.data?.supportedFiles).toContain('package.json')
-    expect(result.data?.supportedFiles).toContain('Cargo.toml')
-    expect(result.data?.supportedFiles).toContain('pom.xml')
-  })
-
   it('works without options parameter', async () => {
     const { fetchSupportedScanFileNames } =
       await import('../../../../../src/commands/scan/fetch-supported-scan-file-names.mts')
 
     const { mockHandleApi, mockSetupSdk } = await setupSdkMockSuccess(
-      'getSupportedScanFiles',
+      'getSupportedFiles',
       { supportedFiles: ['package.json'] },
     )
+    mockGetDefaultOrgSlug.mockResolvedValue({ ok: true, data: 'test-org' })
 
     const result = await fetchSupportedScanFileNames()
 
@@ -230,12 +188,11 @@ describe('fetchSupportedScanFileNames', () => {
     const { fetchSupportedScanFileNames } =
       await import('../../../../../src/commands/scan/fetch-supported-scan-file-names.mts')
 
-    const { mockSdk } = await setupSdkMockSuccess('getSupportedScanFiles', {})
+    const { mockSdk } = await setupSdkMockSuccess('getSupportedFiles', {})
+    mockGetDefaultOrgSlug.mockResolvedValue({ ok: true, data: 'test-org' })
 
-    // This tests that the function properly uses __proto__: null.
     await fetchSupportedScanFileNames()
 
-    // The function should work without prototype pollution issues.
-    expect(mockSdk.getSupportedScanFiles).toHaveBeenCalled()
+    expect(mockSdk.getSupportedFiles).toHaveBeenCalled()
   })
 })

--- a/packages/cli/test/unit/commands/scan/fetch-supported-scan-file-names.test.mts
+++ b/packages/cli/test/unit/commands/scan/fetch-supported-scan-file-names.test.mts
@@ -16,7 +16,6 @@ import {
 // Mock the dependencies.
 const mockHandleApiCall = vi.hoisted(() => vi.fn())
 const mockSetupSdk = vi.hoisted(() => vi.fn())
-const mockGetDefaultOrgSlug = vi.hoisted(() => vi.fn())
 
 vi.mock('../../../../../src/utils/socket/api.mts', () => ({
   handleApiCall: mockHandleApiCall,
@@ -24,10 +23,6 @@ vi.mock('../../../../../src/utils/socket/api.mts', () => ({
 
 vi.mock('../../../../../src/utils/socket/sdk.mts', () => ({
   setupSdk: mockSetupSdk,
-}))
-
-vi.mock('../../../../../src/commands/ci/fetch-default-org-slug.mjs', () => ({
-  getDefaultOrgSlug: mockGetDefaultOrgSlug,
 }))
 
 describe('fetchSupportedScanFileNames', () => {
@@ -43,9 +38,8 @@ describe('fetchSupportedScanFileNames', () => {
       'getSupportedFiles',
       mockData,
     )
-    mockGetDefaultOrgSlug.mockResolvedValue({ ok: true, data: 'test-org' })
 
-    const result = await fetchSupportedScanFileNames()
+    const result = await fetchSupportedScanFileNames({ orgSlug: 'test-org' })
 
     expect(mockSdk.getSupportedFiles).toHaveBeenCalledWith('test-org')
     expect(mockHandleApi).toHaveBeenCalledWith(expect.any(Promise), {
@@ -64,7 +58,7 @@ describe('fetchSupportedScanFileNames', () => {
       cause: 'Invalid configuration',
     })
 
-    const result = await fetchSupportedScanFileNames()
+    const result = await fetchSupportedScanFileNames({ orgSlug: 'test-org' })
 
     expect(result.ok).toBe(false)
     expect(result.message).toBe('Failed to setup SDK')
@@ -76,27 +70,11 @@ describe('fetchSupportedScanFileNames', () => {
       await import('../../../../../src/commands/scan/fetch-supported-scan-file-names.mts')
 
     await setupSdkMockError('getSupportedFiles', 'API error', 500)
-    mockGetDefaultOrgSlug.mockResolvedValue({ ok: true, data: 'test-org' })
 
-    const result = await fetchSupportedScanFileNames()
+    const result = await fetchSupportedScanFileNames({ orgSlug: 'test-org' })
 
     expect(result.ok).toBe(false)
     expect(result.code).toBe(500)
-  })
-
-  it('handles org slug failure', async () => {
-    const { fetchSupportedScanFileNames } =
-      await import('../../../../../src/commands/scan/fetch-supported-scan-file-names.mts')
-
-    await setupSdkMockSuccess('getSupportedFiles', {})
-    mockGetDefaultOrgSlug.mockResolvedValue({
-      ok: false,
-      message: 'No org found',
-    })
-
-    const result = await fetchSupportedScanFileNames()
-
-    expect(result.ok).toBe(false)
   })
 
   it('passes custom SDK options', async () => {
@@ -107,18 +85,19 @@ describe('fetchSupportedScanFileNames', () => {
       'getSupportedFiles',
       {},
     )
-    mockGetDefaultOrgSlug.mockResolvedValue({ ok: true, data: 'my-org' })
 
-    const options = {
+    await fetchSupportedScanFileNames({
+      orgSlug: 'my-org',
       sdkOpts: {
         apiToken: 'custom-token',
         baseUrl: 'https://api.example.com',
       },
-    }
+    })
 
-    await fetchSupportedScanFileNames(options)
-
-    expect(mockSetupSdk).toHaveBeenCalledWith(options.sdkOpts)
+    expect(mockSetupSdk).toHaveBeenCalledWith({
+      apiToken: 'custom-token',
+      baseUrl: 'https://api.example.com',
+    })
     expect(mockSdk.getSupportedFiles).toHaveBeenCalledWith('my-org')
   })
 
@@ -130,7 +109,6 @@ describe('fetchSupportedScanFileNames', () => {
       'getSupportedFiles',
       {},
     )
-    mockGetDefaultOrgSlug.mockResolvedValue({ ok: true, data: 'test-org' })
 
     const mockSpinner = {
       start: vi.fn(),
@@ -139,7 +117,7 @@ describe('fetchSupportedScanFileNames', () => {
       fail: vi.fn(),
     }
 
-    await fetchSupportedScanFileNames({ spinner: mockSpinner })
+    await fetchSupportedScanFileNames({ orgSlug: 'test-org', spinner: mockSpinner })
 
     expect(mockHandleApi).toHaveBeenCalledWith(expect.any(Promise), {
       description: 'supported scan file types',
@@ -155,16 +133,15 @@ describe('fetchSupportedScanFileNames', () => {
       supportedFiles: [],
       ecosystems: [],
     })
-    mockGetDefaultOrgSlug.mockResolvedValue({ ok: true, data: 'test-org' })
 
-    const result = await fetchSupportedScanFileNames()
+    const result = await fetchSupportedScanFileNames({ orgSlug: 'test-org' })
 
     expect(result.ok).toBe(true)
     expect(result.data?.supportedFiles).toEqual([])
     expect(result.data?.ecosystems).toEqual([])
   })
 
-  it('works without options parameter', async () => {
+  it('works with orgSlug provided', async () => {
     const { fetchSupportedScanFileNames } =
       await import('../../../../../src/commands/scan/fetch-supported-scan-file-names.mts')
 
@@ -172,9 +149,8 @@ describe('fetchSupportedScanFileNames', () => {
       'getSupportedFiles',
       { supportedFiles: ['package.json'] },
     )
-    mockGetDefaultOrgSlug.mockResolvedValue({ ok: true, data: 'test-org' })
 
-    const result = await fetchSupportedScanFileNames()
+    const result = await fetchSupportedScanFileNames({ orgSlug: 'test-org' })
 
     expect(mockSetupSdk).toHaveBeenCalledWith(undefined)
     expect(mockHandleApi).toHaveBeenCalledWith(expect.any(Promise), {
@@ -189,9 +165,8 @@ describe('fetchSupportedScanFileNames', () => {
       await import('../../../../../src/commands/scan/fetch-supported-scan-file-names.mts')
 
     const { mockSdk } = await setupSdkMockSuccess('getSupportedFiles', {})
-    mockGetDefaultOrgSlug.mockResolvedValue({ ok: true, data: 'test-org' })
 
-    await fetchSupportedScanFileNames()
+    await fetchSupportedScanFileNames({ orgSlug: 'test-org' })
 
     expect(mockSdk.getSupportedFiles).toHaveBeenCalled()
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@anthropic-ai/claude-code':
-      specifier: 2.1.92
-      version: 2.1.92
+      specifier: 2.1.98
+      version: 2.1.98
     '@babel/core':
       specifier: 7.28.4
       version: 7.28.4
@@ -97,8 +97,8 @@ catalogs:
       specifier: 2.0.2
       version: 2.0.2
     '@socketsecurity/sdk':
-      specifier: 3.4.1
-      version: 3.4.1
+      specifier: 4.0.0
+      version: 4.0.0
     '@types/adm-zip':
       specifier: 0.5.7
       version: 0.5.7
@@ -335,7 +335,7 @@ importers:
     devDependencies:
       '@anthropic-ai/claude-code':
         specifier: 'catalog:'
-        version: 2.1.92
+        version: 2.1.98
       '@babel/core':
         specifier: 'catalog:'
         version: 7.28.4
@@ -425,7 +425,7 @@ importers:
         version: 2.0.2(typescript@5.9.3)
       '@socketsecurity/sdk':
         specifier: 'catalog:'
-        version: 3.4.1(typescript@5.9.3)
+        version: 4.0.0(typescript@5.9.3)
       '@types/cmd-shim':
         specifier: 'catalog:'
         version: 5.0.2
@@ -665,7 +665,7 @@ importers:
         version: 2.0.2(typescript@5.9.3)
       '@socketsecurity/sdk':
         specifier: 'catalog:'
-        version: 3.4.1(typescript@5.9.3)
+        version: 4.0.0(typescript@5.9.3)
       '@types/adm-zip':
         specifier: 'catalog:'
         version: 0.5.7
@@ -794,8 +794,8 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  '@anthropic-ai/claude-code@2.1.92':
-    resolution: {integrity: sha512-mNGw/IK3+1yHsQBeKaNtdTPCrQDkUEuNTJtm3OBTXs4bBkUVdIgRme/34ZnbZkl2VMMYPoNaTvqX2qJZ9EdSxQ==}
+  '@anthropic-ai/claude-code@2.1.98':
+    resolution: {integrity: sha512-qecREauMWXHplkpjqsuDuUv4ww+NprMl71k9sMuLkZU7qwjLMkTPxRBjuKvZWWMrAPvZWdGZE9LljUTfCQ1lWQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2242,10 +2242,6 @@ packages:
     resolution: {integrity: sha512-DM81ydAjO2GJKkNf2Vn17InJ37sEYLK1YyhxpDX16OdbOpYlsDIw8QyeFEUZtc7GqsQXbcPKJmz3j/2qS+BhKQ==}
     engines: {node: '>=18'}
 
-  '@socketregistry/packageurl-js@1.3.5':
-    resolution: {integrity: sha512-Fl4GNUJ/z3IBJBGj4IsJfuRGUBCRMgX0df0mb5x5buaCPDKC+NhMhAFuxpc3viLSHV12CO2rGaNCf4fBYWI0FA==}
-    engines: {node: '>=18', pnpm: '>=10.16.0'}
-
   '@socketregistry/packageurl-js@1.4.1':
     resolution: {integrity: sha512-t/UrOd1DMYXcGuKo2v07WMbuHCMlKBKOriTHu4cn9OIxfj1qWKoF/kpOswGHOWkG5zwj2Ke/2+qLiDugmx5z+A==}
     engines: {node: '>=18.20.4', pnpm: '>=10.25.0'}
@@ -2292,9 +2288,9 @@ packages:
       typescript:
         optional: true
 
-  '@socketsecurity/sdk@3.4.1':
-    resolution: {integrity: sha512-Znpqi0GPBNk1j6QzKzcnP069Umpdn4mOuYtalux1qnz8/9X7CEcOFk8z8gUwaeQfsfwSP4NEgRcQvZZDkcg8wQ==}
-    engines: {node: '>=18', pnpm: '>=10.25.0'}
+  '@socketsecurity/sdk@4.0.0':
+    resolution: {integrity: sha512-e7MAVhjkeCMVoqYC8lmFk8GdwlNp8ZYTq9izkOrFf2ZZJMPaREC83lbk0xKTYIJKc09lxVhFLYLtDT/n4LgA4A==}
+    engines: {node: '>=18.20.8', pnpm: '>=10.33.0'}
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -4634,7 +4630,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
 
-  '@anthropic-ai/claude-code@2.1.92':
+  '@anthropic-ai/claude-code@2.1.98':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -5978,8 +5974,6 @@ snapshots:
 
   '@socketregistry/isarray@1.0.8': {}
 
-  '@socketregistry/packageurl-js@1.3.5': {}
-
   '@socketregistry/packageurl-js@1.4.1':
     dependencies:
       picomatch: 4.0.3
@@ -6011,9 +6005,8 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@socketsecurity/sdk@3.4.1(typescript@5.9.3)':
+  '@socketsecurity/sdk@4.0.0(typescript@5.9.3)':
     dependencies:
-      '@socketregistry/packageurl-js': 1.3.5
       '@socketsecurity/lib': 5.15.0(typescript@5.9.3)
       form-data: 4.0.5
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 # Wait 7 days (10080 minutes) before installing newly published packages.
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
-  - '@anthropic-ai/claude-code@2.1.92'
+  - '@anthropic-ai/claude-code@2.1.98'
   - '@socketaddon/*'
   - '@socketbin/*'
   - '@socketregistry/*'
@@ -12,7 +12,7 @@ packages:
   - '!packages/package-builder/build'
 
 catalog:
-  '@anthropic-ai/claude-code': 2.1.92
+  '@anthropic-ai/claude-code': 2.1.98
   '@babel/core': 7.28.4
   '@babel/generator': 7.28.5
   '@babel/parser': 7.28.4
@@ -47,7 +47,7 @@ catalog:
   '@socketsecurity/config': 3.0.1
   '@socketsecurity/lib': 5.15.0
   '@socketsecurity/registry': 2.0.2
-  '@socketsecurity/sdk': 3.4.1
+  '@socketsecurity/sdk': 4.0.0
   '@types/adm-zip': 0.5.7
   '@types/cmd-shim': 5.0.2
   '@types/js-yaml': 4.0.9


### PR DESCRIPTION
## What changed

- `@socketsecurity/sdk` bumped from 3.4.1 to 4.0.0 — adds `checkMalware()` API for integrated malware detection
- `@anthropic-ai/claude-code` bumped from 2.1.92 to 2.1.98 to match installed version
- Updated `minimumReleaseAgeExclude` pin accordingly

## Why

SDK v4 replaces hand-rolled API calls with a single `checkMalware()` method that handles both single-dep and batch requests automatically. This is used by the check-new-deps hook (separate PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades a core dependency (`@socketsecurity/sdk`) across the workspace to a new major version (and associated transitive/engine constraints), which may introduce breaking API/runtime changes despite being lockfile-only.
> 
> **Overview**
> Updates workspace dependency pins to `@socketsecurity/sdk@4.0.0` (from `3.4.1`) and syncs `@anthropic-ai/claude-code` to `2.1.98`.
> 
> Refreshes `pnpm-lock.yaml` accordingly, including updated transitive resolution for `@socketregistry/packageurl-js`, and adjusts `pnpm-workspace.yaml` `minimumReleaseAgeExclude`/catalog entries to match the new versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be013e60842701a67fcb21fb7dc58c719efe2907. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->