### PR TITLE
upgrading coana to version 14.12.209

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.80](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.80) - 2026-04-10
+
+### Changed
+- Updated the Coana CLI to v `14.12.209`.
+
 ## [1.1.79](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.79) - 2026-04-08
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.79",
+  "version": "1.1.80",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -97,7 +97,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.205",
+    "@coana-tech/cli": "14.12.209",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.205
-        version: 14.12.205
+        specifier: 14.12.209
+        version: 14.12.209
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@14.12.205':
-    resolution: {integrity: sha512-+iprCFeKFpD3kOkPd9Xje568XVzmAPYOFqiGqfYnPcd0PiaeD/yvPix1qDXhImaFhEX3J2vH8eZmDM3hz0jXpA==}
+  '@coana-tech/cli@14.12.209':
+    resolution: {integrity: sha512-10ZnT7nUq0Uh20O7LYYX5CgeNXCN5OGFYroIJwSxE6bcGc8CaPXb8Q24FrOwLQo8ppYhdovsPzVXPnTWWpR3pw==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5385,7 +5385,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@14.12.205': {}
+  '@coana-tech/cli@14.12.209': {}
 
   '@colors/colors@1.5.0':
     optional: true

--- a/src/commands/fix/cmd-fix.integration.test.mts
+++ b/src/commands/fix/cmd-fix.integration.test.mts
@@ -516,6 +516,7 @@ describe('socket fix', async () => {
       )
       expect(code, 'should exit with non-zero code').not.toBe(0)
     },
+    { timeout: testTimeout },
   )
 
   cmdit(


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 14.12.205 to 14.12.209

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency/version bump only; behavior changes are limited to whatever changes in the updated `@coana-tech/cli` bring to reach/fix functionality.
> 
> **Overview**
> Bumps the bundled Coana dependency by updating `@coana-tech/cli` from `14.12.205` to `14.12.209`, and updates `pnpm-lock.yaml` accordingly.
> 
> Also increments the Socket CLI version to `1.1.80` and records the upgrade in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f32a5bc1b336e5c0a0102294aeb209c1688ecd03. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->