### PR TITLE
fix: correct version to 1.1.81 and restore 1.1.80 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [1.1.80](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.80) - 2026-04-10
+## [1.1.81](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.81) - 2026-04-10
 
 ### Changed
 - Updated the Coana CLI to v `14.12.211`.
+
+## [1.1.80](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.80) - 2026-04-10
+
+### Changed
+- Updated the Coana CLI to v `14.12.209`.
 
 ## [1.1.79](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.79) - 2026-04-08
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.80",
+  "version": "1.1.81",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",


### PR DESCRIPTION
## Summary
- The previous coana bump PR (#1188) incorrectly merged as 1.1.80, overwriting the existing 1.1.80 entry (14.12.209)
- Restores the 1.1.80 changelog entry for coana 14.12.209
- Bumps version to 1.1.81 with a new changelog entry for coana 14.12.211

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates release metadata (version number and changelog entries) with no runtime code changes.
> 
> **Overview**
> Bumps the package version to `1.1.81`.
> 
> Updates `CHANGELOG.md` to add a new `1.1.81` entry for the Coana CLI update to `14.12.211`, and restores the `1.1.80` entry noting Coana CLI `14.12.209`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b22a48481c8196e8316e24921f33118ef065e302. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->