### PR TITLE
fix: normalize platform keys and repository prefix in hook config

### DIFF
--- a/.claude/hooks/setup-security-tools/external-tools.json
+++ b/.claude/hooks/setup-security-tools/external-tools.json
@@ -4,59 +4,86 @@
     "zizmor": {
       "description": "GitHub Actions security scanner",
       "version": "1.23.1",
-      "repository": "zizmorcore/zizmor",
-      "assets": {
-        "darwin-arm64": "zizmor-aarch64-apple-darwin.tar.gz",
-        "darwin-x64": "zizmor-x86_64-apple-darwin.tar.gz",
-        "linux-arm64": "zizmor-aarch64-unknown-linux-gnu.tar.gz",
-        "linux-x64": "zizmor-x86_64-unknown-linux-gnu.tar.gz",
-        "win32-x64": "zizmor-x86_64-pc-windows-msvc.zip"
-      },
+      "repository": "github:zizmorcore/zizmor",
+      "release": "asset",
       "checksums": {
-        "zizmor-aarch64-apple-darwin.tar.gz": "2632561b974c69f952258c1ab4b7432d5c7f92e555704155c3ac28a2910bd717",
-        "zizmor-aarch64-unknown-linux-gnu.tar.gz": "3725d7cd7102e4d70827186389f7d5930b6878232930d0a3eb058d7e5b47e658",
-        "zizmor-x86_64-apple-darwin.tar.gz": "89d5ed42081dd9d0433a10b7545fac42b35f1f030885c278b9712b32c66f2597",
-        "zizmor-x86_64-pc-windows-msvc.zip": "33c2293ff02834720dd7cd8b47348aafb2e95a19bdc993c0ecaca9c804ade92a",
-        "zizmor-x86_64-unknown-linux-gnu.tar.gz": "67a8df0a14352dd81882e14876653d097b99b0f4f6b6fe798edc0320cff27aff"
+        "darwin-arm64": {
+          "asset": "zizmor-aarch64-apple-darwin.tar.gz",
+          "sha256": "2632561b974c69f952258c1ab4b7432d5c7f92e555704155c3ac28a2910bd717"
+        },
+        "darwin-x64": {
+          "asset": "zizmor-x86_64-apple-darwin.tar.gz",
+          "sha256": "89d5ed42081dd9d0433a10b7545fac42b35f1f030885c278b9712b32c66f2597"
+        },
+        "linux-arm64": {
+          "asset": "zizmor-aarch64-unknown-linux-gnu.tar.gz",
+          "sha256": "3725d7cd7102e4d70827186389f7d5930b6878232930d0a3eb058d7e5b47e658"
+        },
+        "linux-x64": {
+          "asset": "zizmor-x86_64-unknown-linux-gnu.tar.gz",
+          "sha256": "67a8df0a14352dd81882e14876653d097b99b0f4f6b6fe798edc0320cff27aff"
+        },
+        "win-x64": {
+          "asset": "zizmor-x86_64-pc-windows-msvc.zip",
+          "sha256": "33c2293ff02834720dd7cd8b47348aafb2e95a19bdc993c0ecaca9c804ade92a"
+        }
       }
     },
     "sfw-free": {
       "description": "Socket Firewall (free tier)",
       "version": "v1.6.1",
-      "repository": "SocketDev/sfw-free",
-      "platforms": {
-        "darwin-arm64": "macos-arm64",
-        "darwin-x64": "macos-x86_64",
-        "linux-arm64": "linux-arm64",
-        "linux-x64": "linux-x86_64",
-        "win32-x64": "windows-x86_64"
-      },
+      "repository": "github:SocketDev/sfw-free",
+      "release": "asset",
       "checksums": {
-        "linux-arm64": "df2eedb2daf2572eee047adb8bfd81c9069edcb200fc7d3710fca98ec3ca81a1",
-        "linux-x86_64": "4a1e8b65e90fce7d5fd066cf0af6c93d512065fa4222a475c8d959a6bc14b9ff",
-        "macos-arm64": "bf1616fc44ac49f1cb2067fedfa127a3ae65d6ec6d634efbb3098cfa355e5555",
-        "macos-x86_64": "724ccea19d847b79db8cc8e38f5f18ce2dd32336007f42b11bed7d2e5f4a2566",
-        "windows-x86_64": "c953e62ad7928d4d8f2302f5737884ea1a757babc26bed6a42b9b6b68a5d54af"
+        "darwin-arm64": {
+          "asset": "sfw-free-macos-arm64",
+          "sha256": "bf1616fc44ac49f1cb2067fedfa127a3ae65d6ec6d634efbb3098cfa355e5555"
+        },
+        "darwin-x64": {
+          "asset": "sfw-free-macos-x86_64",
+          "sha256": "724ccea19d847b79db8cc8e38f5f18ce2dd32336007f42b11bed7d2e5f4a2566"
+        },
+        "linux-arm64": {
+          "asset": "sfw-free-linux-arm64",
+          "sha256": "df2eedb2daf2572eee047adb8bfd81c9069edcb200fc7d3710fca98ec3ca81a1"
+        },
+        "linux-x64": {
+          "asset": "sfw-free-linux-x86_64",
+          "sha256": "4a1e8b65e90fce7d5fd066cf0af6c93d512065fa4222a475c8d959a6bc14b9ff"
+        },
+        "win-x64": {
+          "asset": "sfw-free-windows-x86_64.exe",
+          "sha256": "c953e62ad7928d4d8f2302f5737884ea1a757babc26bed6a42b9b6b68a5d54af"
+        }
       },
       "ecosystems": ["npm", "yarn", "pnpm", "pip", "uv", "cargo"]
     },
     "sfw-enterprise": {
       "description": "Socket Firewall (enterprise tier)",
       "version": "v1.6.1",
-      "repository": "SocketDev/firewall-release",
-      "platforms": {
-        "darwin-arm64": "macos-arm64",
-        "darwin-x64": "macos-x86_64",
-        "linux-arm64": "linux-arm64",
-        "linux-x64": "linux-x86_64",
-        "win32-x64": "windows-x86_64"
-      },
+      "repository": "github:SocketDev/firewall-release",
+      "release": "asset",
       "checksums": {
-        "linux-arm64": "671270231617142404a1564e52672f79b806f9df3f232fcc7606329c0246da55",
-        "linux-x86_64": "9115b4ca8021eb173eb9e9c3627deb7f1066f8debd48c5c9d9f3caabb2a26a4b",
-        "macos-arm64": "acad0b517601bb7408e2e611c9226f47dcccbd83333d7fc5157f1d32ed2b953d",
-        "macos-x86_64": "01d64d40effda35c31f8d8ee1fed1388aac0a11aba40d47fba8a36024b77500c",
-        "windows-x86_64": "9a50e1ddaf038138c3f85418dc5df0113bbe6fc884f5abe158beaa9aea18d70a"
+        "darwin-arm64": {
+          "asset": "sfw-macos-arm64",
+          "sha256": "acad0b517601bb7408e2e611c9226f47dcccbd83333d7fc5157f1d32ed2b953d"
+        },
+        "darwin-x64": {
+          "asset": "sfw-macos-x86_64",
+          "sha256": "01d64d40effda35c31f8d8ee1fed1388aac0a11aba40d47fba8a36024b77500c"
+        },
+        "linux-arm64": {
+          "asset": "sfw-linux-arm64",
+          "sha256": "671270231617142404a1564e52672f79b806f9df3f232fcc7606329c0246da55"
+        },
+        "linux-x64": {
+          "asset": "sfw-linux-x86_64",
+          "sha256": "9115b4ca8021eb173eb9e9c3627deb7f1066f8debd48c5c9d9f3caabb2a26a4b"
+        },
+        "win-x64": {
+          "asset": "sfw-windows-x86_64.exe",
+          "sha256": "9a50e1ddaf038138c3f85418dc5df0113bbe6fc884f5abe158beaa9aea18d70a"
+        }
       },
       "ecosystems": ["npm", "yarn", "pnpm", "pip", "uv", "cargo", "gem", "bundler", "nuget"]
     }

--- a/.claude/hooks/setup-security-tools/index.mts
+++ b/.claude/hooks/setup-security-tools/index.mts
@@ -121,12 +121,14 @@ async function setupZizmor(): Promise<boolean> {
   }
 
   // Download archive via dlx (handles caching + checksum).
-  const platformKey = `${process.platform}-${process.arch}`
-  const asset = ZIZMOR.assets?.[platformKey]
-  if (!asset) throw new Error(`Unsupported platform: ${platformKey}`)
-  const expectedSha = ZIZMOR.checksums?.[asset]
-  if (!expectedSha) throw new Error(`No checksum for: ${asset}`)
-  const url = `https://github.com/${ZIZMOR.repository}/releases/download/v${ZIZMOR.version}/${asset}`
+  const platformKey = `${process.platform === 'win32' ? 'win' : process.platform}-${process.arch}`
+  const platformEntry = ZIZMOR.checksums?.[platformKey]
+  if (!platformEntry) {
+    throw new Error(`Unsupported platform: ${platformKey}`)
+  }
+  const { asset, sha256: expectedSha } = platformEntry
+  const repo = ZIZMOR.repository?.replace(/^[^:]+:/, '') ?? ''
+  const url = `https://github.com/${repo}/releases/download/v${ZIZMOR.version}/${asset}`
 
   logger.log(`Downloading zizmor v${ZIZMOR.version} (${asset})...`)
   const { binaryPath: archivePath, downloaded } = await downloadBinary({
@@ -174,17 +176,16 @@ async function setupSfw(apiKey: string | undefined): Promise<boolean> {
   logger.log(`=== Socket Firewall (${isEnterprise ? 'enterprise' : 'free'}) ===`)
 
   // Platform.
-  const platformKey = `${process.platform}-${process.arch}`
-  const sfwPlatform = sfwConfig.platforms?.[platformKey]
-  if (!sfwPlatform) throw new Error(`Unsupported platform: ${platformKey}`)
+  const platformKey = `${process.platform === 'win32' ? 'win' : process.platform}-${process.arch}`
+  const platformEntry = sfwConfig.checksums?.[platformKey]
+  if (!platformEntry) {
+    throw new Error(`Unsupported platform: ${platformKey}`)
+  }
 
   // Checksum + asset.
-  const sha256 = sfwConfig.checksums?.[sfwPlatform]
-  if (!sha256) throw new Error(`No checksum for: ${sfwPlatform}`)
-  const prefix = isEnterprise ? 'sfw' : 'sfw-free'
-  const suffix = sfwPlatform.startsWith('windows') ? '.exe' : ''
-  const asset = `${prefix}-${sfwPlatform}${suffix}`
-  const url = `https://github.com/${sfwConfig.repository}/releases/download/${sfwConfig.version}/${asset}`
+  const { asset, sha256 } = platformEntry
+  const repo = sfwConfig.repository?.replace(/^[^:]+:/, '') ?? ''
+  const url = `https://github.com/${repo}/releases/download/${sfwConfig.version}/${asset}`
   const binaryName = isEnterprise ? 'sfw' : 'sfw-free'
 
   // Download (with cache + checksum).

--- a/.claude/hooks/setup-security-tools/update.mts
+++ b/.claude/hooks/setup-security-tools/update.mts
@@ -146,7 +146,7 @@ async function updateZizmor(config: Config): Promise<UpdateResult> {
     return { tool, skipped: true, updated: false, reason: 'not in config' }
   }
 
-  const repo = toolConfig.repository ?? 'zizmorcore/zizmor'
+  const repo = toolConfig.repository?.replace(/^[^:]+:/, '') ?? 'zizmorcore/zizmor'
 
   let release: GhRelease
   try {
@@ -265,7 +265,7 @@ async function updateSfwTool(
     return { tool: toolName, skipped: true, updated: false, reason: 'not in config' }
   }
 
-  const repo = toolConfig.repository
+  const repo = toolConfig.repository?.replace(/^[^:]+:/, '')
   if (!repo) {
     return { tool: toolName, skipped: true, updated: false, reason: 'no repository' }
   }

--- a/packages/cli/scripts/sea-build-utils/downloads.mjs
+++ b/packages/cli/scripts/sea-build-utils/downloads.mjs
@@ -261,11 +261,11 @@ export async function downloadExternalTools(platform, arch, isMusl = false) {
   // Filter by release === 'asset' to include all GitHub-released tools.
   for (const [toolName, toolConfig] of Object.entries(externalTools)) {
     if (toolConfig.release === 'asset') {
-      const repoPath = toolConfig.repository.replace(/^github:/, '')
+      const repoPath = toolConfig.repository.replace(/^[^:]+:/, '')
       const parts = repoPath.split('/')
       if (parts.length !== 2 || !parts[0] || !parts[1]) {
         throw new Error(
-          `Invalid repository format for ${toolName}: expected 'github:owner/repo', got '${toolConfig.repository}'`,
+          `Invalid repository format for ${toolName}: expected '<host>:owner/repo', got '${toolConfig.repository}'`,
         )
       }
       const [owner, repo] = parts
@@ -534,7 +534,7 @@ export async function downloadExternalTools(platform, arch, isMusl = false) {
       // socket_basics orchestrates the security tools (trivy, trufflehog, opengrep).
       const socketBasicsConfig = externalTools['socket-basics']
       if (socketBasicsConfig && socketBasicsConfig.release === 'archive') {
-        const repoPath = socketBasicsConfig.repository.replace(/^github:/, '')
+        const repoPath = socketBasicsConfig.repository.replace(/^[^:]+:/, '')
         const releaseVersion = socketBasicsConfig.version
         const version = releaseVersion.replace(/^v/, '') // Remove 'v' prefix for version
 

--- a/packages/cli/scripts/sync-checksums.mjs
+++ b/packages/cli/scripts/sync-checksums.mjs
@@ -216,7 +216,7 @@ async function main() {
   let failed = 0
 
   for (const tool of githubTools) {
-    const repoPath = tool.repository.replace(/^github:/, '')
+    const repoPath = tool.repository.replace(/^[^:]+:/, '')
     const releaseTag = tool.tag ?? tool.version
     console.log(`[${tool.key}] ${repoPath} @ ${releaseTag}`)
 


### PR DESCRIPTION
Use win- instead of win32- for Windows platform keys. Add github: prefix to repository fields.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config/compatibility change that only affects how the hook resolves download URLs and platform lookups for Windows binaries.
> 
> **Overview**
> Normalizes the hook’s external tool metadata to use `github:`-prefixed `repository` values and changes Windows platform keys from `win32-x64` to `win-x64` in `external-tools.json`.
> 
> Updates the setup script (`index.mts`) to compute `platformKey` as `win-<arch>` on Windows so Zizmor and Socket Firewall downloads resolve the correct assets/checksums.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b239a7b5257aa9f0c285dd9beecda9cc1c29d3de. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->