### PR TITLE
upgrading coana to version 14.12.213

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.82](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.82) - 2026-04-13
+
+### Changed
+- Updated the Coana CLI to v `14.12.213`.
+
 ## [1.1.81](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.81) - 2026-04-10
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.81",
+  "version": "1.1.82",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -97,7 +97,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.211",
+    "@coana-tech/cli": "14.12.213",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.211
-        version: 14.12.211
+        specifier: 14.12.213
+        version: 14.12.213
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@14.12.211':
-    resolution: {integrity: sha512-TeJgG04ovQe3yZ07mzX69gZaGP9xCT4yzaojsURwrCBzAZXPQmTpzAwiRtmZ4h+KYdCHHb3fspTSUH8kGGLxhQ==}
+  '@coana-tech/cli@14.12.213':
+    resolution: {integrity: sha512-3AuSWS+6VZ+9mBDfUI/m67kuxdXMIvp9vmHMxDwwf/u0eH1M5dwE0gc5c5MH65AIpBtRSH0DmgK57cC6CirsEA==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5385,7 +5385,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@14.12.211': {}
+  '@coana-tech/cli@14.12.213': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 14.12.211 to 14.12.213

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump limited to a dev dependency and associated release metadata; behavior changes (if any) come from the upstream Coana CLI update.
> 
> **Overview**
> Bumps `@coana-tech/cli` from `14.12.211` to `14.12.213` and updates `pnpm-lock.yaml` accordingly.
> 
> Cuts a new patch release (`1.1.82`) and records the Coana CLI upgrade in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fafffc07d57218a792c105aa77eee877c71c34c3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->