### PR TITLE
fix: improve socket fix error messages for misplaced IDs and missing directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.83](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.83) - 2026-04-14
+
+### Fixed
+- `socket fix` now shows a clear error when a vulnerability ID (GHSA, CVE, or PURL) is passed as a positional argument instead of with `--id`, with a helpful "Did you mean" suggestion
+- `socket fix` now shows a clear error when the target directory does not exist, instead of a confusing API error about missing files
+
 ## [1.1.82](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.82) - 2026-04-13
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.82",
+  "version": "1.1.83",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",

--- a/src/commands/fix/cmd-fix.integration.test.mts
+++ b/src/commands/fix/cmd-fix.integration.test.mts
@@ -442,9 +442,7 @@ describe('socket fix', async () => {
     async cmd => {
       const { code, stderr, stdout } = await spawnSocketCli(binCliPath, cmd)
       const output = stdout + stderr
-      expect(output).toMatch(
-        /Unable to resolve|An error was thrown while requesting/,
-      )
+      expect(output).toMatch(/Target directory does not exist/)
       expect(code, 'should exit with non-zero code').not.toBe(0)
     },
   )
@@ -737,9 +735,7 @@ describe('socket fix', async () => {
       async cmd => {
         const { code, stderr, stdout } = await spawnSocketCli(binCliPath, cmd)
         const output = stdout + stderr
-        expect(output).toMatch(
-          /Unable to resolve|An error was thrown while requesting/,
-        )
+        expect(output).toMatch(/Target directory does not exist/)
         expect(code).toBeGreaterThan(0)
       },
     )

--- a/src/commands/fix/cmd-fix.mts
+++ b/src/commands/fix/cmd-fix.mts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import path from 'node:path'
 
 import terminalLink from 'terminal-link'
@@ -400,6 +401,34 @@ async function run(
     return
   }
 
+  // Check if a positional argument looks like a vulnerability ID (GHSA, CVE,
+  // or PURL) that was likely intended to be passed with --id.
+  const rawInput = cli.input[0]
+  if (
+    rawInput &&
+    (/^GHSA-/i.test(rawInput) ||
+      /^CVE-/i.test(rawInput) ||
+      rawInput.startsWith('pkg:'))
+  ) {
+    logger.fail(
+      `"${rawInput}" looks like a vulnerability identifier, not a directory path.\nDid you mean: socket fix ${FLAG_ID} ${rawInput}`,
+    )
+    process.exitCode = 1
+    return
+  }
+
+  let [cwd = '.'] = cli.input
+  // Note: path.resolve vs .join:
+  // If given path is absolute then cwd should not affect it.
+  cwd = path.resolve(process.cwd(), cwd)
+
+  // Validate the target directory exists.
+  if (!existsSync(cwd)) {
+    logger.fail(`Target directory does not exist: ${cwd}`)
+    process.exitCode = 1
+    return
+  }
+
   if (dryRun) {
     logger.log(constants.DRY_RUN_NOT_SAVING)
     return
@@ -415,11 +444,6 @@ async function run(
   }
 
   const orgSlug = orgSlugCResult.data
-
-  let [cwd = '.'] = cli.input
-  // Note: path.resolve vs .join:
-  // If given path is absolute then cwd should not affect it.
-  cwd = path.resolve(process.cwd(), cwd)
 
   const { spinner } = constants
 


### PR DESCRIPTION
## Summary
- Detect when a vulnerability ID (GHSA, CVE, or PURL) is passed as a positional argument to `socket fix` instead of with `--id`, and show a helpful "Did you mean" suggestion
- Validate the target directory exists before making API calls, showing a clear error instead of a confusing "Need at least one file to be uploaded" API error
- Bump version to 1.1.83

## Test plan
- [x] `./sd fix GHSA-xhpv-hc6g-r9c6` → shows "Did you mean: socket fix --id GHSA-xhpv-hc6g-r9c6"
- [x] `./sd fix CVE-2021-23337` → shows "Did you mean: socket fix --id CVE-2021-23337"
- [x] `./sd fix pkg:npm/lodash@4.17.20` → shows "Did you mean: socket fix --id pkg:npm/lodash@4.17.20"
- [x] `./sd fix /nonexistent/directory` → shows "Target directory does not exist: /nonexistent/directory"
- [x] Type check passes
- [x] Lint passes
- [x] Integration tests updated and passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because this PR replaces the package/build/CI tooling (new Rollup configs, new bins/exports, new lint/typecheck setup, and new GitHub workflows), which can easily affect distribution artifacts and publishing. It also changes `socket fix` argument validation/behavior, so regressions could block fix flows in CI and local usage.
> 
> **Overview**
> **Major toolchain + packaging overhaul.** Replaces the previous JS-based CLI packaging with a pnpm + Rollup-based build system (new `.config/rollup.*`, Babel/TS configs, `bin/*` entrypoints, updated `package.json` exports/files/engines, pnpm overrides/patches, and new formatter/linter configs like `eslint.config.js`, `biome.json`, `oxlint`).
> 
> **CI/CD changes.** Removes the old Dependabot + reusable workflows and adds explicit GitHub Actions workflows for lint/typecheck/test, E2E, and npm publishing with provenance and Socket firewall shims.
> 
> **User-facing `socket fix` improvements.** Adds early validation that rejects positional GHSA/CVE/PURL arguments with a “Did you mean: socket fix --id …” hint, and checks that the target directory exists before making API calls; updates tests and bumps version to `1.1.83` with corresponding changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f8d472bfb09640ee3faeef2c26fa0e83697592e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->