### PR TITLE
fix(build): improve asset download resilience against rate limits

### DIFF
--- a/packages/build-infra/lib/github-releases.mjs
+++ b/packages/build-infra/lib/github-releases.mjs
@@ -12,11 +12,11 @@ import { pRetry } from '@socketsecurity/lib/promises'
 
 const logger = getDefaultLogger()
 
-// Cache GitHub API responses for 1 hour to avoid rate limiting.
+// Cache GitHub API responses for 4 hours to reduce API calls and avoid rate limiting.
 const cache = createTtlCache({
   memoize: true,
   prefix: 'github-releases',
-  ttl: 60 * 60 * 1000, // 1 hour.
+  ttl: 4 * 60 * 60 * 1000, // 4 hours.
 })
 
 /**
@@ -155,8 +155,8 @@ export async function getLatestRelease(
         return null
       },
       {
-        backoffFactor: 1,
-        baseDelayMs: 5_000,
+        backoffFactor: 2,
+        baseDelayMs: 3_000,
         onRetry: (attempt, error) => {
           if (!quiet) {
             logger.info(
@@ -231,8 +231,8 @@ export async function getReleaseAssetUrl(
         return asset.browser_download_url
       },
       {
-        backoffFactor: 1,
-        baseDelayMs: 5_000,
+        backoffFactor: 2,
+        baseDelayMs: 3_000,
         onRetry: (attempt, error) => {
           if (!quiet) {
             logger.info(`  Retry attempt ${attempt + 1}/3 for asset URL...`)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@socketsecurity/cli",
-  "version": "0.0.0-copied-from-packages-socket",
+  "version": "0.0.0",
   "description": "CLI for Socket.dev",
   "private": true,
   "license": "MIT",

--- a/packages/cli/scripts/download-assets.mjs
+++ b/packages/cli/scripts/download-assets.mjs
@@ -231,6 +231,14 @@ async function downloadAssets(assetNames, parallel = true) {
  * Main entry point.
  */
 async function main() {
+  // Skip downloads entirely when SKIP_ASSET_DOWNLOAD is set.
+  // Useful for repeated local builds where assets are already cached,
+  // or when GitHub API rate limits are exhausted.
+  if (process.env.SKIP_ASSET_DOWNLOAD) {
+    logger.info('Skipping asset downloads (SKIP_ASSET_DOWNLOAD is set)')
+    return
+  }
+
   const args = process.argv.slice(2)
   const parallel = !args.includes('--no-parallel')
   const assetArgs = args.filter(arg => !arg.startsWith('--'))


### PR DESCRIPTION
## Summary

- Increase GitHub release cache TTL from 1h to 4h to reduce API calls during repeated builds
- Use exponential backoff (factor 2) instead of linear retries for GitHub API requests
- Add `SKIP_ASSET_DOWNLOAD` env var to skip downloads when assets are already cached locally

The `SKIP_ASSET_DOWNLOAD=1` toggle is useful when:
- Repeated local builds exhaust GitHub API rate limits
- Pre-commit hooks trigger rebuilds with cached assets
- Working offline with previously downloaded assets

## Test plan

- [x] Build succeeds with downloads
- [x] All tests pass
- [ ] Test `SKIP_ASSET_DOWNLOAD=1 pnpm build` uses cached assets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-infra behavior changes limited to caching/retry timings and an opt-in environment flag; main risk is stale release metadata for up to 4 hours or unintentionally skipping downloads when the env var is set.
> 
> **Overview**
> Build asset fetching now makes fewer GitHub API calls by increasing the releases cache TTL from **1 hour to 4 hours**.
> 
> GitHub API retries for release listing and asset URL lookup switch to **exponential backoff** (`backoffFactor: 2`, shorter base delay) to better handle rate limits.
> 
> The CLI asset downloader supports `SKIP_ASSET_DOWNLOAD` to **bypass all downloads** (useful for cached/offline builds).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5241c44cbee4b94a09c5ea9928d11f8a48712f72. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->