### PR TITLE
fix(ci): replace close/reopen hack with workflow_dispatch for bot PRs

### DIFF
--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -52,6 +52,7 @@ jobs:
     if: needs.check-updates.outputs.has-updates == 'true' && inputs.dry-run != true
     runs-on: ubuntu-latest
     permissions:
+      actions: write # Trigger CI workflow via workflow_dispatch
       contents: write # Push update branch
       pull-requests: write # Create PR
     steps:
@@ -73,7 +74,9 @@ jobs:
         run: |
           BRANCH_NAME="weekly-update-$(date +%Y%m%d)"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPO}.git"
-          git checkout -b "$BRANCH_NAME"
+          # Branch from HEAD~1 so the PR is behind main, making the
+          # "Update branch" button available to trigger enterprise checks.
+          git checkout -b "$BRANCH_NAME" HEAD~1
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
       - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
@@ -280,16 +283,42 @@ jobs:
             --head "$BRANCH_NAME" \
             --base main
 
+      # Pushes made with GITHUB_TOKEN don't trigger other workflows.
+      # Use workflow_dispatch to directly trigger CI on the PR branch.
+      - name: Trigger CI checks
+        if: steps.final.outputs.success == 'true' && steps.validate.outputs.valid == 'true' && steps.changes.outputs.has-changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH_NAME: ${{ steps.branch.outputs.branch }}
+        run: gh workflow run ci.yml --ref "$BRANCH_NAME"
+
       - name: Add job summary
         if: steps.final.outputs.success == 'true' && steps.validate.outputs.valid == 'true' && steps.changes.outputs.has-changes == 'true'
         env:
+          GH_TOKEN: ${{ github.token }}
           BRANCH_NAME: ${{ steps.branch.outputs.branch }}
         run: |
           COMMIT_COUNT=$(git rev-list --count origin/main..HEAD)
-          echo "## Weekly Update Complete" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** \`${BRANCH_NAME}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Commits:** ${COMMIT_COUNT}" >> $GITHUB_STEP_SUMMARY
+          pr_number=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number' || echo "")
+          pr_url="https://github.com/${{ github.repository }}/pull/${pr_number}"
+
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Weekly Update Complete
+
+          **PR:** [#${pr_number}](${pr_url})
+          **Branch:** \`${BRANCH_NAME}\`
+          **Commits:** ${COMMIT_COUNT}
+
+          > **Note:** Enterprise required workflows (e.g. Audit GHA Workflows) won't trigger
+          > automatically on bot PRs. Click **"Update branch"** on the PR to trigger them,
+          > or push an empty commit to the branch:
+          >
+          > \`\`\`sh
+          > git fetch origin ${BRANCH_NAME} && git checkout ${BRANCH_NAME}
+          > git commit --allow-empty -m "chore: trigger enterprise checks"
+          > git push origin ${BRANCH_NAME}
+          > \`\`\`
+          EOF
 
       - name: Upload Claude output
         if: always()


### PR DESCRIPTION
## Summary

- Add `actions: write` permission to trigger CI via `workflow_dispatch`
- Branch from `HEAD~1` so PR is behind main, enabling the "Update branch" button
- Add "Trigger CI checks" step using `gh workflow run ci.yml`
- Enhance job summary with PR link and enterprise workflow instructions

Ported from SocketDev/socket-sdk-js#592.

## Test plan

- [ ] Trigger the weekly-update workflow manually via `workflow_dispatch`
- [ ] Verify CI is triggered on the bot PR branch
- [ ] Verify the "Update branch" button appears on the created PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e337f8b1c8d5edff7f5c7259d0fb05d341f465f9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->