### PR TITLE
upgrading coana to version 14.12.218

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.84](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.84) - 2026-04-17
+
+### Changed
+- Updated the Coana CLI to v `14.12.218`.
+
 ## [1.1.83](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.83) - 2026-04-14
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.83",
+  "version": "1.1.84",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -97,7 +97,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.213",
+    "@coana-tech/cli": "14.12.218",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.213
-        version: 14.12.213
+        specifier: 14.12.218
+        version: 14.12.218
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@14.12.213':
-    resolution: {integrity: sha512-3AuSWS+6VZ+9mBDfUI/m67kuxdXMIvp9vmHMxDwwf/u0eH1M5dwE0gc5c5MH65AIpBtRSH0DmgK57cC6CirsEA==}
+  '@coana-tech/cli@14.12.218':
+    resolution: {integrity: sha512-9LIEYEt1j6kOTm8EPnofCLXhIqwn4D234NqeImhJdfVJjz6rSHR0tDdAO9Qw9Lhdo4o2vQLhJ4ZffuaST/f3+Q==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5385,7 +5385,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@14.12.213': {}
+  '@coana-tech/cli@14.12.218': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 14.12.213 to 14.12.218

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency/version bump with no application logic changes; main risk is any behavioral change introduced by the updated Coana CLI binary.
> 
> **Overview**
> Releases `1.1.84` and updates `@coana-tech/cli` from `14.12.213` to `14.12.218`, including the corresponding `pnpm-lock.yaml` refresh.
> 
> Updates `CHANGELOG.md` with the new release entry noting the Coana CLI upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63d20a7a110d31377e95ee3cd02edf66107ce044. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->