### PR TITLE
chore(tsconfig): explicit sourceMap and declarationMap: false

### DIFF
--- a/.claude/hooks/check-new-deps/tsconfig.json
+++ b/.claude/hooks/check-new-deps/tsconfig.json
@@ -1,13 +1,15 @@
 {
   "compilerOptions": {
-    "noEmit": true,
-    "target": "esnext",
+    "declarationMap": false,
+    "erasableSyntaxOnly": true,
     "module": "nodenext",
     "moduleResolution": "nodenext",
+    "noEmit": true,
     "rewriteRelativeImportExtensions": true,
-    "erasableSyntaxOnly": true,
-    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "sourceMap": false,
     "strict": true,
-    "skipLibCheck": true
+    "target": "esnext",
+    "verbatimModuleSyntax": true
   }
 }

--- a/.config/tsconfig.base.json
+++ b/.config/tsconfig.base.json
@@ -28,7 +28,7 @@
     "resolveJsonModule": true,
     "rewriteRelativeImportExtensions": true,
     "skipLibCheck": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "strict": true,
     "strictNullChecks": true,
     "target": "ES2024",

--- a/.config/tsconfig.build.json
+++ b/.config/tsconfig.build.json
@@ -1,9 +1,10 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
     "composite": true,
-    "incremental": true
+    "declaration": true,
+    "declarationMap": false,
+    "incremental": true,
+    "sourceMap": false
   }
 }

--- a/.config/tsconfig.check.json
+++ b/.config/tsconfig.check.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "declarationMap": false,
+    "sourceMap": false,
     "typeRoots": ["../node_modules/@types"]
   },
   "include": [

--- a/.config/tsconfig.external-aliases.json
+++ b/.config/tsconfig.external-aliases.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.check.json",
   "compilerOptions": {
+    "declarationMap": false,
     "paths": {
       "@socketsecurity/lib": ["../socket-lib/dist/index.d.ts"],
       "@socketsecurity/lib/*": ["../socket-lib/dist/*"],
@@ -8,6 +9,7 @@
         "../socket-registry/registry/dist/index.d.ts"
       ],
       "@socketsecurity/registry/*": ["../socket-registry/registry/dist/*"]
-    }
+    },
+    "sourceMap": false
   }
 }

--- a/.config/tsconfig.test.json
+++ b/.config/tsconfig.test.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "declarationMap": false,
     "noUnusedLocals": false,
-    "noUnusedParameters": false
+    "noUnusedParameters": false,
+    "sourceMap": false
   }
 }

--- a/packages/cli/.config/tsconfig.check.json
+++ b/packages/cli/.config/tsconfig.check.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "declarationMap": false,
+    "sourceMap": false,
     "typeRoots": ["../node_modules/@types"]
   },
   "include": ["../src/**/*.mts", "../*.config.mts", "./*.mts"],

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "extends": "../../.config/tsconfig.base.json",
+  "compilerOptions": {
+    "declarationMap": false,
+    "sourceMap": false
+  },
   "include": [
     "src/**/*.mts",
     "src/**/*.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "extends": "./.config/tsconfig.base.json",
+  "compilerOptions": {
+    "declarationMap": false,
+    "sourceMap": false
+  },
   "include": ["src/**/*.mts", "src/**/*.d.ts"],
   "exclude": [
     "src/**/*.test.mts",


### PR DESCRIPTION
Sets `sourceMap: false` and `declarationMap: false` explicitly on every `tsconfig.json` in the repo. Keys are fully alphanumerically sorted within each `compilerOptions` block.

We never want to ship sourcemaps or declaration maps. Making the flags explicit prevents accidental regression when someone edits a config and forgets to check inheritance.

## Files touched

- `.config/tsconfig.base.json` (was `sourceMap: true` → `false`)
- `.config/tsconfig.build.json` (was `declarationMap: true` → `false`; also adds `sourceMap: false`)
- `.config/tsconfig.check.json`
- `.config/tsconfig.external-aliases.json`
- `.config/tsconfig.test.json`
- `packages/cli/.config/tsconfig.check.json`
- `packages/cli/tsconfig.json`
- `tsconfig.json`
- `.claude/hooks/check-new-deps/tsconfig.json`

Split out from #1211 so the dep-hook cleanup there stays focused.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change affecting TypeScript build/check outputs; main risk is reduced debugging fidelity if any workflow relied on sourcemaps or declaration maps.
> 
> **Overview**
> Disables generation of TypeScript sourcemaps and declaration maps across the repo by explicitly setting `sourceMap: false` and `declarationMap: false` in all relevant `tsconfig` variants (base/build/check/test, root, CLI, and the `.claude` dependency hook).
> 
> Also normalizes `compilerOptions` ordering and updates inherited defaults (notably flipping `.config/tsconfig.base.json` `sourceMap` to `false`, and `.config/tsconfig.build.json` `declarationMap` to `false` while adding `sourceMap: false`) to prevent accidental re-enablement via config edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 625010cbf2d55532dc73971b47afce233e96786a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->