### PR TITLE
chore(templates): minify: false in package-builder esbuild configs

### DIFF
--- a/packages/package-builder/templates/cli-package/.config/esbuild.index.mts
+++ b/packages/package-builder/templates/cli-package/.config/esbuild.index.mts
@@ -18,7 +18,7 @@ const cliPath = path.resolve(__dirname, '../../cli')
 const config = createIndexConfig({
   entryPoint: path.join(cliPath, 'src', 'index.mts'),
   outfile: path.join(rootPath, 'dist', 'index.js'),
-  minify: true,
+  minify: false,
 })
 
 if (fileURLToPath(import.meta.url) === process.argv[1]) {

--- a/packages/package-builder/templates/cli-sentry-package/.config/esbuild.index.mts
+++ b/packages/package-builder/templates/cli-sentry-package/.config/esbuild.index.mts
@@ -18,7 +18,7 @@ const cliPath = path.resolve(__dirname, '../../cli')
 const config = createIndexConfig({
   entryPoint: path.join(cliPath, 'src', 'index.mts'),
   outfile: path.join(rootPath, 'dist', 'index.js'),
-  minify: true,
+  minify: false,
 })
 
 if (fileURLToPath(import.meta.url) === process.argv[1]) {


### PR DESCRIPTION
Flip `minify: true` → `minify: false` in both package-builder templates (`cli-package` and `cli-sentry-package`).

## Why

Repo-wide rule: shipped bundles never minify. Minification breaks ESM/CJS interop and makes debugging harder. The `esbuild-minify` validation scripts elsewhere in the org (socket-lib, socket-packageurl-js, socket-registry, socket-sdk-js) already enforce this for finished packages. The templates should default to the same so newly-scaffolded packages are compliant out of the box.

## Files

- `packages/package-builder/templates/cli-package/.config/esbuild.index.mts`
- `packages/package-builder/templates/cli-sentry-package/.config/esbuild.index.mts`

Paired with similar cleanup in [socket-cli#1213](https://github.com/SocketDev/socket-cli/pull/1213) (tsconfig sourcemaps).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template-only build output change; no runtime logic changes beyond producing unminified bundles.
> 
> **Overview**
> Newly scaffolded `cli-package` and `cli-sentry-package` templates now set `minify: false` in their `esbuild.index.mts` configs, disabling minification for the generated CLI entry bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fe51b3d6ecfe13b988a19da7dc9edb25a7c8351. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->