### PR TITLE
chore(build): drop minification from index bundler

### DIFF
--- a/packages/cli/scripts/esbuild-utils.mts
+++ b/packages/cli/scripts/esbuild-utils.mts
@@ -20,10 +20,9 @@ const logger = getDefaultLogger()
  * @param {Object} options - Configuration options
  * @param {string} options.entryPoint - Path to entry point file
  * @param {string} options.outfile - Path to output file
- * @param {boolean} [options.minify=false] - Whether to minify output
  * @returns {Object} esbuild configuration object
  */
-export function createIndexConfig({ entryPoint, minify = false, outfile }: { entryPoint: string; minify?: boolean; outfile: string }) {
+export function createIndexConfig({ entryPoint, outfile }: { entryPoint: string; outfile: string }) {
   // Get inlined environment variables for build-time constant replacement.
   const inlinedEnvVars = getInlinedEnvVars()
 
@@ -34,6 +33,7 @@ export function createIndexConfig({ entryPoint, minify = false, outfile }: { ent
     bundle: true,
     entryPoints: [entryPoint],
     format: 'cjs',
+    minify: false,
     outfile,
     platform: 'node',
     // Source maps off for entry point production build.
@@ -48,13 +48,6 @@ export function createIndexConfig({ entryPoint, minify = false, outfile }: { ent
     plugins: [envVarReplacementPlugin(inlinedEnvVars)],
     // Plugin needs to transform output.
     write: false,
-  }
-
-  if (minify) {
-    config.minify = true
-  } else {
-    config.minifyWhitespace = true
-    config.minifyIdentifiers = true
   }
 
   return config

--- a/packages/package-builder/templates/cli-package/.config/esbuild.index.mts
+++ b/packages/package-builder/templates/cli-package/.config/esbuild.index.mts
@@ -18,7 +18,6 @@ const cliPath = path.resolve(__dirname, '../../cli')
 const config = createIndexConfig({
   entryPoint: path.join(cliPath, 'src', 'index.mts'),
   outfile: path.join(rootPath, 'dist', 'index.js'),
-  minify: false,
 })
 
 if (fileURLToPath(import.meta.url) === process.argv[1]) {

--- a/packages/package-builder/templates/cli-sentry-package/.config/esbuild.index.mts
+++ b/packages/package-builder/templates/cli-sentry-package/.config/esbuild.index.mts
@@ -18,7 +18,6 @@ const cliPath = path.resolve(__dirname, '../../cli')
 const config = createIndexConfig({
   entryPoint: path.join(cliPath, 'src', 'index.mts'),
   outfile: path.join(rootPath, 'dist', 'index.js'),
-  minify: false,
 })
 
 if (fileURLToPath(import.meta.url) === process.argv[1]) {


### PR DESCRIPTION
## Summary
- Removes the partial-minify branch (minifyWhitespace/minifyIdentifiers) in `createIndexConfig` so the index loader output is straight, unminified JavaScript — matching the rest of the prod build.
- Adds an explicit `minify: false` to `createIndexConfig` so the "off" state is one obvious thing.
- Drops the now-redundant `minify: false` arg from the two package-builder template callers (the util enforces it).

## Why
One shape of output is easier to read, easier to grep when debugging, and eliminates a two-branched `minify` path that contributors had to reason about. We don't ship minified bundles anywhere, so there's no benefit to the partial version.

## Test plan
- [x] `pnpm run type` passes
- [x] `pnpm run build:cli` succeeds and produces unminified output
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build output formatting change only (minification toggling removed) with no runtime logic or security-sensitive behavior changes; main risk is unexpected bundle size/perf differences.
> 
> **Overview**
> The index-loader esbuild config (`createIndexConfig`) no longer accepts a `minify` option and now **always emits unminified output** via an explicit `minify: false`, removing the previous partial-minification branch.
> 
> The package-builder templates for `cli-package` and `cli-sentry-package` are updated to stop passing `minify: false`, relying on the utility’s enforced behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32710d62c6425fb92a1e7781c10718f3a13b8c57. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->