### PR TITLE
chore(build): bump esbuild target to node25

### DIFF
--- a/packages/cli/.config/esbuild.cli.mts
+++ b/packages/cli/.config/esbuild.cli.mts
@@ -14,7 +14,7 @@ import { IMPORT_META_URL_BANNER } from 'build-infra/lib/esbuild-helpers'
 import { unicodeTransformPlugin } from 'build-infra/lib/esbuild-plugin-unicode-transform'
 
 import {
-  createDefineEntries,
+  createBaseConfig,
   envVarReplacementPlugin,
   getInlinedEnvVars,
   runBuild,
@@ -58,33 +58,27 @@ function resolveSocketLibExternal(socketLibPath: string, packageName: string) {
 }
 
 
+const baseConfig = createBaseConfig(inlinedEnvVars)
+
 const config: BuildOptions = {
+  ...baseConfig,
+  banner: {
+    js: `#!/usr/bin/env node\n"use strict";\n${IMPORT_META_URL_BANNER.js}`,
+  },
+  define: {
+    ...baseConfig.define,
+    'import.meta.url': '__importMetaUrl',
+  },
   entryPoints: [path.join(rootPath, 'src/cli-dispatch.mts')],
-  bundle: true,
-  outfile: path.join(rootPath, 'build/cli.js'),
-  platform: 'node',
-  target: 'node25',
-  format: 'cjs',
+  keepNames: true,
+  // .cs files used by node-gyp on Windows.
+  loader: { '.cs': 'empty' },
   logOverride: {
     'commonjs-variable-in-esm': 'silent',
     'require-resolve-not-external': 'silent',
   },
-  // .cs files used by node-gyp on Windows.
-  loader: { '.cs': 'empty' },
-  sourcemap: false,
-  minify: false,
-  keepNames: true,
-  write: false,
   metafile: true,
-  define: {
-    'process.env.NODE_ENV': '"production"',
-    'import.meta.url': '__importMetaUrl',
-    ...createDefineEntries(inlinedEnvVars),
-  },
-  banner: {
-    js: `#!/usr/bin/env node\n"use strict";\n${IMPORT_META_URL_BANNER.js}`,
-  },
-
+  outfile: path.join(rootPath, 'build/cli.js'),
   plugins: [
     unicodeTransformPlugin(),
     // Environment variable replacement must run AFTER unicode transform.

--- a/packages/cli/.config/esbuild.cli.mts
+++ b/packages/cli/.config/esbuild.cli.mts
@@ -63,7 +63,7 @@ const config: BuildOptions = {
   bundle: true,
   outfile: path.join(rootPath, 'build/cli.js'),
   platform: 'node',
-  target: 'node18',
+  target: 'node25',
   format: 'cjs',
   logOverride: {
     'commonjs-variable-in-esm': 'silent',

--- a/packages/cli/scripts/esbuild-utils.mts
+++ b/packages/cli/scripts/esbuild-utils.mts
@@ -16,41 +16,55 @@ import { EnvironmentVariables } from './environment-variables.mts'
 const logger = getDefaultLogger()
 
 /**
- * Create a standard index loader config.
- * @param {Object} options - Configuration options
- * @param {string} options.entryPoint - Path to entry point file
- * @param {string} options.outfile - Path to output file
- * @returns {Object} esbuild configuration object
+ * Settings every Socket CLI esbuild config shares.
+ *
+ * Kept in one place so the target Node version, module format, minify
+ * default, etc. can't drift between the index loader and the main CLI
+ * bundle. Callers spread this and add variant-specific fields
+ * (entry points, output, banner, plugins, extra defines).
  */
-export function createIndexConfig({ entryPoint, outfile }: { entryPoint: string; outfile: string }) {
-  // Get inlined environment variables for build-time constant replacement.
-  const inlinedEnvVars = getInlinedEnvVars()
-
-  const config: BuildOptions = {
-    banner: {
-      js: '#!/usr/bin/env node',
-    },
+export function createBaseConfig(
+  inlinedEnvVars: Record<string, string>,
+): BuildOptions {
+  return {
     bundle: true,
-    entryPoints: [entryPoint],
-    format: 'cjs',
-    minify: false,
-    outfile,
-    platform: 'node',
-    // Source maps off for entry point production build.
-    sourcemap: false,
-    target: 'node25',
-    // Define environment variables for inlining.
     define: {
       'process.env.NODE_ENV': '"production"',
       ...createDefineEntries(inlinedEnvVars),
     },
-    // Add plugin for post-bundle env var replacement.
-    plugins: [envVarReplacementPlugin(inlinedEnvVars)],
-    // Plugin needs to transform output.
+    format: 'cjs',
+    minify: false,
+    platform: 'node',
+    // We don't ship minified bundles and we don't ship sourcemaps for prod.
+    sourcemap: false,
+    target: 'node25',
+    // Plugin writes are handled by `runBuild` so every caller's env-var
+    // replacement can mutate output buffers before they hit disk.
     write: false,
   }
+}
 
-  return config
+/**
+ * Create a standard index loader config.
+ */
+export function createIndexConfig({
+  entryPoint,
+  outfile,
+}: {
+  entryPoint: string
+  outfile: string
+}): BuildOptions {
+  const inlinedEnvVars = getInlinedEnvVars()
+
+  return {
+    ...createBaseConfig(inlinedEnvVars),
+    banner: {
+      js: '#!/usr/bin/env node',
+    },
+    entryPoints: [entryPoint],
+    outfile,
+    plugins: [envVarReplacementPlugin(inlinedEnvVars)],
+  }
 }
 
 /**

--- a/packages/cli/scripts/esbuild-utils.mts
+++ b/packages/cli/scripts/esbuild-utils.mts
@@ -38,7 +38,7 @@ export function createIndexConfig({ entryPoint, outfile }: { entryPoint: string;
     platform: 'node',
     // Source maps off for entry point production build.
     sourcemap: false,
-    target: 'node18',
+    target: 'node25',
     // Define environment variables for inlining.
     define: {
       'process.env.NODE_ENV': '"production"',


### PR DESCRIPTION
## Summary
- Bumps the `target` in the CLI and shared index bundlers from `'node18'` to `'node25'` to match what we actually ship and run (`.node-version` = 25.9.0).

## Why
The prior `'node18'` target meant esbuild was still lowering modern syntax that's been native for years. Matching the runtime we target removes unnecessary transforms and keeps the bundle honest about the runtime floor.

## Test plan
- [x] `pnpm run type` green
- [x] `pnpm run build:cli` succeeds
- [x] Confirmed esbuild 0.25.11 accepts `node25` as a target
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build output will now assume Node 25 features; if any environments still run the generated CLI on older Node versions, bundles may fail at runtime. The change also centralizes shared esbuild options, so misconfiguration could affect both the CLI bundle and index loader builds.
> 
> **Overview**
> Updates the Socket CLI esbuild setup to target `node25` and centralizes shared bundler settings in a new `createBaseConfig()` helper.
> 
> `esbuild.cli.mts` and `createIndexConfig()` now spread this base config (shared `define`, CJS format, no sourcemaps/minify, `write: false`), reducing drift between bundles while keeping CLI-specific banner/defines/plugins on top.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbc0a47bf86c1f31de06c508c76b9913afd9f60d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->