### PR TITLE
chore(build): hash inputs in smart-build cache check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 # Build outputs and artifacts
 # ============================================================================
 **/.build-checkpoints
+**/*.build-signature
 **/.cache/
 /.rollup.cache
 **/.type-coverage/

--- a/scripts/build.mts
+++ b/scripts/build.mts
@@ -18,10 +18,13 @@
  *   pnpm run build --help                    # Show this help
  */
 
-import { existsSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
+
+import fg from 'fast-glob'
 
 import colors from 'yoctocolors-cjs'
 
@@ -54,6 +57,12 @@ interface BuildPackageConfig {
   name: string
   filter: string
   outputCheck: string
+  /**
+   * Glob patterns (repo-relative) whose file contents contribute to the build
+   * signature. A change to any matching file invalidates the cache and forces
+   * a rebuild.
+   */
+  inputs: string[]
 }
 
 interface BuildResult {
@@ -87,8 +96,62 @@ const BUILD_PACKAGES: BuildPackageConfig[] = [
     name: 'CLI Package',
     filter: '@socketsecurity/cli',
     outputCheck: 'packages/cli/dist/index.js',
+    inputs: [
+      'packages/cli/.config/**/*.{mts,ts,json}',
+      'packages/cli/scripts/**/*.{mts,ts}',
+      'packages/cli/src/**/*.{mts,ts,cts,json}',
+      'packages/cli/package.json',
+      'packages/cli/tsconfig.json',
+      'packages/build-infra/lib/**/*.{mts,ts}',
+      'packages/build-infra/package.json',
+      'pnpm-lock.yaml',
+      '.node-version',
+    ],
   },
 ]
+
+/**
+ * Compute a SHA-256 signature over the contents of files matched by the
+ * package's input globs. Files are sorted to keep the hash deterministic.
+ */
+function computeBuildSignature(pkg: BuildPackageConfig): string {
+  const files = fg.sync(pkg.inputs, {
+    cwd: rootDir,
+    onlyFiles: true,
+    dot: true,
+    absolute: true,
+  })
+  files.sort()
+
+  const hash = createHash('sha256')
+  for (const file of files) {
+    const relative = path.relative(rootDir, file)
+    hash.update(relative)
+    hash.update('\0')
+    hash.update(readFileSync(file))
+    hash.update('\0')
+  }
+  return hash.digest('hex')
+}
+
+/**
+ * Path to the sidecar signature file written alongside the build output.
+ */
+function signaturePath(pkg: BuildPackageConfig): string {
+  return path.join(rootDir, `${pkg.outputCheck}.build-signature`)
+}
+
+function readSignature(pkg: BuildPackageConfig): string | null {
+  const file = signaturePath(pkg)
+  if (!existsSync(file)) {
+    return null
+  }
+  return readFileSync(file, 'utf8').trim()
+}
+
+function writeSignature(pkg: BuildPackageConfig, signature: string): void {
+  writeFileSync(signaturePath(pkg), `${signature}\n`, 'utf8')
+}
 
 /**
  * Parse command line arguments.
@@ -210,6 +273,12 @@ function showHelp(): void {
 /**
  * Check if a package needs to be built.
  * Returns true if build is needed, false if can skip.
+ *
+ * Rebuild triggers:
+ *   1. --force
+ *   2. Missing build output
+ *   3. Missing signature sidecar
+ *   4. Current input signature differs from the recorded one
  */
 function needsBuild(pkg: BuildPackageConfig, force: boolean): boolean {
   if (force) {
@@ -221,8 +290,12 @@ function needsBuild(pkg: BuildPackageConfig, force: boolean): boolean {
     return true
   }
 
-  // Output exists, can skip.
-  return false
+  const stored = readSignature(pkg)
+  if (!stored) {
+    return true
+  }
+
+  return computeBuildSignature(pkg) !== stored
 }
 
 /**
@@ -263,6 +336,15 @@ async function buildPackage(
   logger.log(
     `${colors.green('✓')} ${pkg.name}: ${colors.green('built')} (${duration}s)`,
   )
+
+  try {
+    writeSignature(pkg, computeBuildSignature(pkg))
+  } catch (e) {
+    logger.warn(
+      `Could not write build signature for ${pkg.name}: ${e instanceof Error ? e.message : String(e)}`,
+    )
+  }
+
   return { success: true, skipped: false }
 }
 


### PR DESCRIPTION
## Why this exists

Today's smart-build cache check is *output-only*: if `packages/cli/dist/index.js` exists, it skips. That's fine for "the dist is there" but it misses every other reason a rebuild is needed.

**The pain point I hit:** bumping `target: 'node18'` → `'node25'` in `packages/cli/.config/esbuild.cli.mts`, running `pnpm build`, seeing "CLI Package: skipped (up to date)", getting confused, `--force`-ing, and realizing the smart build had silently served stale output for a config change. That's a junior-dev-hostile trap — you change the bundler's behavior, the tool says "up to date", and you have to know to distrust it.

Other things that fall into the same bucket:
- `pnpm-lock.yaml` changed (dependency bump) → old bundle, stale deps.
- `packages/build-infra/lib/**` changed (shared build helpers) → stale bundle.
- `.node-version` bumped → stale bundle targeting the old runtime floor.

## What this changes

`needsBuild()` now also rebuilds when the *inputs* change, not just when the output is missing.

**How it works:**
1. Each package entry declares a list of input globs (config, scripts, source, lockfile, `.node-version`).
2. On every build attempt, we SHA-256 the (sorted) file paths + contents into a single \"build signature\".
3. After a successful build, we write that signature next to the output as `dist/index.js.build-signature` (gitignored).
4. Next smart build re-hashes inputs; if the hash differs from the stored one, we rebuild.

**Why content hashing instead of mtime:**
- `git checkout`, `rebase`, branch switching all rewrite mtimes even when content is identical. mtime-based checks thrash on every branch switch.
- Content hash gives us \"the inputs are *semantically* the same\" → maximum cache hits, zero stale hits.

`--force` still bypasses everything.

Inputs currently tracked for the CLI:
- `packages/cli/.config/**/*.{mts,ts,json}`
- `packages/cli/scripts/**/*.{mts,ts}`
- `packages/cli/src/**/*.{mts,ts,cts,json}`
- `packages/cli/package.json`, `tsconfig.json`
- `packages/build-infra/lib/**/*.{mts,ts}`, `package.json`
- `pnpm-lock.yaml`
- `.node-version`

## Test plan
- [x] Fresh \`pnpm run build\` builds and writes \`*.build-signature\`
- [x] Second \`pnpm run build\` with no changes → skipped
- [x] Adding a comment to \`.config/esbuild.cli.mts\` → rebuilds
- [x] Reverting that change → rebuilds back (signature changed)
- [x] \`--force\` still always builds
- [x] Signature sidecar gitignored
- [ ] CI green