### PR TITLE
docs: link docs/ from README and fix stale command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ Key variables for development:
 | `SOCKET_CLI_API_BASE_URL` | Override API endpoint |
 | `SOCKET_CLI_NO_API_TOKEN` | Disable default API token |
 
+## Further Reading
+
+- [`docs/build-guide.md`](docs/build-guide.md) — build pipeline, SEA binaries, cache management
+- [`docs/bundle-tools.md`](docs/bundle-tools.md) — how bundled tools (opengrep, trivy, etc.) are integrated
+- [`packages/cli/README.md`](packages/cli/README.md) — CLI package architecture
+- [`packages/build-infra/README.md`](packages/build-infra/README.md) — shared build tooling
+- [`packages/package-builder/README.md`](packages/package-builder/README.md) — template-based package generation
+
 ## See Also
 
 - [Socket API Reference](https://docs.socket.dev/reference)

--- a/docs/build-guide.md
+++ b/docs/build-guide.md
@@ -252,13 +252,13 @@ Assets are downloaded from [socket-btm](https://github.com/SocketDev/socket-btm)
 
 ```bash
 # Clear download cache
-pnpm run clean-cache
+pnpm run clean:cache
 
 # Clear CLI build cache
 pnpm --filter @socketsecurity/cli run clean
 
 # Clear all caches
-pnpm clean
+pnpm run clean
 ```
 
 ### Environment Variables


### PR DESCRIPTION
## Summary
- README now has a "Further Reading" section pointing at `docs/build-guide.md`, `docs/bundle-tools.md`, and each package's README so a new contributor can find the deeper docs from the landing page.
- Fixes a stale script name in `docs/build-guide.md` — `pnpm run clean-cache` → `pnpm run clean:cache` (the actual `package.json` script uses a colon). Same block: `pnpm clean` → `pnpm run clean`.

## Test plan
- [x] Links in the new README section resolve
- [x] `pnpm run clean:cache` exists in root package.json
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no runtime behavior, build logic, or shipped artifacts are modified.
> 
> **Overview**
> Adds a **Further Reading** section to the root `README.md`, linking to key internal docs (`docs/*`) and package-level READMEs to make contributor documentation easier to discover.
> 
> Updates `docs/build-guide.md` to fix stale cache/clean command examples (`clean-cache` → `clean:cache`, and `pnpm clean` → `pnpm run clean`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6659017737a0fcd9b8015fd69e56e7e7b428f3d9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->