### PR TITLE
chore(tools): add checksum for socket-basics archive

### DIFF
--- a/packages/cli/bundle-tools.json
+++ b/packages/cli/bundle-tools.json
@@ -47,7 +47,10 @@
     "repository": "github:SocketDev/socket-basics",
     "release": "archive",
     "version": "v2.0.2",
-    "packageManager": "pip"
+    "packageManager": "pip",
+    "checksums": {
+      "socket-basics-v2.0.2.tar.gz": "ba175171f07ac927eb926387e526283320630e80da42da000ec6894a55adeb13"
+    }
   },
   "socketsecurity": {
     "description": "Socket Python CLI (socket-python-cli)",

--- a/packages/cli/scripts/sea-build-utils/downloads.mts
+++ b/packages/cli/scripts/sea-build-utils/downloads.mts
@@ -538,6 +538,17 @@ export async function downloadExternalTools(platform, arch, isMusl = false) {
         const releaseVersion = socketBasicsConfig.version
         const version = releaseVersion.replace(/^v/, '') // Remove 'v' prefix for version
 
+        // Checksum key matches the local filename convention used for
+        // archive-style releases (`socket-basics-v<ver>.tar.gz`).
+        const archiveKey = `socket-basics-${releaseVersion}.tar.gz`
+        const archiveSha256 = socketBasicsConfig.checksums?.[archiveKey]
+        if (!archiveSha256) {
+          throw new Error(
+            `Missing SHA-256 checksum for socket-basics archive: ${archiveKey}. ` +
+              'Please update bundle-tools.json with the correct checksum.',
+          )
+        }
+
         logger.log(`  Installing socket_basics ${version} from GitHub...`)
 
         // Download source tarball from GitHub.
@@ -551,6 +562,7 @@ export async function downloadExternalTools(platform, arch, isMusl = false) {
           progressInterval: 10,
           retries: 2,
           retryDelay: 5_000,
+          sha256: archiveSha256,
         })
 
         // Install from tarball using pip (handles building and dependencies).


### PR DESCRIPTION
## Summary
Adds a SHA-256 checksum for the `socket-basics` source archive in `bundle-tools.json` and wires it through the downloader so it gets verified like every other bundled tool.

## Before
`socket-basics` was the one entry in `bundle-tools.json` without a `checksums` block, so its download went unverified while the other tools (opengrep, trivy, trufflehog, sfw, python, etc.) all had per-asset SHA-256 entries enforced.

## After
- `bundle-tools.json` now has:
  ```json
  "checksums": {
    "socket-basics-v2.0.2.tar.gz": "ba17...eb13"
  }
  ```
- `downloads.mts` passes `sha256: archiveSha256` into the same `httpDownload(...)` helper the rest of the tools use, and throws if the checksum entry is missing (matching the existing pattern at lines 327–345 / 472–508).

## Notes
- The checksum key uses the tag-qualified filename (`socket-basics-v<ver>.tar.gz`) to stay consistent with the asset-keyed checksums elsewhere in the file and the local-path convention used in `downloads.mts`.
- Future version bumps can be handled by the `/sync-checksums` skill that already exists for the other tools.

## Test plan
- [x] `pnpm run type` green
- [x] `node scripts/validate-checksums.mts` green
- [x] `pnpm run build:cli` succeeds
- [ ] CI green (exercises the SEA build path which actually fetches the archive)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, scoped change that only tightens download verification for a bundled tool; primary risk is build failures if the checksum key/name is incorrect.
> 
> **Overview**
> Adds a `checksums` entry for the `socket-basics` GitHub source tarball in `bundle-tools.json`.
> 
> Updates SEA build tooling to **require** that checksum and pass it to `httpDownload` when fetching the `socket-basics` archive; the build now fails fast with a clear error if the checksum is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4844e90ac39bdb553b9129cb4e3c6b2b894e99e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->