### PR TITLE
docs(claude): clarify .claude/ markdown exception

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,9 @@ If user repeats instruction 2+ times, ask: "Should I add this to CLAUDE.md?"
 
 ### Documentation Policy
 
-Do NOT litter the repository with documentation files. Allowed locations: `docs/`, root `README.md`/`CHANGELOG.md`/`SECURITY.md`/`CLAUDE.md`, `packages/*/README.md`, `test/fixtures/*/README.md`, `test/*/README.md`. No `.claude/*.md` analysis docs, no ad-hoc markdown files.
+Do NOT litter the repository with documentation files. Allowed locations: `docs/`, root `README.md`/`CHANGELOG.md`/`SECURITY.md`/`CLAUDE.md`, `packages/*/README.md`, `test/fixtures/*/README.md`, `test/*/README.md`. No ad-hoc markdown files.
+
+**`.claude/` exception**: markdown files under `.claude/agents/`, `.claude/commands/`, `.claude/hooks/`, and `.claude/skills/` are allowed because the Claude harness reads them as configuration (agent definitions, command metadata, `SKILL.md` entrypoints, skill references). These are config, not analysis docs. Ad-hoc analysis/session notes in `.claude/` are still disallowed.
 
 ---
 


### PR DESCRIPTION
## Summary
Small policy fix to CLAUDE.md.

The old "Documentation Policy" text read as if every `.md` file under `.claude/` was forbidden, but the Claude harness actually reads a bunch of them as config (agent definitions, command metadata, `SKILL.md` entrypoints, skill references). Those have been checked in all along, and we want them to be — so the stated policy and the checked-in files disagreed.

This PR rewrites the section so the rule matches reality:
- harness-config markdown under `.claude/agents`, `.claude/commands`, `.claude/hooks`, `.claude/skills` is allowed
- ad-hoc analysis/session notes dropped into `.claude/` are still disallowed, same as before
- the rest of the repo rule (no litter, allowed locations) is unchanged

Pure doc change; no code touched.

## Test plan
- [x] `grep` of .claude/*.md files matches the carve-out described in the new text
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime/code impact; risk is limited to potential policy interpretation changes.
> 
> **Overview**
> Updates `CLAUDE.md`’s *Documentation Policy* to explicitly allow markdown files under `.claude/agents/`, `.claude/commands/`, `.claude/hooks/`, and `.claude/skills/` as Claude harness configuration, while continuing to forbid ad-hoc analysis/session notes in `.claude/` and keeping the rest of the “no doc sprawl” rule unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 276a40c578735f167069a160269eee8c9c45b00b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->