### PR TITLE
fix(api): include request path in API error messages

### DIFF
--- a/packages/cli/src/utils/socket/api.mts
+++ b/packages/cli/src/utils/socket/api.mts
@@ -456,7 +456,7 @@ export async function queryApiSafeText(
     return {
       ok: false,
       message,
-      cause: networkDiagnostics,
+      cause: `${networkDiagnostics} (path: ${path})`,
     }
   }
 
@@ -497,7 +497,7 @@ export async function queryApiSafeText(
     return {
       ok: false,
       message: 'API request failed',
-      cause: 'Unexpected error reading response text',
+      cause: `Unexpected error reading response text (path: ${path})`,
     }
   }
 }
@@ -634,7 +634,7 @@ export async function sendApiRequest<T>(
     return {
       ok: false,
       message,
-      cause: networkDiagnostics,
+      cause: `${networkDiagnostics} (path: ${path})`,
     }
   }
 
@@ -677,7 +677,7 @@ export async function sendApiRequest<T>(
     return {
       ok: false,
       message: 'API request failed',
-      cause: 'Unexpected error parsing response JSON',
+      cause: `Unexpected error parsing response JSON (path: ${path})`,
     }
   }
 }

--- a/packages/cli/test/unit/utils/socket/api.test.mts
+++ b/packages/cli/test/unit/utils/socket/api.test.mts
@@ -466,6 +466,9 @@ describe('api utilities', () => {
       expect(result.ok).toBe(false)
       if (!result.ok) {
         expect(result.message).toContain('failed')
+        // The cause must include the request path so the user can tell
+        // which endpoint failed when several calls are in flight.
+        expect(result.cause).toContain('(path: test/path)')
       }
       expect(mockFailAndStop).toHaveBeenCalled()
     })
@@ -490,6 +493,7 @@ describe('api utilities', () => {
       expect(result.ok).toBe(false)
       if (!result.ok) {
         expect(result.cause).toContain('response text')
+        expect(result.cause).toContain('(path: test/path)')
       }
     })
   })
@@ -625,6 +629,8 @@ describe('api utilities', () => {
       expect(result.ok).toBe(false)
       if (!result.ok) {
         expect(result.message).toContain('failed')
+        // Request path must be surfaced in error cause for debuggability.
+        expect(result.cause).toContain('(path: test/path)')
       }
     })
 
@@ -639,6 +645,7 @@ describe('api utilities', () => {
       expect(result.ok).toBe(false)
       if (!result.ok) {
         expect(result.cause).toContain('parsing')
+        expect(result.cause).toContain('(path: test/path)')
       }
     })
 


### PR DESCRIPTION
## Summary
Port of the remaining behavior from v1.x #1094 to main.

Main already surfaces the endpoint in many error paths (via \`(endpoint: \${description})\` in \`handleApiCall\` / \`handleApiCallNoSpinner\`, and \`(path: \${path})\` on non-ok responses). This PR closes the remaining gaps where an error could be returned without any endpoint context, making it hard to tell which request failed when multiple are in flight.

### What changed
Appends \`(path: \${path})\` to four error \`cause\` strings in \`packages/cli/src/utils/socket/api.mts\`:
- \`queryApiSafeText\` catch block (network error)
- \`queryApiSafeText\` response-text-read catch
- \`sendApiRequest\` catch block (network error)
- \`sendApiRequest\` JSON-parse catch

### Why this matters
v1.x changelog (#1094): *"This lacks the request URL, making it difficult to debug which endpoint failed — especially when multiple API calls are involved in a single command."*

## Test plan
- [x] \`pnpm run type\` clean
- [x] \`pnpm run build:cli\` succeeds
- [x] Pre-commit hooks (lint + build + tests) pass
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: string-only changes to error `cause` fields plus unit test assertions; no API behavior or request logic changes beyond more descriptive errors.
> 
> **Overview**
> **Improves CLI API debuggability** by always including the request `path` in returned error `cause` messages for `queryApiSafeText` and `sendApiRequest`, covering network failures and response read/JSON parse exceptions.
> 
> Updates unit tests to assert `cause` includes `(path: …)` in these error scenarios so multiple in-flight requests can be distinguished.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 933877dd2c58cf9311358320e18c43fb25323b7e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->