### PR TITLE
fix(scan): respect projectIgnorePaths from socket.yml

### DIFF
--- a/packages/cli/src/commands/fix/coana-fix.mts
+++ b/packages/cli/src/commands/fix/coana-fix.mts
@@ -29,6 +29,7 @@ import {
 import { FLAG_DRY_RUN } from '../../constants/cli.mts'
 import { GQL_PR_STATE_OPEN } from '../../constants/github.mts'
 import { DOT_SOCKET_DOT_FACTS_JSON } from '../../constants/paths.mts'
+import { findSocketYmlSync } from '../../utils/config.mts'
 import { spawnCoanaDlx } from '../../utils/dlx/spawn.mjs'
 import { getErrorCause } from '../../utils/error/errors.mjs'
 import { getPackageFilesForScan } from '../../utils/fs/path-resolve.mjs'
@@ -121,7 +122,15 @@ export async function coanaFix(
   }
 
   const supportedFiles = supportedFilesCResult.data
+
+  // Load socket.yml so projectIgnorePaths is respected when collecting files.
+  const socketYmlResult = findSocketYmlSync(cwd)
+  const socketConfig = socketYmlResult.ok
+    ? socketYmlResult.data?.parsed
+    : undefined
+
   const scanFilepaths = await getPackageFilesForScan(['.'], supportedFiles, {
+    config: socketConfig,
     cwd,
   })
 

--- a/packages/cli/src/commands/scan/handle-create-new-scan.mts
+++ b/packages/cli/src/commands/scan/handle-create-new-scan.mts
@@ -31,6 +31,7 @@ import { runSocketBasics } from '../../utils/basics/spawn.mts'
 function excludeFactsJson(paths: string[]): string[] {
   return paths.filter(p => path.basename(p) !== DOT_SOCKET_DOT_FACTS_JSON)
 }
+import { findSocketYmlSync } from '../../utils/config.mts'
 import { getPackageFilesForScan } from '../../utils/fs/path-resolve.mts'
 import { readOrDefaultSocketJson } from '../../utils/socket/json.mts'
 import { socketDocsLink } from '../../utils/terminal/link.mts'
@@ -149,7 +150,15 @@ export async function handleCreateNewScan({
   spinner.start('Searching for local files to include in scan...')
 
   const supportedFiles = supportedFilesCResult.data
+
+  // Load socket.yml so projectIgnorePaths is respected when collecting files.
+  const socketYmlResult = findSocketYmlSync(cwd)
+  const socketConfig = socketYmlResult.ok
+    ? socketYmlResult.data?.parsed
+    : undefined
+
   const packagePaths = await getPackageFilesForScan(targets, supportedFiles, {
+    config: socketConfig,
     cwd,
   })
 

--- a/packages/cli/src/commands/scan/handle-scan-reach.mts
+++ b/packages/cli/src/commands/scan/handle-scan-reach.mts
@@ -7,6 +7,7 @@ const logger = getDefaultLogger()
 import { fetchSupportedScanFileNames } from './fetch-supported-scan-file-names.mts'
 import { outputScanReach } from './output-scan-reach.mts'
 import { performReachabilityAnalysis } from './perform-reachability-analysis.mts'
+import { findSocketYmlSync } from '../../utils/config.mts'
 import { getPackageFilesForScan } from '../../utils/fs/path-resolve.mts'
 import { checkCommandInput } from '../../utils/validation/check-input.mts'
 
@@ -49,7 +50,15 @@ export async function handleScanReach({
   )
 
   const supportedFiles = supportedFilesCResult.data
+
+  // Load socket.yml so projectIgnorePaths is respected when collecting files.
+  const socketYmlResult = findSocketYmlSync(cwd)
+  const socketConfig = socketYmlResult.ok
+    ? socketYmlResult.data?.parsed
+    : undefined
+
   const packagePaths = await getPackageFilesForScan(targets, supportedFiles, {
+    config: socketConfig,
     cwd,
   })
 

--- a/packages/cli/test/unit/commands/fix/handle-fix-limit.test.mts
+++ b/packages/cli/test/unit/commands/fix/handle-fix-limit.test.mts
@@ -113,6 +113,8 @@ vi.mock('../../../../src/commands/fix/pr-lifecycle-logger.mts', () => ({
 
 vi.mock('@socketsecurity/lib/fs', () => ({
   readJsonSync: mockReadJsonSync,
+  // Return undefined so findSocketYmlSync treats socket.yml as absent.
+  safeReadFileSync: vi.fn(() => undefined),
 }))
 
 vi.mock('node:fs', () => ({


### PR DESCRIPTION
## Summary
Port of v1.x #1137 to main. \`socket scan create\`, \`socket scan reach\`, and \`socket fix\` (the coana path) now honor the \`projectIgnorePaths\` list from \`socket.yml\` when collecting files — previously they ignored it even though the surrounding code expected to receive it.

## What was going on
Main already has a \`config\` option plumbed through \`getPackageFilesForScan\` → \`globWithGitIgnore\`, which respects \`projectIgnorePaths\` when given the parsed socket.yml. The three call sites above just weren't loading socket.yml to feed it in.

## Changes
- \`handle-create-new-scan.mts\`: load socket.yml via \`findSocketYmlSync\`, pass parsed config to \`getPackageFilesForScan\`.
- \`handle-scan-reach.mts\`: same.
- \`coana-fix.mts\`: same.
- \`test/unit/commands/fix/handle-fix-limit.test.mts\`: the \`@socketsecurity/lib/fs\` mock now also returns \`safeReadFileSync\` (used by \`findSocketYmlSync\`); returns \`undefined\` so the test treats socket.yml as absent, preserving existing behavior assertions.

## Test plan
- [x] \`pnpm run type\` clean
- [x] \`pnpm --filter @socketsecurity/cli run test:unit\` — all 343 test files pass
- [x] \`pnpm run build:cli\` succeeds
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which manifest files are discovered and uploaded for `scan`/`reach`/`fix` by applying `socket.yml` ignore rules; risk is mainly unintended exclusion/inclusion of files that affects scan and fix results.
> 
> **Overview**
> Ensures `socket scan create`, `socket scan reach`, and the `coanaFix` path in `socket fix` **honor `projectIgnorePaths` from `socket.yml`** when collecting local manifest files by loading `socket.yml` via `findSocketYmlSync` and passing the parsed config into `getPackageFilesForScan`.
> 
> Updates the `socket fix --limit` unit test mocks to include `safeReadFileSync` (used by `findSocketYmlSync`) so tests continue to treat `socket.yml` as absent unless explicitly provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9adde73ce72cf3de14bc32af6459680bbee0895. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->