### PR TITLE
fix(api): distinguish 401 (auth failure) from 403 (permissions)

### DIFF
--- a/packages/cli/src/commands/scan/perform-reachability-analysis.mts
+++ b/packages/cli/src/commands/scan/perform-reachability-analysis.mts
@@ -2,6 +2,7 @@ import path from 'node:path'
 
 import { getDefaultLogger } from '@socketsecurity/lib/logger'
 
+import { HTTP_STATUS_UNAUTHORIZED } from '../../constants/http.mts'
 import { DOT_SOCKET_DOT_FACTS_JSON } from '../../constants/paths.mts'
 import {
   SOCKET_DEFAULT_BRANCH,
@@ -81,6 +82,15 @@ export async function performReachabilityAnalysis(
   // Check if user has enterprise plan for reachability analysis.
   const orgsCResult = await fetchOrganization()
   if (!orgsCResult.ok) {
+    const httpCode = (orgsCResult as { data?: { code?: number } }).data?.code
+    if (httpCode === HTTP_STATUS_UNAUTHORIZED) {
+      return {
+        ok: false,
+        message: 'Authentication failed',
+        cause:
+          'Your API token appears to be invalid, expired, or revoked. Please check your token and try again.',
+      }
+    }
     return {
       ok: false,
       message: 'Unable to verify plan permissions',

--- a/packages/cli/src/utils/socket/api.mts
+++ b/packages/cli/src/utils/socket/api.mts
@@ -163,7 +163,16 @@ export async function getErrorMessageForHttpStatusCode(code: number) {
       '💡 Try: Check your command syntax and parameter values.'
     )
   }
-  if (code === HTTP_STATUS_FORBIDDEN || code === HTTP_STATUS_UNAUTHORIZED) {
+  if (code === HTTP_STATUS_UNAUTHORIZED) {
+    return (
+      '❌ Authentication failed: Your Socket API token appears to be invalid, expired, or revoked.\n' +
+      '💡 Try:\n' +
+      '  • Run `socket whoami` to verify your current token\n' +
+      '  • Run `socket login` to re-authenticate\n' +
+      `  • Manage tokens at ${SOCKET_SETTINGS_API_TOKENS_URL}`
+    )
+  }
+  if (code === HTTP_STATUS_FORBIDDEN) {
     return (
       '❌ Access denied: Your API token lacks required permissions or organization access.\n' +
       '💡 Try:\n' +

--- a/packages/cli/test/unit/utils/socket/api.test.mts
+++ b/packages/cli/test/unit/utils/socket/api.test.mts
@@ -173,7 +173,10 @@ describe('api utilities', () => {
 
     it('returns message for 401 Unauthorized', async () => {
       const result = await getErrorMessageForHttpStatusCode(401)
-      expect(result).toContain('permissions')
+      // 401 is now distinct from 403: it's an auth/token problem, not
+      // a permissions problem. Callers get actionable "re-auth" guidance.
+      expect(result).toContain('Authentication failed')
+      expect(result).toContain('token')
     })
 
     it('returns message for 403 Forbidden', async () => {


### PR DESCRIPTION
## Summary
Backport of v1.x #1145 to main. \`socket scan create --reach\` (and all other calls) used to show "Access denied / lacks required permissions" for a **401 Unauthorized** response — which is misleading when the real problem is a revoked, expired, or invalid API token. This sent users chasing permissions instead of re-authenticating.

## Changes
- **\`utils/socket/api.mts\` \`getErrorMessageForHttpStatusCode\`**: split 401 and 403 into separate branches. 401 now returns an "Authentication failed" message with actionable "run socket whoami / login" guidance; 403 keeps the existing permissions-focused message.
- **\`commands/scan/perform-reachability-analysis.mts\`**: when the enterprise-plan probe returns 401 from \`fetchOrganization\`, bail with "Authentication failed" instead of the generic "Unable to verify plan permissions" — the old message actively misled users who had a revoked token.
- Updated the matching \`getErrorMessageForHttpStatusCode\` 401 test assertion.

## What was skipped from v1.x
The v1.x change also added an extra \`logger.fail\` call in \`fetch-organization-list.mts\`. On main, \`handleApiCall\` already wires the cause into the returned \`CResult\` so callers can log once; adding it at the fetcher would double-log in most paths. Skipped.

## Test plan
- [x] \`pnpm run type\` clean
- [x] \`pnpm --filter @socketsecurity/cli run test:unit\` — all 343 files, 5156 tests pass
- [x] \`pnpm run build:cli\` succeeds
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI error messaging and one early-return branch on a failed org fetch, with updated unit coverage. Main risk is minor behavior change in user-facing guidance for 401 vs 403 responses.
> 
> **Overview**
> Clarifies HTTP error handling by **splitting 401 Unauthorized from 403 Forbidden** in `getErrorMessageForHttpStatusCode`, returning a token/re-authentication message for 401 while keeping permissions/plan guidance for 403.
> 
> Updates reachability analysis (`perform-reachability-analysis.mts`) to detect a 401 from `fetchOrganization()` and fail fast with an **"Authentication failed"** result instead of a generic plan-permissions verification error, and adjusts the related unit test expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3d5ce8343a10d58aeace42c44c0216dffc854c3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->