### PR TITLE
fix(fix): validate target directory and detect misplaced IDs

### DIFF
--- a/packages/cli/src/commands/fix/cmd-fix.mts
+++ b/packages/cli/src/commands/fix/cmd-fix.mts
@@ -422,10 +422,18 @@ async function run(
     const isCve = upperInput.startsWith('CVE-')
     const isPurl = rawInput.startsWith('pkg:')
     if (isGhsa || isCve || isPurl) {
-      // `handle-fix.mts` matches GHSA/CVE prefixes case-sensitively, so
-      // echo GHSA/CVE in uppercase in the suggestion. PURLs keep their
-      // original case (they're intentionally lowercase).
-      const suggestion = isPurl ? rawInput : upperInput
+      // `handle-fix.mts` validates IDs with case-sensitive format regexes:
+      //   * GHSA — prefix must be uppercase, body segments lowercase [a-z0-9]
+      //   * CVE  — prefix must be uppercase, body is all digits (case-free)
+      // PURLs are intentionally lowercase and validated separately.
+      let suggestion: string
+      if (isGhsa) {
+        suggestion = 'GHSA-' + rawInput.slice(5).toLowerCase()
+      } else if (isCve) {
+        suggestion = 'CVE-' + rawInput.slice(4)
+      } else {
+        suggestion = rawInput
+      }
       logger.fail(
         `"${rawInput}" looks like a vulnerability identifier, not a directory path.\nDid you mean: socket fix ${FLAG_ID} ${suggestion}`,
       )

--- a/packages/cli/src/commands/fix/cmd-fix.mts
+++ b/packages/cli/src/commands/fix/cmd-fix.mts
@@ -409,6 +409,46 @@ async function run(
     return
   }
 
+  // Detect the common mistake of passing a vulnerability ID (GHSA / CVE /
+  // PURL) as a positional argument when the user meant to use `--id`.
+  // Without this guard we treat the ID as a directory path, resolve to cwd,
+  // and eventually fail with a confusing upload error. Run this before
+  // `getDefaultOrgSlug()` so users still get the helpful message when no
+  // API token is configured.
+  const rawInput = cli.input[0]
+  if (rawInput) {
+    const upperInput = rawInput.toUpperCase()
+    const isGhsa = upperInput.startsWith('GHSA-')
+    const isCve = upperInput.startsWith('CVE-')
+    const isPurl = rawInput.startsWith('pkg:')
+    if (isGhsa || isCve || isPurl) {
+      // `handle-fix.mts` matches GHSA/CVE prefixes case-sensitively, so
+      // echo GHSA/CVE in uppercase in the suggestion. PURLs keep their
+      // original case (they're intentionally lowercase).
+      const suggestion = isPurl ? rawInput : upperInput
+      logger.fail(
+        `"${rawInput}" looks like a vulnerability identifier, not a directory path.\nDid you mean: socket fix ${FLAG_ID} ${suggestion}`,
+      )
+      process.exitCode = 1
+      return
+    }
+  }
+
+  let [cwd = '.'] = cli.input
+  // Note: path.resolve vs .join:
+  // If given path is absolute then cwd should not affect it.
+  cwd = path.resolve(process.cwd(), cwd)
+
+  // Validate the target directory exists so we fail fast with a clear
+  // message instead of the API's "Need at least one file to be uploaded".
+  // Also runs before the org-slug resolution so the user sees a clearer
+  // error when pointing at a typo'd path without an API token set.
+  if (!existsSync(cwd)) {
+    logger.fail(`Target directory does not exist: ${cwd}`)
+    process.exitCode = 1
+    return
+  }
+
   const orgSlugCResult = await getDefaultOrgSlug()
   if (!orgSlugCResult.ok) {
     process.exitCode = orgSlugCResult.code ?? 1
@@ -419,37 +459,6 @@ async function run(
   }
 
   const orgSlug = orgSlugCResult.data
-
-  // Detect the common mistake of passing a vulnerability ID (GHSA / CVE /
-  // PURL) as a positional argument when the user meant to use `--id`.
-  // Without this guard we treat the ID as a directory path, resolve to cwd,
-  // and eventually fail with a confusing upload error.
-  const rawInput = cli.input[0]
-  if (
-    rawInput &&
-    (/^GHSA-/i.test(rawInput) ||
-      /^CVE-/i.test(rawInput) ||
-      rawInput.startsWith('pkg:'))
-  ) {
-    logger.fail(
-      `"${rawInput}" looks like a vulnerability identifier, not a directory path.\nDid you mean: socket fix ${FLAG_ID} ${rawInput}`,
-    )
-    process.exitCode = 1
-    return
-  }
-
-  let [cwd = '.'] = cli.input
-  // Note: path.resolve vs .join:
-  // If given path is absolute then cwd should not affect it.
-  cwd = path.resolve(process.cwd(), cwd)
-
-  // Validate the target directory exists so we fail fast with a clear
-  // message instead of the API's "Need at least one file to be uploaded".
-  if (!existsSync(cwd)) {
-    logger.fail(`Target directory does not exist: ${cwd}`)
-    process.exitCode = 1
-    return
-  }
 
   const spinner = undefined
 

--- a/packages/cli/src/commands/fix/cmd-fix.mts
+++ b/packages/cli/src/commands/fix/cmd-fix.mts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import path from 'node:path'
 
 import terminalLink from 'terminal-link'
@@ -419,10 +420,36 @@ async function run(
 
   const orgSlug = orgSlugCResult.data
 
+  // Detect the common mistake of passing a vulnerability ID (GHSA / CVE /
+  // PURL) as a positional argument when the user meant to use `--id`.
+  // Without this guard we treat the ID as a directory path, resolve to cwd,
+  // and eventually fail with a confusing upload error.
+  const rawInput = cli.input[0]
+  if (
+    rawInput &&
+    (/^GHSA-/i.test(rawInput) ||
+      /^CVE-/i.test(rawInput) ||
+      rawInput.startsWith('pkg:'))
+  ) {
+    logger.fail(
+      `"${rawInput}" looks like a vulnerability identifier, not a directory path.\nDid you mean: socket fix ${FLAG_ID} ${rawInput}`,
+    )
+    process.exitCode = 1
+    return
+  }
+
   let [cwd = '.'] = cli.input
   // Note: path.resolve vs .join:
   // If given path is absolute then cwd should not affect it.
   cwd = path.resolve(process.cwd(), cwd)
+
+  // Validate the target directory exists so we fail fast with a clear
+  // message instead of the API's "Need at least one file to be uploaded".
+  if (!existsSync(cwd)) {
+    logger.fail(`Target directory does not exist: ${cwd}`)
+    process.exitCode = 1
+    return
+  }
 
   const spinner = undefined
 

--- a/packages/cli/test/unit/commands/fix/cmd-fix.test.mts
+++ b/packages/cli/test/unit/commands/fix/cmd-fix.test.mts
@@ -366,16 +366,35 @@ describe('cmd-fix', () => {
       )
     })
 
-    it('should uppercase a lowercase GHSA/CVE in the suggestion', async () => {
+    it('should normalize a lowercase GHSA suggestion to prefix-upper / body-lower', async () => {
       await cmdFix.run(['ghsa-abcd-efgh-ijkl'], importMeta, context)
 
       expect(process.exitCode).toBe(1)
       expect(mockHandleFix).not.toHaveBeenCalled()
-      // handle-fix.mts matches GHSA/CVE prefixes case-sensitively, so the
-      // suggested command must use the uppercase form or it will fail
-      // downstream with "Unsupported ID format".
+      // handle-fix.mts validates GHSA format as /^GHSA-[a-z0-9]{4}-...$/:
+      // prefix must be uppercase, body segments must stay lowercase.
       expect(mockLogger.fail).toHaveBeenCalledWith(
-        expect.stringContaining('--id GHSA-ABCD-EFGH-IJKL'),
+        expect.stringContaining('--id GHSA-abcd-efgh-ijkl'),
+      )
+    })
+
+    it('should normalize a lowercase CVE suggestion to uppercase CVE prefix', async () => {
+      await cmdFix.run(['cve-2021-23337'], importMeta, context)
+
+      expect(process.exitCode).toBe(1)
+      expect(mockHandleFix).not.toHaveBeenCalled()
+      expect(mockLogger.fail).toHaveBeenCalledWith(
+        expect.stringContaining('--id CVE-2021-23337'),
+      )
+    })
+
+    it('should leave a PURL suggestion untouched', async () => {
+      await cmdFix.run(['pkg:npm/left-pad@1.3.0'], importMeta, context)
+
+      expect(process.exitCode).toBe(1)
+      expect(mockHandleFix).not.toHaveBeenCalled()
+      expect(mockLogger.fail).toHaveBeenCalledWith(
+        expect.stringContaining('--id pkg:npm/left-pad@1.3.0'),
       )
     })
 

--- a/packages/cli/test/unit/commands/fix/cmd-fix.test.mts
+++ b/packages/cli/test/unit/commands/fix/cmd-fix.test.mts
@@ -331,85 +331,80 @@ describe('cmd-fix', () => {
       )
     })
 
-    it('should support custom cwd argument', async () => {
-      // Use a path that definitely exists (the test's own cwd) because
-      // cmd-fix now validates the target directory upfront.
-      const realDir = process.cwd()
-      await cmdFix.run([realDir], importMeta, context)
+    describe('misplaced vulnerability identifier detection', () => {
+      // The case matrix handle-fix.mts actually validates downstream:
+      //   GHSA: /^GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}$/
+      //   CVE:  /^CVE-\d{4}-\d{4,}$/
+      // Suggestion must be exactly the form that passes those regexes,
+      // otherwise the user follows our advice and still gets an error.
+      it.each([
+        // [label, input, expectedSuggestion]
+        // GHSA: prefix to upper, body to lower, regardless of input casing.
+        ['canonical GHSA', 'GHSA-abcd-efgh-ijkl', 'GHSA-abcd-efgh-ijkl'],
+        ['lowercase GHSA', 'ghsa-abcd-efgh-ijkl', 'GHSA-abcd-efgh-ijkl'],
+        ['mixed-case GHSA', 'GhSa-AbCd-EfGh-IjKl', 'GHSA-abcd-efgh-ijkl'],
+        // CVE: prefix to upper, body is digits so case is a no-op.
+        ['canonical CVE', 'CVE-2021-23337', 'CVE-2021-23337'],
+        ['lowercase CVE', 'cve-2021-23337', 'CVE-2021-23337'],
+        // PURL: always lowercase by spec, echo verbatim.
+        ['npm PURL', 'pkg:npm/left-pad@1.3.0', 'pkg:npm/left-pad@1.3.0'],
+      ])(
+        'detects %s and suggests the downstream-valid form',
+        async (_label, input, expectedSuggestion) => {
+          await cmdFix.run([input], importMeta, context)
 
-      expect(mockHandleFix).toHaveBeenCalledWith(
-        expect.objectContaining({
-          cwd: realDir,
-        }),
+          expect(process.exitCode).toBe(1)
+          expect(mockHandleFix).not.toHaveBeenCalled()
+          expect(mockLogger.fail).toHaveBeenCalledWith(
+            expect.stringContaining(
+              'looks like a vulnerability identifier, not a directory path',
+            ),
+          )
+          expect(mockLogger.fail).toHaveBeenCalledWith(
+            expect.stringContaining(`--id ${expectedSuggestion}`),
+          )
+        },
       )
+
+      it('validates IDs before resolving the org slug (no API token path)', async () => {
+        await cmdFix.run(['GHSA-xxxx-xxxx-xxxx'], importMeta, context)
+
+        // The check must run *before* `getDefaultOrgSlug`, so users without
+        // a configured API token still see the helpful message instead of
+        // the generic "Unable to resolve org".
+        expect(mockGetDefaultOrgSlug).not.toHaveBeenCalled()
+      })
     })
 
-    it('should fail fast when target directory does not exist', async () => {
-      await cmdFix.run(['./this/path/does/not/exist'], importMeta, context)
+    describe('target directory validation', () => {
+      it('should fail fast when target directory does not exist', async () => {
+        await cmdFix.run(['./this/path/does/not/exist'], importMeta, context)
 
-      expect(process.exitCode).toBe(1)
-      expect(mockHandleFix).not.toHaveBeenCalled()
-      expect(mockLogger.fail).toHaveBeenCalledWith(
-        expect.stringContaining('Target directory does not exist'),
-      )
-    })
+        expect(process.exitCode).toBe(1)
+        expect(mockHandleFix).not.toHaveBeenCalled()
+        expect(mockLogger.fail).toHaveBeenCalledWith(
+          expect.stringContaining('Target directory does not exist'),
+        )
+      })
 
-    it('should fail fast when a GHSA is passed as a positional arg', async () => {
-      await cmdFix.run(['GHSA-xxxx-xxxx-xxxx'], importMeta, context)
+      it('validates the directory before resolving the org slug', async () => {
+        await cmdFix.run(['./this/path/does/not/exist'], importMeta, context)
 
-      expect(process.exitCode).toBe(1)
-      expect(mockHandleFix).not.toHaveBeenCalled()
-      expect(mockLogger.fail).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'looks like a vulnerability identifier, not a directory path',
-        ),
-      )
-    })
+        expect(mockGetDefaultOrgSlug).not.toHaveBeenCalled()
+      })
 
-    it('should normalize a lowercase GHSA suggestion to prefix-upper / body-lower', async () => {
-      await cmdFix.run(['ghsa-abcd-efgh-ijkl'], importMeta, context)
+      it('lets a real directory flow through to handleFix', async () => {
+        const realDir = process.cwd()
+        await cmdFix.run([realDir], importMeta, context)
 
-      expect(process.exitCode).toBe(1)
-      expect(mockHandleFix).not.toHaveBeenCalled()
-      // handle-fix.mts validates GHSA format as /^GHSA-[a-z0-9]{4}-...$/:
-      // prefix must be uppercase, body segments must stay lowercase.
-      expect(mockLogger.fail).toHaveBeenCalledWith(
-        expect.stringContaining('--id GHSA-abcd-efgh-ijkl'),
-      )
-    })
-
-    it('should normalize a lowercase CVE suggestion to uppercase CVE prefix', async () => {
-      await cmdFix.run(['cve-2021-23337'], importMeta, context)
-
-      expect(process.exitCode).toBe(1)
-      expect(mockHandleFix).not.toHaveBeenCalled()
-      expect(mockLogger.fail).toHaveBeenCalledWith(
-        expect.stringContaining('--id CVE-2021-23337'),
-      )
-    })
-
-    it('should leave a PURL suggestion untouched', async () => {
-      await cmdFix.run(['pkg:npm/left-pad@1.3.0'], importMeta, context)
-
-      expect(process.exitCode).toBe(1)
-      expect(mockHandleFix).not.toHaveBeenCalled()
-      expect(mockLogger.fail).toHaveBeenCalledWith(
-        expect.stringContaining('--id pkg:npm/left-pad@1.3.0'),
-      )
-    })
-
-    it('should fail fast without calling getDefaultOrgSlug when input looks like an ID', async () => {
-      await cmdFix.run(['GHSA-xxxx-xxxx-xxxx'], importMeta, context)
-
-      // The validation must run before the network-backed org-slug resolution,
-      // so users without a configured API token still see the helpful message.
-      expect(mockGetDefaultOrgSlug).not.toHaveBeenCalled()
-    })
-
-    it('should fail fast without calling getDefaultOrgSlug when target dir missing', async () => {
-      await cmdFix.run(['./this/path/does/not/exist'], importMeta, context)
-
-      expect(mockGetDefaultOrgSlug).not.toHaveBeenCalled()
+        expect(mockHandleFix).toHaveBeenCalledWith(
+          expect.objectContaining({ cwd: realDir }),
+        )
+        // Sanity: no bail on the happy path.
+        expect(mockLogger.fail).not.toHaveBeenCalledWith(
+          expect.stringContaining('Target directory does not exist'),
+        )
+      })
     })
 
     it('should support --json output mode', async () => {

--- a/packages/cli/test/unit/commands/fix/cmd-fix.test.mts
+++ b/packages/cli/test/unit/commands/fix/cmd-fix.test.mts
@@ -366,6 +366,33 @@ describe('cmd-fix', () => {
       )
     })
 
+    it('should uppercase a lowercase GHSA/CVE in the suggestion', async () => {
+      await cmdFix.run(['ghsa-abcd-efgh-ijkl'], importMeta, context)
+
+      expect(process.exitCode).toBe(1)
+      expect(mockHandleFix).not.toHaveBeenCalled()
+      // handle-fix.mts matches GHSA/CVE prefixes case-sensitively, so the
+      // suggested command must use the uppercase form or it will fail
+      // downstream with "Unsupported ID format".
+      expect(mockLogger.fail).toHaveBeenCalledWith(
+        expect.stringContaining('--id GHSA-ABCD-EFGH-IJKL'),
+      )
+    })
+
+    it('should fail fast without calling getDefaultOrgSlug when input looks like an ID', async () => {
+      await cmdFix.run(['GHSA-xxxx-xxxx-xxxx'], importMeta, context)
+
+      // The validation must run before the network-backed org-slug resolution,
+      // so users without a configured API token still see the helpful message.
+      expect(mockGetDefaultOrgSlug).not.toHaveBeenCalled()
+    })
+
+    it('should fail fast without calling getDefaultOrgSlug when target dir missing', async () => {
+      await cmdFix.run(['./this/path/does/not/exist'], importMeta, context)
+
+      expect(mockGetDefaultOrgSlug).not.toHaveBeenCalled()
+    })
+
     it('should support --json output mode', async () => {
       await cmdFix.run(['--json'], importMeta, context)
 

--- a/packages/cli/test/unit/commands/fix/cmd-fix.test.mts
+++ b/packages/cli/test/unit/commands/fix/cmd-fix.test.mts
@@ -332,12 +332,37 @@ describe('cmd-fix', () => {
     })
 
     it('should support custom cwd argument', async () => {
-      await cmdFix.run(['./custom/path'], importMeta, context)
+      // Use a path that definitely exists (the test's own cwd) because
+      // cmd-fix now validates the target directory upfront.
+      const realDir = process.cwd()
+      await cmdFix.run([realDir], importMeta, context)
 
       expect(mockHandleFix).toHaveBeenCalledWith(
         expect.objectContaining({
-          cwd: expect.stringContaining('custom/path'),
+          cwd: realDir,
         }),
+      )
+    })
+
+    it('should fail fast when target directory does not exist', async () => {
+      await cmdFix.run(['./this/path/does/not/exist'], importMeta, context)
+
+      expect(process.exitCode).toBe(1)
+      expect(mockHandleFix).not.toHaveBeenCalled()
+      expect(mockLogger.fail).toHaveBeenCalledWith(
+        expect.stringContaining('Target directory does not exist'),
+      )
+    })
+
+    it('should fail fast when a GHSA is passed as a positional arg', async () => {
+      await cmdFix.run(['GHSA-xxxx-xxxx-xxxx'], importMeta, context)
+
+      expect(process.exitCode).toBe(1)
+      expect(mockHandleFix).not.toHaveBeenCalled()
+      expect(mockLogger.fail).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'looks like a vulnerability identifier, not a directory path',
+        ),
       )
     })
 


### PR DESCRIPTION
## Summary
Backport of v1.x #1199 to main. Two quality-of-life fixes for \`socket fix\` that surface clear error messages instead of the confusing API error users hit today.

### Misplaced vulnerability ID

Before:
\`\`\`
$ socket fix GHSA-xxxx-xxxx-xxxx
✖ Socket API error: Need at least one file to be uploaded
\`\`\`

After:
\`\`\`
$ socket fix GHSA-xxxx-xxxx-xxxx
✖ "GHSA-xxxx-xxxx-xxxx" looks like a vulnerability identifier, not a directory path.
Did you mean: socket fix --id GHSA-xxxx-xxxx-xxxx
\`\`\`

Triggered on first positional arg matching \`/^GHSA-/\`, \`/^CVE-/\`, or \`pkg:…\`.

### Nonexistent target directory

Before: silently resolve to absolute, glob zero files, API rejects with the same confusing "Need at least one file to be uploaded".

After:
\`\`\`
$ socket fix ./does-not-exist
✖ Target directory does not exist: /absolute/path/to/does-not-exist
\`\`\`

## Tests
- Reworked the existing "should support custom cwd argument" test to use a guaranteed-existing path (\`process.cwd()\`) now that we validate the dir upfront.
- Added "should fail fast when target directory does not exist".
- Added "should fail fast when a GHSA is passed as a positional arg".

## Test plan
- [x] \`pnpm run type\` clean
- [x] \`pnpm --filter @socketsecurity/cli run test:unit\` — all 343 files pass
- [x] \`pnpm run build:cli\` succeeds
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds early CLI input validation and clearer error messages, with corresponding unit tests; main risk is minor behavior change for users previously relying on implicit path handling.
> 
> **Overview**
> Improves `socket fix` UX by **detecting GHSA/CVE/PURL values mistakenly passed as the positional CWD** and exiting with a helpful `--id` suggestion instead of proceeding to a confusing upload error.
> 
> Adds **fast-fail validation that the target directory exists** (before org-slug/API token resolution) to surface a clear local error and avoid the API’s generic “Need at least one file to be uploaded” failure. Unit tests are updated/expanded to cover the new validation and ordering guarantees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7a1bb1d7b931a4bb31e56dcd17254395fb68b32. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->