### PR TITLE
docs(claude): always existsSync; forbid async fileExists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,9 +114,9 @@ Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). User-facing cha
 
 - `.mts` extensions for TypeScript modules
 - 🚨 ALWAYS use separate `import type` statements -- NEVER mix runtime and type imports
-- Node.js fs: `import { someSyncThing, promises as fs } from 'node:fs'`
+- Node.js fs: `import { existsSync, promises as fs } from 'node:fs'` (cherry-pick `existsSync`, alias promises as `fs`)
 - Process spawning: MUST use `spawn` from `@socketsecurity/registry/lib/spawn` (NEVER `child_process`)
-- File existence: ALWAYS use `existsSync()` from `node:fs` (NEVER `fs.access`)
+- File existence: ALWAYS use `existsSync` from `node:fs`. NEVER `fs.access`, `fs.stat`-for-existence, or an async `fileExists` wrapper.
 
 ### Code Patterns
 


### PR DESCRIPTION
## Summary

- Tighten the fs import example in CLAUDE.md to the canonical form `import { existsSync, promises as fs } from 'node:fs'` (was `someSyncThing` placeholder).
- Explicitly forbid async `fileExists` wrappers and `fs.stat`-for-existence checks in addition to `fs.access`.

Docs-only; no code changes. Keeps socket-cli's CLAUDE.md in sync with the shared rule being rolled out across the socket-* repos.

## Test plan

- [x] `pnpm run fix` + `pnpm run check` passed via pre-commit hooks
- [ ] Reviewer sanity-check the wording

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only updates guidance in `CLAUDE.md` with no runtime code changes. Risk is limited to potential developer confusion if teams were relying on the previously looser wording.
> 
> **Overview**
> Clarifies the `CLAUDE.md` Node.js `fs` guidance by standardizing the import example to `import { existsSync, promises as fs } from 'node:fs'`.
> 
> Tightens the file-existence rule to explicitly forbid `fs.access`, `fs.stat`-for-existence checks, and any async `fileExists` wrapper in favor of using `existsSync`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e41555d10eb3002737d830fd6ad755a3391b4809. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->