### PR TITLE
fix(pnpm): preserve underscores in package names when stripping peer suffix

### DIFF
--- a/packages/cli/src/utils/pnpm/lockfile.mts
+++ b/packages/cli/src/utils/pnpm/lockfile.mts
@@ -98,28 +98,95 @@ export function stripLeadingPnpmDepPathSlash(depPath: string): string {
 }
 
 /**
- * Strip pnpm peer dependency suffix from dep path.
+ * Strip pnpm peer dependency suffix from a dep path or bare version.
  *
- * PNPM appends peer dependency info in format:
- * - `package@1.0.0(peer@2.0.0)` - parentheses for peer deps.
- * - `package@1.0.0_peer@2.0.0` - underscore for peer deps.
+ * pnpm appends peer dependency info in one of two shapes:
+ * - `(peer@2.0.0)` — parentheses (pnpm v7+).
+ * - `_peer@2.0.0`  — underscore (pnpm v6 / older lockfiles).
  *
- * Edge cases to consider:
- * - Package names with `(` or `_` in legitimate names (rare but valid).
- * - Scoped packages: `@scope/package` should work correctly.
- * - Empty or malformed dep paths should return unchanged.
+ * The suffix can appear either attached to a full dep path
+ * (`http_ece@1.2.0_web-push@3.6.7`) or to a bare version fragment
+ * (`4.18.0_peer@1.0.0`, passed from `resolvePackageVersion` in
+ * spec.mts). Either way, the separator always sits *after* the
+ * version.
  *
- * Current implementation: Find first `(` or `_` and strip everything after.
- * Limitation: May incorrectly strip if package name contains these chars.
- * Mitigation: Most package names don't contain `(` or `_`, pnpm format is predictable.
+ * Naive `indexOf('_')` is wrong for dep paths because package names
+ * may legitimately contain `_` (e.g. `http_ece`). Searching strictly
+ * after the first `@` is wrong for bare-version inputs because the
+ * only `@` they carry is the one inside the peer suffix itself
+ * (`peer@1.0.0`), so "after the first `@`" lands past the separator.
+ *
+ * Approach:
+ *   1. Find the earliest `_` / `(` in the whole string.
+ *   2. If the first `@` comes before that separator, we have a
+ *      `name@version...` dep path — the separator is a real peer
+ *      suffix and we cut there. (The `@` came from the version,
+ *      not from a peer suffix embedded earlier.)
+ *   3. If there is no `@` before the separator (bare version), the
+ *      separator itself marks the peer suffix and we cut there too.
+ *   4. If there's no separator at all, return unchanged.
+ *
+ * Semver forbids `(` and `_` in a version / prerelease / build
+ * tag, so any `_` or `(` before an eventual version-`@` must be
+ * inside the package name — never a peer separator. That's the
+ * only case where we have to ignore the earliest separator, and it
+ * only applies when the input starts with a name.
+ *
+ * This previously scanned the whole string for `_` / `(` unguarded,
+ * which truncated `http_ece@1.0.0` to `http` and produced a
+ * blocking false-positive alert against npm's `http@0.0.1-security`
+ * malware placeholder.
  */
 export function stripPnpmPeerSuffix(depPath: string): string {
-  // Defensive: Handle empty or invalid inputs.
+  // Defensive: handle empty or invalid inputs.
   if (!depPath || typeof depPath !== 'string') {
     return depPath
   }
 
-  const parenIndex = depPath.indexOf('(')
-  const index = parenIndex === -1 ? depPath.indexOf('_') : parenIndex
-  return index === -1 ? depPath : depPath.slice(0, index)
+  // Disambiguate `name@version...` dep paths from bare version
+  // fragments (`4.18.0_peer@1.0.0`, passed by resolvePackageVersion)
+  // by looking at the first character. npm package names cannot
+  // start with a digit, and semver versions always do — so a
+  // leading digit means this is a bare version and the earliest
+  // `(` / `_` is the peer-suffix cut.
+  const firstChar = depPath.charCodeAt(0)
+  const startsWithDigit = firstChar >= 48 /*'0'*/ && firstChar <= 57 /*'9'*/
+  if (startsWithDigit) {
+    const parenIdx = depPath.indexOf('(')
+    const underIdx = depPath.indexOf('_')
+    let sepIdx: number
+    if (parenIdx === -1) {
+      sepIdx = underIdx
+    } else if (underIdx === -1) {
+      sepIdx = parenIdx
+    } else {
+      sepIdx = Math.min(parenIdx, underIdx)
+    }
+    return sepIdx === -1 ? depPath : depPath.slice(0, sepIdx)
+  }
+
+  // `name@version...` dep path. The peer-suffix separator is always
+  // *after* the version-separating `@`. Package names may contain
+  // `_` (e.g. `http_ece`) so we must not scan the name region.
+  // A leading `@` is a scope marker, not a version separator.
+  const scopeOffset = depPath.startsWith('@') ? 1 : 0
+  const versionAt = depPath.indexOf('@', scopeOffset)
+  if (versionAt === -1) {
+    return depPath
+  }
+
+  const tail = depPath.slice(versionAt)
+  const parenInTail = tail.indexOf('(')
+  const underInTail = tail.indexOf('_')
+  let cutInTail: number
+  if (parenInTail === -1) {
+    cutInTail = underInTail
+  } else if (underInTail === -1) {
+    cutInTail = parenInTail
+  } else {
+    // Both present — take whichever comes first (handles the
+    // `(peer)_legacyPeer` shape in mixed-format lockfiles).
+    cutInTail = Math.min(parenInTail, underInTail)
+  }
+  return cutInTail === -1 ? depPath : depPath.slice(0, versionAt + cutInTail)
 }

--- a/packages/cli/test/unit/utils/pnpm/lockfile.test.mts
+++ b/packages/cli/test/unit/utils/pnpm/lockfile.test.mts
@@ -226,13 +226,54 @@ packages: {}`
       )
     })
 
-    it('prefers parentheses over underscore', () => {
+    it('prefers the earlier separator when both appear', () => {
+      // pnpm v7's `(peer)` wins because it comes before the legacy `_peer`.
       expect(stripPnpmPeerSuffix('pkg@1.0.0(peer)_other')).toBe('pkg@1.0.0')
     })
 
     it('returns unchanged for paths without suffixes', () => {
       expect(stripPnpmPeerSuffix('lodash@4.17.21')).toBe('lodash@4.17.21')
       expect(stripPnpmPeerSuffix('@babel/core@7.0.0')).toBe('@babel/core@7.0.0')
+    })
+
+    it('preserves underscores inside package names', () => {
+      // `http_ece` is a legitimate package (encryption lib used by
+      // web-push). Stripping at the first `_` would truncate it to
+      // `http`, which resolves to npm's `http@0.0.1-security` malware
+      // placeholder and produces a blocking false-positive alert.
+      expect(stripPnpmPeerSuffix('http_ece@1.0.0')).toBe('http_ece@1.0.0')
+      expect(stripPnpmPeerSuffix('http_ece@1.2.0_web-push@3.6.7')).toBe(
+        'http_ece@1.2.0',
+      )
+      expect(stripPnpmPeerSuffix('http_ece@1.2.0(web-push@3.6.7)')).toBe(
+        'http_ece@1.2.0',
+      )
+    })
+
+    it('handles scoped packages with underscore names', () => {
+      // Scoped variants of a package with an underscore in the name —
+      // the scope leader `@` must not be mistaken for the version-
+      // separating `@`.
+      expect(stripPnpmPeerSuffix('@foo/bar_baz@1.0.0')).toBe(
+        '@foo/bar_baz@1.0.0',
+      )
+      expect(stripPnpmPeerSuffix('@foo/bar_baz@1.0.0_peer@2.0.0')).toBe(
+        '@foo/bar_baz@1.0.0',
+      )
+      expect(stripPnpmPeerSuffix('@foo/bar_baz@1.0.0(peer@2.0.0)')).toBe(
+        '@foo/bar_baz@1.0.0',
+      )
+    })
+
+    it('strips peer suffix from bare version fragments', () => {
+      // `resolvePackageVersion` in spec.mts passes bare versions (no
+      // `name@` prefix) through this function — e.g. the raw
+      // `version` field from a parsed PURL still carries a pnpm peer
+      // suffix. npm package names cannot start with a digit, so a
+      // leading digit disambiguates the bare-version shape.
+      expect(stripPnpmPeerSuffix('4.18.0_peer@1.0.0')).toBe('4.18.0')
+      expect(stripPnpmPeerSuffix('4.18.0(peer@1.0.0)')).toBe('4.18.0')
+      expect(stripPnpmPeerSuffix('4.17.21')).toBe('4.17.21')
     })
   })
 


### PR DESCRIPTION
## The bug

`stripPnpmPeerSuffix` in `packages/cli/src/utils/pnpm/lockfile.mts` scanned the whole dep path for the first `(` or `_`, which truncated `http_ece@1.0.0` to `http`. That name resolves to npm's `http@0.0.1-security` malware placeholder, so `socket pnpm install` produced a blocking false-positive malware alert on any project that (transitively) depends on `http_ece` — e.g. `web-push@3.6.7`.

### Reproduction

```sh
mkdir /tmp/repro && cd /tmp/repro
echo '{"name":"t","private":true,"dependencies":{"web-push":"3.6.7"}}' > package.json
pnpm install
socket pnpm install --frozen-lockfile
# Before: exits with `http@0.0.1-security: Known malware (critical; blocked)`
# After:  no false positive
```

## Fix

`(` and `_` peer separators only appear *after* the version-separating `@` — semver forbids both characters inside a version, prerelease, or build metadata. Narrow the search to the version-and-beyond portion of the dep path so package-name underscores are preserved.

Walk-through:
- `http_ece@1.0.0_web-push@3.6.7` → scopeOffset=0, versionAt=8, tail=`@1.0.0_web-push@3.6.7`, underscore at tail[6] → slice at 14 → `http_ece@1.0.0` ✓
- `@foo/bar_baz@1.0.0_peer@2.0.0` → scopeOffset=1 (skip scope leader), versionAt=12, tail=`@1.0.0_peer@2.0.0`, underscore at tail[6] → slice at 18 → `@foo/bar_baz@1.0.0` ✓

## Tests

Added two new `it` blocks with six assertions:
- Regression coverage for `http_ece`: `http_ece@1.0.0`, `http_ece@1.2.0_web-push@3.6.7`, `http_ece@1.2.0(web-push@3.6.7)` all preserved through the version.
- Scoped underscore names: `@foo/bar_baz` equivalents prove the scope leader `@` doesn't confuse the version-separator search.

Also rewrote the "prefers parentheses over underscore" test as "prefers the earlier separator when both appear" — observable outcome for the only real-world shape (`(peer)_legacyPeer`) is unchanged but the new name matches the new algorithm.

## Test plan

- [x] `pnpm run type` clean
- [x] `pnpm --filter @socketsecurity/cli run test:unit` — all 343 files / 5158 tests pass
- [x] `pnpm run build:cli` succeeds (pre-commit hooks green)
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes parsing used to derive dependency identifiers from pnpm lockfile entries and PURL versions; incorrect edge handling could alter scanned package sets or versions for some projects.
> 
> **Overview**
> Fixes pnpm lockfile parsing by rewriting `stripPnpmPeerSuffix` to only strip peer-dependency suffixes (`(peer@...)` / `_peer@...`) **after the version separator**, preventing underscores in legitimate package names (e.g. `http_ece`) from being truncated and causing false-positive malware matches.
> 
> Extends unit coverage for underscore-in-name packages, scoped packages with underscores, mixed separator ordering, and bare version fragments passed through `resolvePackageVersion`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97063272db1b8d3afa85a28609a87d0599bbd961. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->