### PR TITLE
fix(scan): surface GitHub rate-limit errors in bulk repo scan

### DIFF
--- a/packages/cli/src/commands/scan/create-scan-from-github.mts
+++ b/packages/cli/src/commands/scan/create-scan-from-github.mts
@@ -92,7 +92,17 @@ export async function createScanFromGithub({
   }
 
   let scansCreated = 0
+  let reposScanned = 0
+  // Track a blocking error (rate limit / auth) so we can surface it
+  // instead of reporting silent success with "0 manifests". Without
+  // this, a rate-limited GitHub token made every repo fail its tree
+  // fetch, the outer loop swallowed each error, and the final summary
+  // ("N repos / 0 manifests") misled users into thinking the scan
+  // worked. See ASK-167.
+  let blockingError: CResult<undefined> | undefined
+  const perRepoFailures: Array<{ repo: string; message: string }> = []
   for (const repoSlug of targetRepos) {
+    reposScanned += 1
     // eslint-disable-next-line no-await-in-loop
     const scanCResult = await scanRepo(repoSlug, {
       githubApiUrl,
@@ -107,11 +117,53 @@ export async function createScanFromGithub({
       if (scanCreated) {
         scansCreated += 1
       }
+      continue
+    }
+    perRepoFailures.push({
+      repo: repoSlug,
+      message: scanCResult.message,
+    })
+    // Stop the loop if we hit a rate limit or auth failure — every
+    // subsequent repo will fail for the same reason and continuing
+    // only burns more quota while delaying the real error. Strings
+    // here match `handleGitHubApiError` / `handleGraphqlError` in
+    // utils/git/github.mts.
+    if (
+      scanCResult.message === 'GitHub rate limit exceeded' ||
+      scanCResult.message === 'GitHub GraphQL rate limit exceeded' ||
+      scanCResult.message === 'GitHub abuse detection triggered' ||
+      scanCResult.message === 'GitHub authentication failed'
+    ) {
+      blockingError = {
+        ok: false,
+        message: scanCResult.message,
+        cause: scanCResult.cause,
+      }
+      break
     }
   }
 
-  logger.success(targetRepos.length, 'GitHub repos detected')
+  logger.success(reposScanned, 'GitHub repos processed')
   logger.success(scansCreated, 'with supported Manifest files')
+
+  if (blockingError) {
+    logger.fail(blockingError.message)
+    return blockingError
+  }
+
+  // If every repo failed but not for a known-blocking reason, treat
+  // the run as an error so scripts know something went wrong instead
+  // of inferring success from an ok: true with 0 scans.
+  if (reposScanned > 0 && scansCreated === 0 && perRepoFailures.length === reposScanned) {
+    const firstFailure = perRepoFailures[0]!
+    return {
+      ok: false,
+      message: 'All repos failed to scan',
+      cause:
+        `All ${reposScanned} repos failed to scan. First failure for ${firstFailure.repo}: ${firstFailure.message}. ` +
+        'Check the log above for per-repo details.',
+    }
+  }
 
   return {
     ok: true,

--- a/packages/cli/src/commands/scan/create-scan-from-github.mts
+++ b/packages/cli/src/commands/scan/create-scan-from-github.mts
@@ -148,13 +148,13 @@ export async function createScanFromGithub({
     }
   }
 
-  logger.success(reposScanned, 'GitHub repos processed')
-  logger.success(scansCreated, 'with supported Manifest files')
-
   if (blockingError) {
     logger.fail(blockingError.message)
     return blockingError
   }
+
+  logger.success(reposScanned, 'GitHub repos processed')
+  logger.success(scansCreated, 'with supported Manifest files')
 
   // If every repo failed but not for a known-blocking reason, treat
   // the run as an error so scripts know something went wrong instead

--- a/packages/cli/src/commands/scan/create-scan-from-github.mts
+++ b/packages/cli/src/commands/scan/create-scan-from-github.mts
@@ -13,7 +13,14 @@ import { REPORT_LEVEL_ERROR } from '../../constants/reporting.mjs'
 import { formatErrorWithDetail } from '../../utils/error/errors.mjs'
 import { socketHttpRequest } from '../../utils/socket/api.mjs'
 import { isReportSupportedFile } from '../../utils/fs/glob.mts'
-import { getOctokit, withGitHubRetry } from '../../utils/git/github.mts'
+import {
+  GITHUB_ERR_ABUSE_DETECTION,
+  GITHUB_ERR_AUTH_FAILED,
+  GITHUB_ERR_GRAPHQL_RATE_LIMIT,
+  GITHUB_ERR_RATE_LIMIT,
+  getOctokit,
+  withGitHubRetry,
+} from '../../utils/git/github.mts'
 import { fetchListAllRepos } from '../repository/fetch-list-all-repos.mts'
 
 import type { CResult, OutputKind } from '../../types.mts'
@@ -123,16 +130,14 @@ export async function createScanFromGithub({
       repo: repoSlug,
       message: scanCResult.message,
     })
-    // Stop the loop if we hit a rate limit or auth failure — every
-    // subsequent repo will fail for the same reason and continuing
-    // only burns more quota while delaying the real error. Strings
-    // here match `handleGitHubApiError` / `handleGraphqlError` in
-    // utils/git/github.mts.
+    // Stop on rate-limit / auth failures: every subsequent repo will
+    // fail for the same reason and continuing only burns more quota
+    // while delaying the real error.
     if (
-      scanCResult.message === 'GitHub rate limit exceeded' ||
-      scanCResult.message === 'GitHub GraphQL rate limit exceeded' ||
-      scanCResult.message === 'GitHub abuse detection triggered' ||
-      scanCResult.message === 'GitHub authentication failed'
+      scanCResult.message === GITHUB_ERR_RATE_LIMIT ||
+      scanCResult.message === GITHUB_ERR_GRAPHQL_RATE_LIMIT ||
+      scanCResult.message === GITHUB_ERR_ABUSE_DETECTION ||
+      scanCResult.message === GITHUB_ERR_AUTH_FAILED
     ) {
       blockingError = {
         ok: false,

--- a/packages/cli/src/commands/scan/create-scan-from-github.mts
+++ b/packages/cli/src/commands/scan/create-scan-from-github.mts
@@ -134,10 +134,10 @@ export async function createScanFromGithub({
     // fail for the same reason and continuing only burns more quota
     // while delaying the real error.
     if (
-      scanCResult.message === GITHUB_ERR_RATE_LIMIT ||
-      scanCResult.message === GITHUB_ERR_GRAPHQL_RATE_LIMIT ||
       scanCResult.message === GITHUB_ERR_ABUSE_DETECTION ||
-      scanCResult.message === GITHUB_ERR_AUTH_FAILED
+      scanCResult.message === GITHUB_ERR_AUTH_FAILED ||
+      scanCResult.message === GITHUB_ERR_GRAPHQL_RATE_LIMIT ||
+      scanCResult.message === GITHUB_ERR_RATE_LIMIT
     ) {
       blockingError = {
         ok: false,

--- a/packages/cli/src/commands/scan/create-scan-from-github.mts
+++ b/packages/cli/src/commands/scan/create-scan-from-github.mts
@@ -105,7 +105,7 @@ export async function createScanFromGithub({
   // this, a rate-limited GitHub token made every repo fail its tree
   // fetch, the outer loop swallowed each error, and the final summary
   // ("N repos / 0 manifests") misled users into thinking the scan
-  // worked. See ASK-167.
+  // worked.
   let blockingError: CResult<undefined> | undefined
   const perRepoFailures: Array<{ repo: string; message: string }> = []
   for (const repoSlug of targetRepos) {

--- a/packages/cli/src/utils/git/github.mts
+++ b/packages/cli/src/utils/git/github.mts
@@ -54,6 +54,15 @@ import type { SpawnOptions } from '@socketsecurity/lib/spawn'
 
 export type Pr = components['schemas']['pull-request']
 
+// Canonical `message` values returned by `handleGitHubApiError` /
+// `handleGraphqlError`. Exported so callers can short-circuit on
+// blocking conditions without matching free-form strings.
+export const GITHUB_ERR_ABUSE_DETECTION = 'GitHub abuse detection triggered'
+export const GITHUB_ERR_AUTH_FAILED = 'GitHub authentication failed'
+export const GITHUB_ERR_GRAPHQL_RATE_LIMIT =
+  'GitHub GraphQL rate limit exceeded'
+export const GITHUB_ERR_RATE_LIMIT = 'GitHub rate limit exceeded'
+
 interface CacheEntry {
   timestamp: number
   data: JsonContent
@@ -398,7 +407,7 @@ export function handleGraphqlError(
     if (isGraphqlRateLimitError(e)) {
       return {
         ok: false,
-        message: 'GitHub GraphQL rate limit exceeded',
+        message: GITHUB_ERR_GRAPHQL_RATE_LIMIT,
         cause:
           `GitHub GraphQL rate limit exceeded while ${context}. ` +
           'Try again in a few minutes.\n\n' +
@@ -440,7 +449,7 @@ export function handleGitHubApiError(
     if (status === 403 && e.message.includes('secondary rate limit')) {
       return {
         ok: false,
-        message: 'GitHub abuse detection triggered',
+        message: GITHUB_ERR_ABUSE_DETECTION,
         cause:
           `GitHub abuse detection triggered while ${context}. ` +
           'This happens when making too many requests in a short period. ' +
@@ -474,7 +483,7 @@ export function handleGitHubApiError(
 
       return {
         ok: false,
-        message: 'GitHub rate limit exceeded',
+        message: GITHUB_ERR_RATE_LIMIT,
         cause:
           `GitHub API rate limit exceeded while ${context}. ` +
           (waitTime
@@ -492,7 +501,7 @@ export function handleGitHubApiError(
     if (status === 401) {
       return {
         ok: false,
-        message: 'GitHub authentication failed',
+        message: GITHUB_ERR_AUTH_FAILED,
         cause:
           `GitHub authentication failed while ${context}. ` +
           'Your token may be invalid, expired, or missing required permissions.\n\n' +

--- a/packages/cli/test/unit/commands/scan/create-scan-from-github.test.mts
+++ b/packages/cli/test/unit/commands/scan/create-scan-from-github.test.mts
@@ -428,3 +428,106 @@ describe('error message quality', () => {
     }
   })
 })
+
+// Regression tests for ASK-167: the bulk loop in createScanFromGithub
+// used to swallow per-repo failures, so a rate-limited token returned
+// ok:true with "0 manifests". These drive the full function through
+// mocked octokit calls.
+describe('createScanFromGithub rate-limit short-circuit (ASK-167)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns ok:false and stops the loop on GitHub rate limit', async () => {
+    // First call (getRepoDetails for repo-a) fails with rate limit.
+    mockWithGitHubRetry.mockResolvedValueOnce({
+      ok: false,
+      message: 'GitHub rate limit exceeded',
+      cause: 'GitHub API rate limit exceeded.',
+    })
+
+    const { createScanFromGithub } = await import(
+      '../../../../src/commands/scan/create-scan-from-github.mts'
+    )
+
+    const result = await createScanFromGithub({
+      all: false,
+      githubApiUrl: '',
+      githubToken: '',
+      interactive: false,
+      orgGithub: 'org',
+      orgSlug: 'org',
+      outputKind: 'text',
+      repos: 'repo-a,repo-b,repo-c',
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.message).toBe('GitHub rate limit exceeded')
+    }
+    // Short-circuit: only the first repo's getRepoDetails should have run.
+    expect(mockWithGitHubRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns ok:false and stops on GitHub auth failure', async () => {
+    mockWithGitHubRetry.mockResolvedValueOnce({
+      ok: false,
+      message: 'GitHub authentication failed',
+      cause: 'Bad credentials.',
+    })
+
+    const { createScanFromGithub } = await import(
+      '../../../../src/commands/scan/create-scan-from-github.mts'
+    )
+
+    const result = await createScanFromGithub({
+      all: false,
+      githubApiUrl: '',
+      githubToken: '',
+      interactive: false,
+      orgGithub: 'org',
+      orgSlug: 'org',
+      outputKind: 'text',
+      repos: 'repo-a,repo-b',
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.message).toBe('GitHub authentication failed')
+    }
+    expect(mockWithGitHubRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns "All repos failed to scan" when every repo errors with a non-blocking reason', async () => {
+    // Each repo's getRepoDetails fails with a non-rate-limit error;
+    // the loop should finish all repos and return the catch-all error.
+    mockWithGitHubRetry.mockResolvedValue({
+      ok: false,
+      message: 'GitHub resource not found',
+      cause: 'Not found.',
+    })
+
+    const { createScanFromGithub } = await import(
+      '../../../../src/commands/scan/create-scan-from-github.mts'
+    )
+
+    const result = await createScanFromGithub({
+      all: false,
+      githubApiUrl: '',
+      githubToken: '',
+      interactive: false,
+      orgGithub: 'org',
+      orgSlug: 'org',
+      outputKind: 'text',
+      repos: 'repo-a,repo-b',
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.message).toBe('All repos failed to scan')
+      expect(result.cause).toContain('repo-a')
+    }
+    // Both repos should have been attempted (no short-circuit for 404).
+    expect(mockWithGitHubRetry).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/cli/test/unit/commands/scan/create-scan-from-github.test.mts
+++ b/packages/cli/test/unit/commands/scan/create-scan-from-github.test.mts
@@ -433,11 +433,11 @@ describe('error message quality', () => {
   })
 })
 
-// Regression tests for ASK-167: the bulk loop in createScanFromGithub
-// used to swallow per-repo failures, so a rate-limited token returned
-// ok:true with "0 manifests". These drive the full function through
-// mocked octokit calls.
-describe('createScanFromGithub rate-limit short-circuit (ASK-167)', () => {
+// Regression tests: the bulk loop in createScanFromGithub used to
+// swallow per-repo failures, so a rate-limited token returned ok:true
+// with "0 manifests". These drive the full function through mocked
+// octokit calls.
+describe('createScanFromGithub rate-limit short-circuit', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })

--- a/packages/cli/test/unit/commands/scan/create-scan-from-github.test.mts
+++ b/packages/cli/test/unit/commands/scan/create-scan-from-github.test.mts
@@ -51,6 +51,10 @@ const mockWithGitHubRetry = vi.hoisted(() =>
 
 // Mock dependencies.
 vi.mock('../../../../src/utils/git/github.mts', () => ({
+  GITHUB_ERR_ABUSE_DETECTION: 'GitHub abuse detection triggered',
+  GITHUB_ERR_AUTH_FAILED: 'GitHub authentication failed',
+  GITHUB_ERR_GRAPHQL_RATE_LIMIT: 'GitHub GraphQL rate limit exceeded',
+  GITHUB_ERR_RATE_LIMIT: 'GitHub rate limit exceeded',
   getOctokit: vi.fn(() => mockOctokit),
   withGitHubRetry: mockWithGitHubRetry,
 }))

--- a/packages/cli/test/unit/commands/scan/create-scan-from-github.test.mts
+++ b/packages/cli/test/unit/commands/scan/create-scan-from-github.test.mts
@@ -473,6 +473,64 @@ describe('createScanFromGithub rate-limit short-circuit', () => {
     expect(mockWithGitHubRetry).toHaveBeenCalledTimes(1)
   })
 
+  it('returns ok:false and stops on GitHub GraphQL rate limit', async () => {
+    mockWithGitHubRetry.mockResolvedValueOnce({
+      ok: false,
+      message: 'GitHub GraphQL rate limit exceeded',
+      cause: 'GraphQL rate limit hit.',
+    })
+
+    const { createScanFromGithub } = await import(
+      '../../../../src/commands/scan/create-scan-from-github.mts'
+    )
+
+    const result = await createScanFromGithub({
+      all: false,
+      githubApiUrl: '',
+      githubToken: '',
+      interactive: false,
+      orgGithub: 'org',
+      orgSlug: 'org',
+      outputKind: 'text',
+      repos: 'repo-a,repo-b,repo-c',
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.message).toBe('GitHub GraphQL rate limit exceeded')
+    }
+    expect(mockWithGitHubRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns ok:false and stops on GitHub abuse detection', async () => {
+    mockWithGitHubRetry.mockResolvedValueOnce({
+      ok: false,
+      message: 'GitHub abuse detection triggered',
+      cause: 'Secondary rate limit hit.',
+    })
+
+    const { createScanFromGithub } = await import(
+      '../../../../src/commands/scan/create-scan-from-github.mts'
+    )
+
+    const result = await createScanFromGithub({
+      all: false,
+      githubApiUrl: '',
+      githubToken: '',
+      interactive: false,
+      orgGithub: 'org',
+      orgSlug: 'org',
+      outputKind: 'text',
+      repos: 'repo-a,repo-b,repo-c',
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.message).toBe('GitHub abuse detection triggered')
+    }
+    expect(mockWithGitHubRetry).toHaveBeenCalledTimes(1)
+  })
+
   it('returns ok:false and stops on GitHub auth failure', async () => {
     mockWithGitHubRetry.mockResolvedValueOnce({
       ok: false,


### PR DESCRIPTION
## Summary
- The bulk-scan loop in `createScanFromGithub` silently swallowed per-repo failures. A rate-limited GitHub token made every repo fail, yet the outer function returned `ok:true` with "N repos / 0 manifests", misleading users into thinking the scan worked.
- Short-circuit the loop on known blocking errors (rate limit, GraphQL rate limit, abuse detection, auth failure) so subsequent repos don't burn more quota re-hitting the same wall.
- Return an error `CResult` when every repo fails, so scripts can tell the run did not succeed.

## Test plan
- [x] `pnpm --filter @socketsecurity/cli run test:unit test/unit/commands/scan/create-scan-from-github.test.mts` — 16 passed (3 new regression tests)
- [x] `pnpm --filter @socketsecurity/cli run test:unit test/unit/commands/scan/` — 634 passed
- [x] `pnpm run type` — passes
- [x] `pnpm run lint` — passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bulk-scan control flow to short-circuit and return failures on rate-limit/auth conditions, which can alter CLI exit behavior and automation expectations.
> 
> **Overview**
> Fixes `createScanFromGithub` bulk scanning to **stop early and return `ok:false`** when hitting blocking GitHub errors (rate limit, GraphQL rate limit, abuse detection, or auth failure) instead of continuing and reporting misleading "0 manifests" success.
> 
> Also treats the run as an error when *all* repos fail for non-blocking reasons, and updates the summary logging to report repos actually processed. Adds unit regression tests covering rate-limit short-circuiting, auth failure short-circuiting, and the "all repos failed" case (ASK-167).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f7f6491d34bb2690f7b011ebba63d180ed9ec9a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->