### PR TITLE
refactor(error): route uncaught CLI errors through typed-error display

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "oxfmt": "0.37.0",
     "oxlint": "1.52.0",
     "package-builder": "workspace:*",
-    "pony-cause": "catalog:",
     "postject": "catalog:",
     "registry-auth-token": "catalog:",
     "registry-url": "catalog:",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -110,7 +110,6 @@
     "npm-package-arg": "catalog:",
     "open": "catalog:",
     "package-builder": "workspace:*",
-    "pony-cause": "catalog:",
     "registry-auth-token": "catalog:",
     "registry-url": "catalog:",
     "semver": "catalog:",

--- a/packages/cli/src/cli-entry.mts
+++ b/packages/cli/src/cli-entry.mts
@@ -28,7 +28,6 @@ process.emitWarning = function (warning, ...args) {
   return Reflect.apply(originalEmitWarning, this, [warning, ...args])
 }
 
-import { messageWithCauses, stackWithCauses } from 'pony-cause'
 import lookupRegistryAuthToken from 'registry-auth-token'
 import lookupRegistryUrl from 'registry-url'
 
@@ -53,11 +52,10 @@ import { VITEST } from './env/vitest.mts'
 import meow from './meow.mts'
 import { meowWithSubcommands } from './utils/cli/with-subcommands.mts'
 import {
-  AuthError,
-  captureException,
-  InputError,
-} from './utils/error/errors.mts'
-import { failMsgWithBadge } from './utils/error/fail-msg-with-badge.mts'
+  formatErrorForJson,
+  formatErrorForTerminal,
+} from './utils/error/display.mts'
+import { captureException } from './utils/error/errors.mts'
 import { serializeResultJson } from './utils/output/result-json.mts'
 import { runPreflightDownloads } from './utils/preflight/downloads.mts'
 import { isSeaBinary } from './utils/sea/detect.mts'
@@ -181,24 +179,6 @@ void (async () => {
     debug('CLI uncaught error')
     debugDir(e)
 
-    let errorBody: string | undefined
-    let errorTitle: string
-    let errorMessage = ''
-    if (e instanceof AuthError) {
-      errorTitle = 'Authentication error'
-      errorMessage = e.message
-    } else if (e instanceof InputError) {
-      errorTitle = 'Invalid input'
-      errorMessage = e.message
-      errorBody = e.body
-    } else if (e instanceof Error) {
-      errorTitle = 'Unexpected error'
-      errorMessage = messageWithCauses(e)
-      errorBody = stackWithCauses(e)
-    } else {
-      errorTitle = 'Unexpected error with no details'
-    }
-
     // Try to parse the flags, find out if --json is set.
     const isJson = (() => {
       const cli = meow({
@@ -213,20 +193,12 @@ void (async () => {
     })()
 
     if (isJson) {
-      logger.log(
-        serializeResultJson({
-          ok: false,
-          message: errorTitle,
-          cause: errorMessage,
-        }),
-      )
+      logger.log(serializeResultJson(formatErrorForJson(e)))
     } else {
       // Add 2 newlines in stderr to bump below any spinner.
       logger.error('\n')
-      logger.fail(failMsgWithBadge(errorTitle, errorMessage))
-      if (errorBody) {
-        debugDirNs('inspect', { errorBody })
-      }
+      logger.error(formatErrorForTerminal(e))
+      debugDirNs('inspect', { error: e })
     }
 
     await captureException(e)

--- a/packages/cli/src/cli-entry.mts
+++ b/packages/cli/src/cli-entry.mts
@@ -42,6 +42,7 @@ import {
   getSocketCliBootstrapSpec,
 } from '@socketsecurity/lib/env/socket-cli'
 import { getDefaultLogger } from '@socketsecurity/lib/logger'
+import { getDefaultSpinner } from '@socketsecurity/lib/spinner'
 
 import { rootAliases, rootCommands } from './commands.mts'
 import { SOCKET_CLI_BIN_NAME } from './constants/packages.mts'
@@ -174,6 +175,12 @@ void (async () => {
   } catch (e) {
     process.exitCode = 1
 
+    // Stop any active spinner before emitting error output, otherwise
+    // its animation clashes with the error text on the same line.
+    // Spinner-wrapped command paths stop their own on catch, but any
+    // exception that bypasses those handlers reaches us here.
+    getDefaultSpinner()?.stop()
+
     // Track CLI error for telemetry.
     await trackCliError(process.argv, cliStartTime, e, process.exitCode)
     debug('CLI uncaught error')
@@ -195,8 +202,6 @@ void (async () => {
     if (isJson) {
       logger.log(serializeResultJson(formatErrorForJson(e)))
     } else {
-      // Add 2 newlines in stderr to bump below any spinner.
-      logger.error('\n')
       logger.error(formatErrorForTerminal(e))
       debugDirNs('inspect', { error: e })
     }

--- a/packages/cli/src/utils/error/display.mts
+++ b/packages/cli/src/utils/error/display.mts
@@ -2,6 +2,7 @@
 
 import colors from 'yoctocolors-cjs'
 
+import { messageWithCauses } from '@socketsecurity/lib/errors'
 import { LOG_SYMBOLS } from '@socketsecurity/lib/logger'
 import { stripAnsi } from '@socketsecurity/lib/strings'
 
@@ -26,22 +27,18 @@ export type ErrorDisplayOptions = {
 }
 
 /**
- * Append the `.cause` chain (up to 5 levels) to a base message so
- * non-debug users see the diagnostic context from wrapped errors.
- * Typed errors (AuthError, NetworkError, …) can also carry causes.
+ * Append the `.cause` chain to a decorated base message. Typed errors
+ * build their message with suffixes (e.g. ` (HTTP 500)`) before this
+ * is called, so we can't just `messageWithCauses(error)` — we decorate
+ * first, then delegate cause walking to socket-lib.
  */
 function appendCauseChain(baseMessage: string, cause: unknown): string {
-  const plainCauses: string[] = []
-  let walk: unknown = cause
-  let walkDepth = 1
-  while (walk && walkDepth <= 5) {
-    plainCauses.push(walk instanceof Error ? walk.message : String(walk))
-    walk = walk instanceof Error ? walk.cause : undefined
-    walkDepth++
+  if (!cause) {
+    return baseMessage
   }
-  return plainCauses.length
-    ? `${baseMessage}: ${plainCauses.join(': ')}`
-    : baseMessage
+  const causeText =
+    cause instanceof Error ? messageWithCauses(cause) : String(cause)
+  return `${baseMessage}: ${causeText}`
 }
 
 /**

--- a/packages/cli/src/utils/error/display.mts
+++ b/packages/cli/src/utils/error/display.mts
@@ -26,6 +26,25 @@ export type ErrorDisplayOptions = {
 }
 
 /**
+ * Append the `.cause` chain (up to 5 levels) to a base message so
+ * non-debug users see the diagnostic context from wrapped errors.
+ * Typed errors (AuthError, NetworkError, …) can also carry causes.
+ */
+function appendCauseChain(baseMessage: string, cause: unknown): string {
+  const plainCauses: string[] = []
+  let walk: unknown = cause
+  let walkDepth = 1
+  while (walk && walkDepth <= 5) {
+    plainCauses.push(walk instanceof Error ? walk.message : String(walk))
+    walk = walk instanceof Error ? walk.cause : undefined
+    walkDepth++
+  }
+  return plainCauses.length
+    ? `${baseMessage}: ${plainCauses.join(': ')}`
+    : baseMessage
+}
+
+/**
  * Format an error for display with polish and clarity.
  * Uses LOG_SYMBOLS and colors for visual hierarchy.
  */
@@ -47,50 +66,38 @@ export function formatErrorForDisplay(
     if (error.retryAfter) {
       message += ` (retry after ${error.retryAfter}s)`
     }
+    message = appendCauseChain(message, error.cause)
   } else if (error instanceof AuthError) {
     title = 'Authentication error'
-    message = error.message
+    message = appendCauseChain(error.message, error.cause)
   } else if (error instanceof NetworkError) {
     title = 'Network error'
     message = error.message
     if (error.statusCode) {
       message += ` (HTTP ${error.statusCode})`
     }
+    message = appendCauseChain(message, error.cause)
   } else if (error instanceof FileSystemError) {
     title = 'File system error'
     message = error.message
     if (error.path) {
       message += ` (${error.path})`
     }
+    message = appendCauseChain(message, error.cause)
   } else if (error instanceof ConfigError) {
     title = 'Configuration error'
     message = error.message
     if (error.configKey) {
       message += ` (key: ${error.configKey})`
     }
+    message = appendCauseChain(message, error.cause)
   } else if (error instanceof InputError) {
     title = 'Invalid input'
-    message = error.message
+    message = appendCauseChain(error.message, error.cause)
     body = error.body
   } else if (error instanceof Error) {
     title = opts.title || 'Unexpected error'
-    // Concatenate the cause chain into `message` (what non-debug users see)
-    // so diagnostic context from wrapped errors isn't silently dropped.
-    // `showStack` adds a richer formatted body with stack traces below.
-    message = error.message
-    const plainCauses: string[] = []
-    let walk: unknown = error.cause
-    let walkDepth = 1
-    while (walk && walkDepth <= 5) {
-      plainCauses.push(
-        walk instanceof Error ? walk.message : String(walk),
-      )
-      walk = walk instanceof Error ? walk.cause : undefined
-      walkDepth++
-    }
-    if (plainCauses.length) {
-      message = `${message}: ${plainCauses.join(': ')}`
-    }
+    message = appendCauseChain(error.message, error.cause)
 
     if (showStack && error.stack) {
       // Format stack trace with proper indentation.

--- a/packages/cli/src/utils/error/display.mts
+++ b/packages/cli/src/utils/error/display.mts
@@ -74,7 +74,23 @@ export function formatErrorForDisplay(
     body = error.body
   } else if (error instanceof Error) {
     title = opts.title || 'Unexpected error'
+    // Concatenate the cause chain into `message` (what non-debug users see)
+    // so diagnostic context from wrapped errors isn't silently dropped.
+    // `showStack` adds a richer formatted body with stack traces below.
     message = error.message
+    const plainCauses: string[] = []
+    let walk: unknown = error.cause
+    let walkDepth = 1
+    while (walk && walkDepth <= 5) {
+      plainCauses.push(
+        walk instanceof Error ? walk.message : String(walk),
+      )
+      walk = walk instanceof Error ? walk.cause : undefined
+      walkDepth++
+    }
+    if (plainCauses.length) {
+      message = `${message}: ${plainCauses.join(': ')}`
+    }
 
     if (showStack && error.stack) {
       // Format stack trace with proper indentation.

--- a/packages/cli/src/utils/socket/api.mts
+++ b/packages/cli/src/utils/socket/api.mts
@@ -55,6 +55,7 @@ import {
 } from '../ecosystem/requirements.mts'
 import {
   buildErrorCause,
+  ConfigError,
   getNetworkErrorDiagnostics,
 } from '../error/errors.mts'
 
@@ -383,7 +384,10 @@ export async function handleApiCallNoSpinner<T extends SocketSdkOperations>(
 export async function queryApi(path: string, apiToken: string) {
   const baseUrl = getDefaultApiBaseUrl()
   if (!baseUrl) {
-    throw new Error('Socket API base URL is not configured.')
+    throw new ConfigError(
+      'Socket API base URL is not configured.',
+      CONFIG_KEY_API_BASE_URL,
+    )
   }
 
   return await socketHttpRequest(

--- a/packages/cli/src/utils/socket/api.mts
+++ b/packages/cli/src/utils/socket/api.mts
@@ -19,10 +19,9 @@
  * - Falls back to configured apiBaseUrl or default API_V0_URL
  */
 
-import { messageWithCauses } from 'pony-cause'
-
 import { debug, debugDir } from '@socketsecurity/lib/debug'
 import { getSocketCliApiBaseUrl } from '@socketsecurity/lib/env/socket-cli'
+import { messageWithCauses } from '@socketsecurity/lib/errors'
 import { httpRequest } from '@socketsecurity/lib/http-request'
 import { getDefaultLogger } from '@socketsecurity/lib/logger'
 import { getDefaultSpinner } from '@socketsecurity/lib/spinner'

--- a/packages/cli/test/unit/utils/error/display.test.mts
+++ b/packages/cli/test/unit/utils/error/display.test.mts
@@ -150,6 +150,38 @@ describe('error/display', () => {
       expect(result.message).toBe('Something went wrong')
     })
 
+    it('preserves Error.cause chain in message without debug mode', () => {
+      // Regression: formatErrorForDisplay used to only surface causes
+      // under showStack/verbose, so non-debug users lost the most useful
+      // diagnostic context. See PR #1238.
+      const inner = new Error('root DNS failure')
+      const middle = new Error('network call failed', { cause: inner })
+      const outer = new Error('API request failed', { cause: middle })
+
+      const result = formatErrorForDisplay(outer)
+
+      expect(result.message).toContain('API request failed')
+      expect(result.message).toContain('network call failed')
+      expect(result.message).toContain('root DNS failure')
+    })
+
+    it('stops walking causes at depth 5 to avoid runaway chains', () => {
+      // Build inside-out so the outer Error sits at index 10 and chains
+      // down through level-9, level-8, ..., level-0.
+      let e: Error | undefined
+      for (let i = 0; i <= 10; i++) {
+        e = new Error(`level-${i}`, e ? { cause: e } : undefined)
+      }
+
+      const result = formatErrorForDisplay(e!)
+
+      // Top message + 5 causes should appear.
+      expect(result.message).toContain('level-10')
+      expect(result.message).toContain('level-5')
+      // Anything beyond depth 5 should have been truncated.
+      expect(result.message).not.toContain('level-4')
+    })
+
     it('uses custom title when provided', () => {
       const error = new Error('Something went wrong')
 

--- a/packages/cli/test/unit/utils/error/display.test.mts
+++ b/packages/cli/test/unit/utils/error/display.test.mts
@@ -151,9 +151,6 @@ describe('error/display', () => {
     })
 
     it('preserves Error.cause chain in message without debug mode', () => {
-      // Regression: formatErrorForDisplay used to only surface causes
-      // under showStack/verbose, so non-debug users lost the most useful
-      // diagnostic context. See PR #1238.
       const inner = new Error('root DNS failure')
       const middle = new Error('network call failed', { cause: inner })
       const outer = new Error('API request failed', { cause: middle })
@@ -166,8 +163,6 @@ describe('error/display', () => {
     })
 
     it('stops walking causes at depth 5 to avoid runaway chains', () => {
-      // Build inside-out so the outer Error sits at index 10 and chains
-      // down through level-9, level-8, ..., level-0.
       let e: Error | undefined
       for (let i = 0; i <= 10; i++) {
         e = new Error(`level-${i}`, e ? { cause: e } : undefined)
@@ -175,10 +170,8 @@ describe('error/display', () => {
 
       const result = formatErrorForDisplay(e!)
 
-      // Top message + 5 causes should appear.
       expect(result.message).toContain('level-10')
       expect(result.message).toContain('level-5')
-      // Anything beyond depth 5 should have been truncated.
       expect(result.message).not.toContain('level-4')
     })
 

--- a/packages/cli/test/unit/utils/error/display.test.mts
+++ b/packages/cli/test/unit/utils/error/display.test.mts
@@ -162,17 +162,17 @@ describe('error/display', () => {
       expect(result.message).toContain('root DNS failure')
     })
 
-    it('stops walking causes at depth 5 to avoid runaway chains', () => {
-      let e: Error | undefined
-      for (let i = 0; i <= 10; i++) {
-        e = new Error(`level-${i}`, e ? { cause: e } : undefined)
-      }
+    it('terminates on cyclic cause chains', () => {
+      const a = new Error('a')
+      const b = new Error('b')
+      ;(a as Error & { cause?: unknown }).cause = b
+      ;(b as Error & { cause?: unknown }).cause = a
 
-      const result = formatErrorForDisplay(e!)
+      const result = formatErrorForDisplay(a)
 
-      expect(result.message).toContain('level-10')
-      expect(result.message).toContain('level-5')
-      expect(result.message).not.toContain('level-4')
+      expect(result.message).toContain('a')
+      expect(result.message).toContain('b')
+      expect(result.message).toContain('...')
     })
 
     it('uses custom title when provided', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,9 +391,6 @@ catalogs:
     open:
       specifier: 10.2.0
       version: 10.2.0
-    pony-cause:
-      specifier: 2.1.11
-      version: 2.1.11
     postject:
       specifier: 1.0.0-alpha.6
       version: 1.0.0-alpha.6
@@ -702,9 +699,6 @@ importers:
       package-builder:
         specifier: workspace:*
         version: link:packages/package-builder
-      pony-cause:
-        specifier: 'catalog:'
-        version: 2.1.11
       postject:
         specifier: 'catalog:'
         version: 1.0.0-alpha.6
@@ -900,9 +894,6 @@ importers:
       package-builder:
         specifier: workspace:*
         version: link:../package-builder
-      pony-cause:
-        specifier: 'catalog:'
-        version: 2.1.11
       registry-auth-token:
         specifier: 'catalog:'
         version: 5.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -116,7 +116,6 @@ catalog:
   oxlint: 1.52.0
   packageurl-js: npm:@socketregistry/packageurl-js@^1.4.2
   path-parse: npm:@socketregistry/path-parse@^1.0.8
-  pony-cause: 2.1.11
   postject: 1.0.0-alpha.6
   react: 19.2.0
   react-reconciler: 0.33.0


### PR DESCRIPTION
## Summary
- The typed-error classes in `utils/error/errors.mts` (`AuthError`, `InputError`, `ConfigError`, `NetworkError`, `FileSystemError`, `RateLimitError`) plus `formatErrorForDisplay` / `formatErrorForTerminal` / `formatErrorForJson` were only exercised by tests — `cli-entry.mts` used its own inline `if/else` dispatch that handled only `AuthError` / `InputError` / `Error`.
- Replace the inline dispatch in `cli-entry.mts` with `formatErrorForTerminal` / `formatErrorForJson`, so any typed error thrown in production now gets consistent titles, recovery suggestions, and JSON/text formatting (including `Caused by [N]:` chain walking and `Suggested actions:` blocks).
- Convert `queryApi`'s "Socket API base URL is not configured" throw from a generic `Error` to a `ConfigError` keyed on `CONFIG_KEY_API_BASE_URL`. Users now see recovery suggestions directing them to `socket config set` instead of a bare stack trace.

The remaining typed classes (`NetworkError`, `FileSystemError`, `RateLimitError`) stay parked — forcing them into current `CResult`-returning sites would be a larger refactor and isn't needed for the display wiring itself to work. They slot in automatically the moment any throw site adopts them.

## Test plan
- [x] `pnpm --filter @socketsecurity/cli run test:unit test/unit/utils/error/` — 144 passed
- [x] `pnpm --filter @socketsecurity/cli run test:unit test/unit/utils/socket/` — 189 passed
- [x] `pnpm --filter @socketsecurity/cli run test:unit` — 5104 passed
- [x] `pnpm run type` — passes
- [x] `pnpm run lint` — passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CLI’s top-level exception handler and JSON/terminal error payloads, which may affect automation that parses output and alters user-facing diagnostics. Risk is limited to error-reporting paths (no auth/data-flow changes).
> 
> **Overview**
> **Uncaught CLI errors are now formatted via the shared typed-error display layer** instead of an inline `if/else` in `cli-entry.mts`, producing consistent terminal output and `--json` payloads across error types.
> 
> **Spinner/error output interaction is fixed** by stopping any active default spinner before printing top-level error text.
> 
> **Error diagnostics are improved** by including an `Error.cause` chain in the non-verbose message (depth-limited), with new unit tests covering cause preservation and truncation.
> 
> **Misconfiguration handling is made actionable** by changing `queryApi` to throw `ConfigError(CONFIG_KEY_API_BASE_URL)` when the API base URL is missing, enabling recovery suggestions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1525c5e336b6345d13462cb290098a8a017234d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->