### PR TITLE
fix(test): pass --passWithNoTests to vitest

### DIFF
--- a/packages/cli/scripts/test-wrapper.mts
+++ b/packages/cli/scripts/test-wrapper.mts
@@ -144,9 +144,13 @@ async function main() {
       ...(WIN32 ? { shell: true } : {}),
     }
 
+    // --passWithNoTests: a scoped run where the expanded args don't
+    // resolve to any test file should succeed rather than error with
+    // "No test files found". Keeps pre-commit hooks passing when an edit
+    // touches only non-testable code.
     const result = await spawn(
       vitestPath,
-      ['run', ...expandedArgs],
+      ['run', '--passWithNoTests', ...expandedArgs],
       spawnOptions,
     )
     process.exitCode = result?.code || 0

--- a/packages/cli/scripts/test-wrapper.mts
+++ b/packages/cli/scripts/test-wrapper.mts
@@ -153,7 +153,9 @@ async function main() {
       ['run', '--passWithNoTests', ...expandedArgs],
       spawnOptions,
     )
-    process.exitCode = result?.code || 0
+    // `code === null` means the process was killed by a signal — treat
+    // as a failure so SIGKILL / SIGABRT aren't silently reported as 0.
+    process.exitCode = typeof result?.code === 'number' ? result.code : 1
   } catch (e) {
     logger.error('Failed to spawn test process:', e)
     process.exitCode = 1


### PR DESCRIPTION
## Summary

- When a scoped test run (pre-commit hook with \`--staged\`, or an edit that doesn't touch testable code) produces glob/arg patterns that match no test files, \`vitest\` exits with code 1 and "No test files found".
- That's a false failure — a scope that happens to produce zero matches should succeed, not block a commit.
- Add \`--passWithNoTests\` to the vitest args in \`packages/cli/scripts/test-wrapper.mts\` so the exit code reflects actual test outcomes.

## Context

This is part of a cross-repo consistency pass — the same fix has been applied to socket-btm, socket-lib, socket-registry, socket-sdxgen, socket-packageurl-js, socket-tui, and socket-repo-template. socket-sdk-js has its own PR: https://github.com/SocketDev/socket-sdk-js/pull/598

## Test plan

- [ ] Run \`pnpm test\` on a change that only touches non-test files (e.g. a README edit) — should no longer error
- [ ] Run \`pnpm test\` that does touch tests — should still run and fail/pass correctly
- [ ] Pre-commit hook passes on commits that don't affect tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the Vitest invocation flag so scoped runs with zero matched tests exit successfully; no production code paths are affected.
> 
> **Overview**
> Updates the CLI `test-wrapper.mts` to always run Vitest with `--passWithNoTests`, so scoped/globbed test runs that match no files no longer fail with a non-zero exit code.
> 
> Adds a short inline comment explaining the pre-commit/scoped-run motivation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5748ddf3fdf0bb5e4ec938caeaa3e0de08116e49. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->