### PR TITLE
docs(claude): add Promise.race handler-stacking rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ If user repeats instruction 2+ times, ask: "Should I add this to CLAUDE.md?"
 - Backward Compatibility: 🚨 FORBIDDEN to maintain — actively remove when encountered
 - Safe Deletion: Use `safeDelete()` from `@socketsecurity/lib/fs` (NEVER `fs.rm/rmSync` or `rm -rf`)
 - HTTP Requests: NEVER use `fetch()` — use `httpJson`/`httpText`/`httpRequest` from `@socketsecurity/lib/http-request`
+- `Promise.race` / `Promise.any`: NEVER pass a long-lived promise (interrupt signal, pool member) into a race inside a loop. Each call re-attaches `.then` handlers to every arm; handlers accumulate on surviving promises until they settle. For concurrency limiters, use a single-waiter "slot available" signal (resolved by each task's `.then`) instead of re-racing `executing[]`. See nodejs/node#17469 and `@watchable/unpromise`. Race with two fresh arms (e.g. one-shot `withTimeout`) is safe.
 - File existence: ALWAYS `existsSync` from `node:fs`. NEVER `fs.access`, `fs.stat`-for-existence, or an async `fileExists` wrapper. Import: `import { existsSync, promises as fs } from 'node:fs'`.
 
 ### Documentation Policy


### PR DESCRIPTION
## Summary

- Adds a concise rule under SHARED STANDARDS documenting the `Promise.race` / `Promise.any` handler-stacking anti-pattern described in [nodejs/node#17469](https://github.com/nodejs/node/issues/17469) and [@watchable/unpromise](https://github.com/cefn/watchable/tree/main/packages/unpromise).
- Preventive, not reactive — no current socket-cli code exhibits the pattern. Prompted by fixes in sibling repos where the same pattern had crept in: socket-sdk-js#600 and socket-lib#184.

## Test plan

- [ ] Docs-only change — no test plan required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change in `CLAUDE.md`; no runtime or behavioral impact beyond updated engineering guidance.
> 
> **Overview**
> Adds a new **SHARED STANDARDS** guideline in `CLAUDE.md` warning against using `Promise.race`/`Promise.any` with long-lived promises inside loops due to accumulating `.then` handlers, and recommends safer concurrency-limiter signaling patterns (with references to nodejs/node#17469 and `@watchable/unpromise`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c89ed2ee5680e4a288ea1ad82892c3a319cd9dd9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->