### PR TITLE
upgrading coana to version 14.12.219

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.85](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.85) - 2026-04-20
+
+### Changed
+- Updated the Coana CLI to v `14.12.219`.
+
 ## [1.1.84](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.84) - 2026-04-17
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.84",
+  "version": "1.1.85",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -97,7 +97,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.218",
+    "@coana-tech/cli": "14.12.219",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.218
-        version: 14.12.218
+        specifier: 14.12.219
+        version: 14.12.219
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@14.12.218':
-    resolution: {integrity: sha512-9LIEYEt1j6kOTm8EPnofCLXhIqwn4D234NqeImhJdfVJjz6rSHR0tDdAO9Qw9Lhdo4o2vQLhJ4ZffuaST/f3+Q==}
+  '@coana-tech/cli@14.12.219':
+    resolution: {integrity: sha512-66zjhIEY+Of1RY4WOAxup1lDUWxTxrcguGvcAIKdlWubHjNU3gim6dICtUCZpwxsGVuOBVPqHGw+1E2yfEUwkg==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5385,7 +5385,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@14.12.218': {}
+  '@coana-tech/cli@14.12.219': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 14.12.218 to 14.12.219

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only bump: updates the bundled Coana CLI and related lockfile metadata without changing application logic.
> 
> **Overview**
> Bumps the release to `1.1.85` and upgrades `@coana-tech/cli` from `14.12.218` to `14.12.219` (with corresponding `pnpm-lock.yaml` updates).
> 
> Updates `CHANGELOG.md` to document the Coana CLI version bump for this release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1a968fcc96c9c9eda20c16eb37bc41519847184. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->