### PR TITLE
docs(claude): default to perfectionist mindset when user is silent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ The umbrella rule: never run a git command that mutates state belonging to a pat
 - Do not add features, refactor, or make improvements beyond what was asked
 - Simplest approach first; flag architectural flaws and wait for approval
 - When asked to "make a plan," output only the plan — no code until given the go-ahead
+- **Default to perfectionist mindset**: when you have latitude to choose, pick the maximally correct option — no shortcuts, no cosmetic deferrals. Fix state that *looks* stale even if not load-bearing. If pragmatism is the right call, the user will ask for it explicitly. "Works now" ≠ "right."
 
 ## COMPLETION PROTOCOL
 
@@ -82,7 +83,7 @@ The umbrella rule: never run a git command that mutates state belonging to a pat
 
 ## SELF-EVALUATION
 
-- Present two views before calling done: what a perfectionist would reject vs. what a pragmatist would ship
+- Before calling anything done: present both views — what a perfectionist would reject vs. what a pragmatist would ship — and let the user choose. If the user gives no signal, default to perfectionist: do the fuller fix.
 - After fixing a bug: explain why it happened and what category of bug it represents
 - If a fix fails twice: stop, re-read top-down, state where the mental model was wrong
 - If asked to "step back": drop everything, rethink from scratch


### PR DESCRIPTION
## Summary

Adds "Default to perfectionist mindset" directive to the judgment guidance and updates self-evaluation to default to perfectionist when the user gives no signal between the two views.

Rolled out consistently across the Socket fleet (socket-registry, socket-btm, sdxgen, stuie, ultrathink, socket-lib, socket-packageurl-js, socket-repo-template).

## Test plan

- [x] Grep confirms both "Default to perfectionist" additions land in the intended sections

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates contributor/agent guidance without affecting runtime behavior.
> 
> **Overview**
> Updates `CLAUDE.md` to **explicitly default to a “perfectionist mindset”** when there’s latitude in implementation choices (favoring maximally correct fixes over “works now”).
> 
> Adjusts the self-evaluation guidance to require presenting both *perfectionist vs pragmatist* shipping options, and to default to the perfectionist path when the user provides no preference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35d70b553f19b35c6a80a3b183492b839688c7e1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->