### PR TITLE
chore(ci): bump socket-registry refs to main (6e347cee)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@a5923566cd8bcf70aefa1eefacf21f96e328be45 # main
         with:
           checkout: 'false'
 
@@ -168,7 +168,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@a5923566cd8bcf70aefa1eefacf21f96e328be45 # main
         with:
           checkout: 'false'
 
@@ -234,7 +234,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@a5923566cd8bcf70aefa1eefacf21f96e328be45 # main
         with:
           checkout: 'false'
           node-version: ${{ matrix.node-version }}
@@ -310,7 +310,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@a5923566cd8bcf70aefa1eefacf21f96e328be45 # main
         with:
           checkout: 'false'
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
         with:
           checkout: 'false'
 
@@ -168,7 +168,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
         with:
           checkout: 'false'
 
@@ -234,7 +234,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
         with:
           checkout: 'false'
           node-version: ${{ matrix.node-version }}
@@ -310,7 +310,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
         with:
           checkout: 'false'
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
         with:
           checkout: 'false'
 
@@ -168,7 +168,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
         with:
           checkout: 'false'
 
@@ -234,7 +234,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
         with:
           checkout: 'false'
           node-version: ${{ matrix.node-version }}
@@ -310,7 +310,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
         with:
           checkout: 'false'
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@a5923566cd8bcf70aefa1eefacf21f96e328be45 # main
         with:
           checkout: 'false'
 
@@ -91,7 +91,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@a5923566cd8bcf70aefa1eefacf21f96e328be45 # main
         with:
           checkout: 'false'
           registry-url: 'https://registry.npmjs.org'
@@ -141,7 +141,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@a5923566cd8bcf70aefa1eefacf21f96e328be45 # main
         with:
           checkout: 'false'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
         with:
           checkout: 'false'
 
@@ -91,7 +91,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
         with:
           checkout: 'false'
           registry-url: 'https://registry.npmjs.org'
@@ -141,7 +141,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
         with:
           checkout: 'false'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
         with:
           checkout: 'false'
 
@@ -91,7 +91,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
         with:
           checkout: 'false'
           registry-url: 'https://registry.npmjs.org'
@@ -141,7 +141,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
         with:
           checkout: 'false'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@a5923566cd8bcf70aefa1eefacf21f96e328be45 # main
         with:
           checkout: 'false'
 
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@a5923566cd8bcf70aefa1eefacf21f96e328be45 # main
         with:
           checkout: 'false'
 
@@ -79,7 +79,7 @@ jobs:
           git checkout -b "$BRANCH_NAME" HEAD~1
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@46132ceb75d2efd44bb0af38504101366f73ca68 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@a5923566cd8bcf70aefa1eefacf21f96e328be45 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -332,7 +332,7 @@ jobs:
             test.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@46132ceb75d2efd44bb0af38504101366f73ca68 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@a5923566cd8bcf70aefa1eefacf21f96e328be45 # main
         if: always()
 
   notify:

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
         with:
           checkout: 'false'
 
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@46132ceb75d2efd44bb0af38504101366f73ca68 # main
         with:
           checkout: 'false'
 
@@ -79,7 +79,7 @@ jobs:
           git checkout -b "$BRANCH_NAME" HEAD~1
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@6e347cee8d7112844a65016f60afe6761f187551 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@46132ceb75d2efd44bb0af38504101366f73ca68 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -332,7 +332,7 @@ jobs:
             test.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@6e347cee8d7112844a65016f60afe6761f187551 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@46132ceb75d2efd44bb0af38504101366f73ca68 # main
         if: always()
 
   notify:

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
         with:
           checkout: 'false'
 
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@6e347cee8d7112844a65016f60afe6761f187551 # main
         with:
           checkout: 'false'
 
@@ -79,7 +79,7 @@ jobs:
           git checkout -b "$BRANCH_NAME" HEAD~1
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@6e347cee8d7112844a65016f60afe6761f187551 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -332,7 +332,7 @@ jobs:
             test.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@6e347cee8d7112844a65016f60afe6761f187551 # main
         if: always()
 
   notify:


### PR DESCRIPTION
## Summary
- Picks up pinned sfw download fix in `SocketDev/socket-registry/.github/actions/setup`.

## Test plan
- [x] CI workflows re-run against the pinned setup action

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low code risk, but it changes the pinned `SocketDev/socket-registry` composite actions used across CI/publish/update workflows, which could alter build/install behavior and impact CI or release pipelines if the upstream action change is unexpected.
> 
> **Overview**
> Updates GitHub Actions workflows to use a newer pinned commit (`6e347cee…`) for `SocketDev/socket-registry` shared actions (notably `setup-and-install`, plus git-signing setup/cleanup in the weekly updater).
> 
> This refreshes the CI, publish/provenance, and weekly dependency update pipelines to pick up upstream fixes/behavior changes from the shared action implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5258077d6cf62ab9fd5c9e43a4034d2f591d6c17. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->