### PR TITLE
chore(config): drop resolutionMode: highest

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,3 @@
-
 packages:
   - packages/*
   - '!packages/package-builder/build'
@@ -218,7 +217,6 @@ patchedDependencies:
   execa@2.1.0: patches/execa@2.1.0.patch
   execa@5.1.1: patches/execa@5.1.1.patch
   node-gyp@12.2.0: patches/node-gyp@12.2.0.patch
-resolutionMode: highest
 saveExact: true
 strictPeerDependencies: true
 trustPolicy: no-downgrade


### PR DESCRIPTION
## Summary

- Remove \`resolutionMode: highest\` from \`pnpm-workspace.yaml\`.
- Added in #1198 specifically to work around pnpm v11 \`ERR_PNPM_MISSING_TIME\` (upstream: pnpm/pnpm#11238).
- Fixed upstream in pnpm 11.0.0-rc.2 by #11293, which introduced \`minimumReleaseAgeIgnoreMissingTime\` (default \`true\`) — pnpm now emits a warn-once instead of throwing when registry metadata lacks the \`time\` field.
- We pin ≥ rc.2, so v11's default \`time-based\` resolution works again. Removing the workaround lets pnpm pick transitive versions based on publication timing (the v11 intended default) instead of \`highest\`.

## Test plan

- [ ] CI green on this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because changing pnpm resolution strategy can alter transitive dependency versions and the resulting lockfile/install output across the monorepo.
> 
> **Overview**
> Drops `resolutionMode: highest` from `pnpm-workspace.yaml`, allowing pnpm v11 to use its default *time-based* resolution instead of forcing the highest available versions.
> 
> This may change which transitive versions get selected on install (and thus `pnpm-lock.yaml`/CI reproducibility) even though no runtime code is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adc5b7ecc9a296430159292cb683a1471a8eeff8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->