### PR TITLE
fix(deps): bump nanotar 0.2.0 → 0.2.1 to patch CVE-2025-69874

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,8 +199,8 @@ catalogs:
       specifier: 5.5.0
       version: 5.5.0
     nanotar:
-      specifier: 0.2.0
-      version: 0.2.0
+      specifier: 0.2.1
+      version: 0.2.1
     nock:
       specifier: 14.0.10
       version: 14.0.10
@@ -496,7 +496,7 @@ importers:
         version: 5.5.0
       nanotar:
         specifier: 'catalog:'
-        version: 0.2.0
+        version: 0.2.1
       nock:
         specifier: 'catalog:'
         version: 14.0.10
@@ -725,7 +725,7 @@ importers:
         version: 4.0.8
       nanotar:
         specifier: 'catalog:'
-        version: 0.2.0
+        version: 0.2.1
       npm-package-arg:
         specifier: 13.0.0
         version: 13.0.0
@@ -2151,7 +2151,6 @@ packages:
 
   '@socketaddon/iocraft@file:packages/package-builder/build/dev/out/socketaddon-iocraft':
     resolution: {directory: packages/package-builder/build/dev/out/socketaddon-iocraft, type: directory}
-    engines: {node: '>=18'}
 
   '@socketregistry/es-set-tostringtag@1.0.10':
     resolution: {integrity: sha512-btXmvw1JpA8WtSoXx9mTapo9NAyIDKRRzK84i48d8zc0X09M6ORfobVnHbgwhXf7CFhkRzhYrHG9dqbI9vpELQ==}
@@ -3484,8 +3483,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanotar@0.2.0:
-    resolution: {integrity: sha512-9ca1h0Xjvo9bEkE4UOxgAzLV0jHKe6LMaxo37ND2DAhhAtd0j8pR1Wxz+/goMrZO8AEZTWCmyaOsFI/W5AdpCQ==}
+  nanotar@0.2.1:
+    resolution: {integrity: sha512-MUrzzDUcIOPbv7ubhDV/L4CIfVTATd9XhDE2ixFeCrM5yp9AlzUpn91JrnN0HD6hksdxvz9IW9aKANz0Bta0GA==}
 
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
@@ -6987,7 +6986,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  nanotar@0.2.0: {}
+  nanotar@0.2.1: {}
 
   napi-build-utils@2.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -102,7 +102,7 @@ catalog:
   magic-string: 0.30.19
   micromatch: 4.0.8
   mock-fs: 5.5.0
-  nanotar: 0.2.0
+  nanotar: 0.2.1
   nock: 14.0.10
   npm-package-arg: 13.0.0
   npm-run-all2: 8.0.4


### PR DESCRIPTION
## Summary

Patches [Dependabot alert #97](https://github.com/SocketDev/socket-cli/security/dependabot/97) — `nanotar` ≤ 0.2.0 is vulnerable to path traversal in `parseTar()` / `parseTarGzip()` (GHSA-92fh-27vv-894w, CVE-2025-69874, medium severity).

Upstream shipped `0.2.1` as a backport patch minutes after releasing `0.3.0`, so `0.2.1` keeps us on the `0.2.x` line with only the path-sanitization fix applied ([unjs/nanotar#58](https://github.com/unjs/nanotar/pull/58)). Chose `0.2.1` over `0.3.0` to minimize unrelated changes; a later PR can bump to `0.3.0` once that's been exercised in other consumers.

## Test plan

- [x] `pnpm-workspace.yaml` catalog entry bumped.
- [x] `pnpm install` regenerates `pnpm-lock.yaml` with `nanotar@0.2.1` (no other dep churn).
- [ ] CI green on this PR.
- [ ] Dependabot alert #97 auto-resolves after merge.

## Note on sequencing

PR #1249 (fleet-wide pnpm rc.5 alignment) also touches `pnpm-workspace.yaml`. Whichever of the two merges first, the other will need a trivial rebase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; behavior impact is limited to `nanotar` tar parsing, though it could affect any code paths that extract archives.
> 
> **Overview**
> Updates the workspace dependency catalog and lockfile to use `nanotar@0.2.1` instead of `0.2.0`, pulling in the upstream patch for the reported path traversal issue.
> 
> No application/source code changes; the diff is limited to `pnpm-workspace.yaml` and `pnpm-lock.yaml` version/resolution updates (including integrity hash refresh).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34cc060a78c8cdbfe160f27d4f3e8478bf323c69. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->