### PR TITLE
fix(ci): pin sfw download tag, swap SOCKET_API_TOKEN secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }} # zizmor: ignore[secrets-outside-env]
         run: | # zizmor: ignore[github-env]
+          # Pinned version + per-platform checksum pairs. Bumping a tool
+          # requires updating the matching version AND every platform's
+          # SHA256 in the same commit, otherwise the download / verify
+          # steps will diverge.
+          SFW_FREE_VERSION="1.7.2"
+          SFW_ENTERPRISE_VERSION="1.7.2"
           SFW_DIR="${RUNNER_TEMP:-/tmp}/sfw-bin"
           KERNEL="$(uname -s | cut -d- -f1)"
           ARCH="$(uname -m)"
@@ -126,33 +132,39 @@ jobs:
           [ -n "$SOCKET_API_KEY" ] && USE_ENTERPRISE=true
           if [ "$USE_ENTERPRISE" = "true" ]; then
             REPO="SocketDev/firewall-release"
+            SFW_VERSION="$SFW_ENTERPRISE_VERSION"
             case "${KERNEL}-${ARCH}" in
-              Linux-x86_64)                      ASSET="sfw-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="9115b4ca8021eb173eb9e9c3627deb7f1066f8debd48c5c9d9f3caabb2a26a4b" ;;
-              Linux-aarch64)                     ASSET="sfw-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="671270231617142404a1564e52672f79b806f9df3f232fcc7606329c0246da55" ;;
-              Darwin-x86_64)                     ASSET="sfw-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="01d64d40effda35c31f8d8ee1fed1388aac0a11aba40d47fba8a36024b77500c" ;;
-              Darwin-arm64)                      ASSET="sfw-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="acad0b517601bb7408e2e611c9226f47dcccbd83333d7fc5157f1d32ed2b953d" ;;
-              MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="9a50e1ddaf038138c3f85418dc5df0113bbe6fc884f5abe158beaa9aea18d70a" ;;
+              Linux-x86_64)                      ASSET="sfw-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="4482b52e6367bd4610519bfd57a104d5907ec87d5399142ed3bb3d222de1f33d" ;;
+              Linux-aarch64)                     ASSET="sfw-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="c24a79c27e1a01a59b7a160c165930ae029816c72b141fcfcdb2f73e0774898a" ;;
+              Darwin-x86_64)                     ASSET="sfw-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="da252d2a9a5d0edb271bb771e0d01b9cd6fa1635b6d765f61efd61edb6739f12" ;;
+              Darwin-arm64)                      ASSET="sfw-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="b1cdc3bdbd2a3161247bd5cc215eb3c44a90b87fe0b800a33889a14f61bb0d6d" ;;
+              MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="e52ad806a1c41b440f04098eb1c7e407845f03f5740a6a79006ba6fd172056ec" ;;
               *) echo "Unsupported platform: ${KERNEL}-${ARCH}" >&2; exit 1 ;;
             esac
           else
             REPO="SocketDev/sfw-free"
+            SFW_VERSION="$SFW_FREE_VERSION"
             case "${KERNEL}-${ARCH}" in
-              Linux-x86_64)                      ASSET="sfw-free-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="4a1e8b65e90fce7d5fd066cf0af6c93d512065fa4222a475c8d959a6bc14b9ff" ;;
-              Linux-aarch64)                     ASSET="sfw-free-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="df2eedb2daf2572eee047adb8bfd81c9069edcb200fc7d3710fca98ec3ca81a1" ;;
-              Darwin-x86_64)                     ASSET="sfw-free-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="724ccea19d847b79db8cc8e38f5f18ce2dd32336007f42b11bed7d2e5f4a2566" ;;
-              Darwin-arm64)                      ASSET="sfw-free-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="bf1616fc44ac49f1cb2067fedfa127a3ae65d6ec6d634efbb3098cfa355e5555" ;;
-              MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-free-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="c953e62ad7928d4d8f2302f5737884ea1a757babc26bed6a42b9b6b68a5d54af" ;;
+              Linux-x86_64)                      ASSET="sfw-free-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="93e2d9dfa244b82a74e014dc26b1c6af18b4adec20f35254378943db5fe91411" ;;
+              Linux-aarch64)                     ASSET="sfw-free-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="84a045e4e1bb320cc5c0d3929f02e53f199398b5be0637e8846d02d9ef0027b1" ;;
+              Darwin-x86_64)                     ASSET="sfw-free-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="a5427d479d440f08e3789fa191ba57599be64997196daf42e67d964fec0382b4" ;;
+              Darwin-arm64)                      ASSET="sfw-free-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="248fb588e1e1a27e7192f7b079f739fc29a9de61f0bad7e90928363022dc5643" ;;
+              MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-free-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="6d333b4cac9d7c5712e2e99677ca634ac8a3020d550c6308312c60bea97f0a28" ;;
               *) echo "Unsupported platform: ${KERNEL}-${ARCH}" >&2; exit 1 ;;
             esac
           fi
           if [ ! -x "$SFW_BIN" ]; then
             mkdir -p "$SFW_DIR"
-            DOWNLOAD_URL="$(gh api "repos/${REPO}/releases/latest" \
+            DOWNLOAD_URL="$(gh api "repos/${REPO}/releases/tags/v${SFW_VERSION}" \
               --jq ".assets[] | select(.name == \"$ASSET\") | .browser_download_url")"
+            if [ -z "$DOWNLOAD_URL" ]; then
+              echo "Asset ${ASSET} not found in ${REPO}@v${SFW_VERSION}" >&2
+              exit 1
+            fi
             curl -fsSL -o "$SFW_BIN" "$DOWNLOAD_URL"
             ACTUAL_SHA256="$( (sha256sum "$SFW_BIN" 2>/dev/null || shasum -a 256 "$SFW_BIN") | cut -d' ' -f1 | tr -d '\\')"
             if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
-              echo "Checksum mismatch for ${ASSET}!" >&2
+              echo "Checksum mismatch for ${ASSET} (${REPO}@v${SFW_VERSION})!" >&2
               echo "  Expected: ${EXPECTED_SHA256}" >&2
               echo "  Actual:   ${ACTUAL_SHA256}" >&2
               rm -f "$SFW_BIN"
@@ -283,6 +295,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }} # zizmor: ignore[secrets-outside-env]
         run: | # zizmor: ignore[github-env]
+          # Pinned version + per-platform checksum pairs. Bumping a tool
+          # requires updating the matching version AND every platform's
+          # SHA256 in the same commit, otherwise the download / verify
+          # steps will diverge.
+          SFW_FREE_VERSION="1.7.2"
+          SFW_ENTERPRISE_VERSION="1.7.2"
           SFW_DIR="${RUNNER_TEMP:-/tmp}/sfw-bin"
           KERNEL="$(uname -s | cut -d- -f1)"
           ARCH="$(uname -m)"
@@ -290,33 +308,39 @@ jobs:
           [ -n "$SOCKET_API_KEY" ] && USE_ENTERPRISE=true
           if [ "$USE_ENTERPRISE" = "true" ]; then
             REPO="SocketDev/firewall-release"
+            SFW_VERSION="$SFW_ENTERPRISE_VERSION"
             case "${KERNEL}-${ARCH}" in
-              Linux-x86_64)                      ASSET="sfw-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="9115b4ca8021eb173eb9e9c3627deb7f1066f8debd48c5c9d9f3caabb2a26a4b" ;;
-              Linux-aarch64)                     ASSET="sfw-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="671270231617142404a1564e52672f79b806f9df3f232fcc7606329c0246da55" ;;
-              Darwin-x86_64)                     ASSET="sfw-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="01d64d40effda35c31f8d8ee1fed1388aac0a11aba40d47fba8a36024b77500c" ;;
-              Darwin-arm64)                      ASSET="sfw-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="acad0b517601bb7408e2e611c9226f47dcccbd83333d7fc5157f1d32ed2b953d" ;;
-              MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="9a50e1ddaf038138c3f85418dc5df0113bbe6fc884f5abe158beaa9aea18d70a" ;;
+              Linux-x86_64)                      ASSET="sfw-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="4482b52e6367bd4610519bfd57a104d5907ec87d5399142ed3bb3d222de1f33d" ;;
+              Linux-aarch64)                     ASSET="sfw-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="c24a79c27e1a01a59b7a160c165930ae029816c72b141fcfcdb2f73e0774898a" ;;
+              Darwin-x86_64)                     ASSET="sfw-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="da252d2a9a5d0edb271bb771e0d01b9cd6fa1635b6d765f61efd61edb6739f12" ;;
+              Darwin-arm64)                      ASSET="sfw-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="b1cdc3bdbd2a3161247bd5cc215eb3c44a90b87fe0b800a33889a14f61bb0d6d" ;;
+              MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="e52ad806a1c41b440f04098eb1c7e407845f03f5740a6a79006ba6fd172056ec" ;;
               *) echo "Unsupported platform: ${KERNEL}-${ARCH}" >&2; exit 1 ;;
             esac
           else
             REPO="SocketDev/sfw-free"
+            SFW_VERSION="$SFW_FREE_VERSION"
             case "${KERNEL}-${ARCH}" in
-              Linux-x86_64)                      ASSET="sfw-free-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="4a1e8b65e90fce7d5fd066cf0af6c93d512065fa4222a475c8d959a6bc14b9ff" ;;
-              Linux-aarch64)                     ASSET="sfw-free-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="df2eedb2daf2572eee047adb8bfd81c9069edcb200fc7d3710fca98ec3ca81a1" ;;
-              Darwin-x86_64)                     ASSET="sfw-free-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="724ccea19d847b79db8cc8e38f5f18ce2dd32336007f42b11bed7d2e5f4a2566" ;;
-              Darwin-arm64)                      ASSET="sfw-free-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="bf1616fc44ac49f1cb2067fedfa127a3ae65d6ec6d634efbb3098cfa355e5555" ;;
-              MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-free-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="c953e62ad7928d4d8f2302f5737884ea1a757babc26bed6a42b9b6b68a5d54af" ;;
+              Linux-x86_64)                      ASSET="sfw-free-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="93e2d9dfa244b82a74e014dc26b1c6af18b4adec20f35254378943db5fe91411" ;;
+              Linux-aarch64)                     ASSET="sfw-free-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="84a045e4e1bb320cc5c0d3929f02e53f199398b5be0637e8846d02d9ef0027b1" ;;
+              Darwin-x86_64)                     ASSET="sfw-free-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="a5427d479d440f08e3789fa191ba57599be64997196daf42e67d964fec0382b4" ;;
+              Darwin-arm64)                      ASSET="sfw-free-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="248fb588e1e1a27e7192f7b079f739fc29a9de61f0bad7e90928363022dc5643" ;;
+              MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-free-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="6d333b4cac9d7c5712e2e99677ca634ac8a3020d550c6308312c60bea97f0a28" ;;
               *) echo "Unsupported platform: ${KERNEL}-${ARCH}" >&2; exit 1 ;;
             esac
           fi
           if [ ! -x "$SFW_BIN" ]; then
             mkdir -p "$SFW_DIR"
-            DOWNLOAD_URL="$(gh api "repos/${REPO}/releases/latest" \
+            DOWNLOAD_URL="$(gh api "repos/${REPO}/releases/tags/v${SFW_VERSION}" \
               --jq ".assets[] | select(.name == \"$ASSET\") | .browser_download_url")"
+            if [ -z "$DOWNLOAD_URL" ]; then
+              echo "Asset ${ASSET} not found in ${REPO}@v${SFW_VERSION}" >&2
+              exit 1
+            fi
             curl -fsSL -o "$SFW_BIN" "$DOWNLOAD_URL"
             ACTUAL_SHA256="$( (sha256sum "$SFW_BIN" 2>/dev/null || shasum -a 256 "$SFW_BIN") | cut -d' ' -f1 | tr -d '\\')"
             if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
-              echo "Checksum mismatch for ${ASSET}!" >&2
+              echo "Checksum mismatch for ${ASSET} (${REPO}@v${SFW_VERSION})!" >&2
               echo "  Expected: ${EXPECTED_SHA256}" >&2
               echo "  Actual:   ${ACTUAL_SHA256}" >&2
               rm -f "$SFW_BIN"
@@ -452,6 +476,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }} # zizmor: ignore[secrets-outside-env]
         run: | # zizmor: ignore[github-env]
+          # Pinned version + per-platform checksum pairs. Bumping a tool
+          # requires updating the matching version AND every platform's
+          # SHA256 in the same commit, otherwise the download / verify
+          # steps will diverge.
+          SFW_FREE_VERSION="1.7.2"
+          SFW_ENTERPRISE_VERSION="1.7.2"
           SFW_DIR="${RUNNER_TEMP:-/tmp}/sfw-bin"
           KERNEL="$(uname -s | cut -d- -f1)"
           ARCH="$(uname -m)"
@@ -459,33 +489,39 @@ jobs:
           [ -n "$SOCKET_API_KEY" ] && USE_ENTERPRISE=true
           if [ "$USE_ENTERPRISE" = "true" ]; then
             REPO="SocketDev/firewall-release"
+            SFW_VERSION="$SFW_ENTERPRISE_VERSION"
             case "${KERNEL}-${ARCH}" in
-              Linux-x86_64)                      ASSET="sfw-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="9115b4ca8021eb173eb9e9c3627deb7f1066f8debd48c5c9d9f3caabb2a26a4b" ;;
-              Linux-aarch64)                     ASSET="sfw-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="671270231617142404a1564e52672f79b806f9df3f232fcc7606329c0246da55" ;;
-              Darwin-x86_64)                     ASSET="sfw-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="01d64d40effda35c31f8d8ee1fed1388aac0a11aba40d47fba8a36024b77500c" ;;
-              Darwin-arm64)                      ASSET="sfw-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="acad0b517601bb7408e2e611c9226f47dcccbd83333d7fc5157f1d32ed2b953d" ;;
-              MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="9a50e1ddaf038138c3f85418dc5df0113bbe6fc884f5abe158beaa9aea18d70a" ;;
+              Linux-x86_64)                      ASSET="sfw-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="4482b52e6367bd4610519bfd57a104d5907ec87d5399142ed3bb3d222de1f33d" ;;
+              Linux-aarch64)                     ASSET="sfw-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="c24a79c27e1a01a59b7a160c165930ae029816c72b141fcfcdb2f73e0774898a" ;;
+              Darwin-x86_64)                     ASSET="sfw-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="da252d2a9a5d0edb271bb771e0d01b9cd6fa1635b6d765f61efd61edb6739f12" ;;
+              Darwin-arm64)                      ASSET="sfw-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="b1cdc3bdbd2a3161247bd5cc215eb3c44a90b87fe0b800a33889a14f61bb0d6d" ;;
+              MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="e52ad806a1c41b440f04098eb1c7e407845f03f5740a6a79006ba6fd172056ec" ;;
               *) echo "Unsupported platform: ${KERNEL}-${ARCH}" >&2; exit 1 ;;
             esac
           else
             REPO="SocketDev/sfw-free"
+            SFW_VERSION="$SFW_FREE_VERSION"
             case "${KERNEL}-${ARCH}" in
-              Linux-x86_64)                      ASSET="sfw-free-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="4a1e8b65e90fce7d5fd066cf0af6c93d512065fa4222a475c8d959a6bc14b9ff" ;;
-              Linux-aarch64)                     ASSET="sfw-free-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="df2eedb2daf2572eee047adb8bfd81c9069edcb200fc7d3710fca98ec3ca81a1" ;;
-              Darwin-x86_64)                     ASSET="sfw-free-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="724ccea19d847b79db8cc8e38f5f18ce2dd32336007f42b11bed7d2e5f4a2566" ;;
-              Darwin-arm64)                      ASSET="sfw-free-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="bf1616fc44ac49f1cb2067fedfa127a3ae65d6ec6d634efbb3098cfa355e5555" ;;
-              MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-free-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="c953e62ad7928d4d8f2302f5737884ea1a757babc26bed6a42b9b6b68a5d54af" ;;
+              Linux-x86_64)                      ASSET="sfw-free-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="93e2d9dfa244b82a74e014dc26b1c6af18b4adec20f35254378943db5fe91411" ;;
+              Linux-aarch64)                     ASSET="sfw-free-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="84a045e4e1bb320cc5c0d3929f02e53f199398b5be0637e8846d02d9ef0027b1" ;;
+              Darwin-x86_64)                     ASSET="sfw-free-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="a5427d479d440f08e3789fa191ba57599be64997196daf42e67d964fec0382b4" ;;
+              Darwin-arm64)                      ASSET="sfw-free-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="248fb588e1e1a27e7192f7b079f739fc29a9de61f0bad7e90928363022dc5643" ;;
+              MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-free-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="6d333b4cac9d7c5712e2e99677ca634ac8a3020d550c6308312c60bea97f0a28" ;;
               *) echo "Unsupported platform: ${KERNEL}-${ARCH}" >&2; exit 1 ;;
             esac
           fi
           if [ ! -x "$SFW_BIN" ]; then
             mkdir -p "$SFW_DIR"
-            DOWNLOAD_URL="$(gh api "repos/${REPO}/releases/latest" \
+            DOWNLOAD_URL="$(gh api "repos/${REPO}/releases/tags/v${SFW_VERSION}" \
               --jq ".assets[] | select(.name == \"$ASSET\") | .browser_download_url")"
+            if [ -z "$DOWNLOAD_URL" ]; then
+              echo "Asset ${ASSET} not found in ${REPO}@v${SFW_VERSION}" >&2
+              exit 1
+            fi
             curl -fsSL -o "$SFW_BIN" "$DOWNLOAD_URL"
             ACTUAL_SHA256="$( (sha256sum "$SFW_BIN" 2>/dev/null || shasum -a 256 "$SFW_BIN") | cut -d' ' -f1 | tr -d '\\')"
             if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
-              echo "Checksum mismatch for ${ASSET}!" >&2
+              echo "Checksum mismatch for ${ASSET} (${REPO}@v${SFW_VERSION})!" >&2
               echo "  Expected: ${EXPECTED_SHA256}" >&2
               echo "  Actual:   ${ACTUAL_SHA256}" >&2
               rm -f "$SFW_BIN"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -155,5 +155,5 @@ jobs:
 
       - name: Run e2e tests
         env:
-          SOCKET_CLI_API_TOKEN: ${{ secrets.SOCKET_CLI_API_TOKEN }} # zizmor: ignore[secrets-outside-env]
+          SOCKET_CLI_API_TOKEN: ${{ secrets.SOCKET_API_TOKEN }} # zizmor: ignore[secrets-outside-env]
         run: pnpm run e2e-tests

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -70,25 +70,34 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: | # zizmor: ignore[github-env]
+          # Pinned version + per-platform checksum pair. Bumping sfw-free
+          # requires updating SFW_FREE_VERSION AND every platform's
+          # SHA256 in the same commit, otherwise the download / verify
+          # steps will diverge.
+          SFW_FREE_VERSION="1.7.2"
           SFW_DIR="${RUNNER_TEMP:-/tmp}/sfw-bin"
           KERNEL="$(uname -s | cut -d- -f1)"
           ARCH="$(uname -m)"
           case "${KERNEL}-${ARCH}" in
-            Linux-x86_64)                      ASSET="sfw-free-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="4a1e8b65e90fce7d5fd066cf0af6c93d512065fa4222a475c8d959a6bc14b9ff" ;;
-            Linux-aarch64)                     ASSET="sfw-free-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="df2eedb2daf2572eee047adb8bfd81c9069edcb200fc7d3710fca98ec3ca81a1" ;;
-            Darwin-x86_64)                     ASSET="sfw-free-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="724ccea19d847b79db8cc8e38f5f18ce2dd32336007f42b11bed7d2e5f4a2566" ;;
-            Darwin-arm64)                      ASSET="sfw-free-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="bf1616fc44ac49f1cb2067fedfa127a3ae65d6ec6d634efbb3098cfa355e5555" ;;
-            MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-free-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="c953e62ad7928d4d8f2302f5737884ea1a757babc26bed6a42b9b6b68a5d54af" ;;
+            Linux-x86_64)                      ASSET="sfw-free-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="93e2d9dfa244b82a74e014dc26b1c6af18b4adec20f35254378943db5fe91411" ;;
+            Linux-aarch64)                     ASSET="sfw-free-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="84a045e4e1bb320cc5c0d3929f02e53f199398b5be0637e8846d02d9ef0027b1" ;;
+            Darwin-x86_64)                     ASSET="sfw-free-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="a5427d479d440f08e3789fa191ba57599be64997196daf42e67d964fec0382b4" ;;
+            Darwin-arm64)                      ASSET="sfw-free-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="248fb588e1e1a27e7192f7b079f739fc29a9de61f0bad7e90928363022dc5643" ;;
+            MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-free-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="6d333b4cac9d7c5712e2e99677ca634ac8a3020d550c6308312c60bea97f0a28" ;;
             *) echo "Unsupported platform: ${KERNEL}-${ARCH}" >&2; exit 1 ;;
           esac
           if [ ! -x "$SFW_BIN" ]; then
             mkdir -p "$SFW_DIR"
-            DOWNLOAD_URL="$(gh api repos/SocketDev/sfw-free/releases/latest \
+            DOWNLOAD_URL="$(gh api "repos/SocketDev/sfw-free/releases/tags/v${SFW_FREE_VERSION}" \
               --jq ".assets[] | select(.name == \"$ASSET\") | .browser_download_url")"
+            if [ -z "$DOWNLOAD_URL" ]; then
+              echo "Asset ${ASSET} not found in SocketDev/sfw-free@v${SFW_FREE_VERSION}" >&2
+              exit 1
+            fi
             curl -fsSL -o "$SFW_BIN" "$DOWNLOAD_URL"
             ACTUAL_SHA256="$( (sha256sum "$SFW_BIN" 2>/dev/null || shasum -a 256 "$SFW_BIN") | cut -d' ' -f1 | tr -d '\\')"
             if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
-              echo "Checksum mismatch for ${ASSET}!" >&2
+              echo "Checksum mismatch for ${ASSET} (SocketDev/sfw-free@v${SFW_FREE_VERSION})!" >&2
               echo "  Expected: ${EXPECTED_SHA256}" >&2
               echo "  Actual:   ${ACTUAL_SHA256}" >&2
               rm -f "$SFW_BIN"

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -89,6 +89,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }} # zizmor: ignore[secrets-outside-env]
         run: | # zizmor: ignore[github-env]
+          # Pinned version + per-platform checksum pairs. Bumping a tool
+          # requires updating the matching version AND every platform's
+          # SHA256 in the same commit, otherwise the download / verify
+          # steps will diverge.
+          SFW_FREE_VERSION="1.7.2"
+          SFW_ENTERPRISE_VERSION="1.7.2"
           SFW_DIR="${RUNNER_TEMP:-/tmp}/sfw-bin"
           KERNEL="$(uname -s | cut -d- -f1)"
           ARCH="$(uname -m)"
@@ -96,33 +102,39 @@ jobs:
           [ -n "$SOCKET_API_KEY" ] && USE_ENTERPRISE=true
           if [ "$USE_ENTERPRISE" = "true" ]; then
             REPO="SocketDev/firewall-release"
+            SFW_VERSION="$SFW_ENTERPRISE_VERSION"
             case "${KERNEL}-${ARCH}" in
-              Linux-x86_64)                      ASSET="sfw-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="9115b4ca8021eb173eb9e9c3627deb7f1066f8debd48c5c9d9f3caabb2a26a4b" ;;
-              Linux-aarch64)                     ASSET="sfw-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="671270231617142404a1564e52672f79b806f9df3f232fcc7606329c0246da55" ;;
-              Darwin-x86_64)                     ASSET="sfw-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="01d64d40effda35c31f8d8ee1fed1388aac0a11aba40d47fba8a36024b77500c" ;;
-              Darwin-arm64)                      ASSET="sfw-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="acad0b517601bb7408e2e611c9226f47dcccbd83333d7fc5157f1d32ed2b953d" ;;
-              MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="9a50e1ddaf038138c3f85418dc5df0113bbe6fc884f5abe158beaa9aea18d70a" ;;
+              Linux-x86_64)                      ASSET="sfw-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="4482b52e6367bd4610519bfd57a104d5907ec87d5399142ed3bb3d222de1f33d" ;;
+              Linux-aarch64)                     ASSET="sfw-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="c24a79c27e1a01a59b7a160c165930ae029816c72b141fcfcdb2f73e0774898a" ;;
+              Darwin-x86_64)                     ASSET="sfw-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="da252d2a9a5d0edb271bb771e0d01b9cd6fa1635b6d765f61efd61edb6739f12" ;;
+              Darwin-arm64)                      ASSET="sfw-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="b1cdc3bdbd2a3161247bd5cc215eb3c44a90b87fe0b800a33889a14f61bb0d6d" ;;
+              MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="e52ad806a1c41b440f04098eb1c7e407845f03f5740a6a79006ba6fd172056ec" ;;
               *) echo "Unsupported platform: ${KERNEL}-${ARCH}" >&2; exit 1 ;;
             esac
           else
             REPO="SocketDev/sfw-free"
+            SFW_VERSION="$SFW_FREE_VERSION"
             case "${KERNEL}-${ARCH}" in
-              Linux-x86_64)                      ASSET="sfw-free-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="4a1e8b65e90fce7d5fd066cf0af6c93d512065fa4222a475c8d959a6bc14b9ff" ;;
-              Linux-aarch64)                     ASSET="sfw-free-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="df2eedb2daf2572eee047adb8bfd81c9069edcb200fc7d3710fca98ec3ca81a1" ;;
-              Darwin-x86_64)                     ASSET="sfw-free-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="724ccea19d847b79db8cc8e38f5f18ce2dd32336007f42b11bed7d2e5f4a2566" ;;
-              Darwin-arm64)                      ASSET="sfw-free-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="bf1616fc44ac49f1cb2067fedfa127a3ae65d6ec6d634efbb3098cfa355e5555" ;;
-              MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-free-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="c953e62ad7928d4d8f2302f5737884ea1a757babc26bed6a42b9b6b68a5d54af" ;;
+              Linux-x86_64)                      ASSET="sfw-free-linux-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="93e2d9dfa244b82a74e014dc26b1c6af18b4adec20f35254378943db5fe91411" ;;
+              Linux-aarch64)                     ASSET="sfw-free-linux-arm64"         ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="84a045e4e1bb320cc5c0d3929f02e53f199398b5be0637e8846d02d9ef0027b1" ;;
+              Darwin-x86_64)                     ASSET="sfw-free-macos-x86_64"       ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="a5427d479d440f08e3789fa191ba57599be64997196daf42e67d964fec0382b4" ;;
+              Darwin-arm64)                      ASSET="sfw-free-macos-arm64"        ; SFW_BIN="$SFW_DIR/sfw"     ; EXPECTED_SHA256="248fb588e1e1a27e7192f7b079f739fc29a9de61f0bad7e90928363022dc5643" ;;
+              MINGW64_NT-x86_64|MSYS_NT-x86_64) ASSET="sfw-free-windows-x86_64.exe" ; SFW_BIN="$SFW_DIR/sfw.exe" ; EXPECTED_SHA256="6d333b4cac9d7c5712e2e99677ca634ac8a3020d550c6308312c60bea97f0a28" ;;
               *) echo "Unsupported platform: ${KERNEL}-${ARCH}" >&2; exit 1 ;;
             esac
           fi
           if [ ! -x "$SFW_BIN" ]; then
             mkdir -p "$SFW_DIR"
-            DOWNLOAD_URL="$(gh api "repos/${REPO}/releases/latest" \
+            DOWNLOAD_URL="$(gh api "repos/${REPO}/releases/tags/v${SFW_VERSION}" \
               --jq ".assets[] | select(.name == \"$ASSET\") | .browser_download_url")"
+            if [ -z "$DOWNLOAD_URL" ]; then
+              echo "Asset ${ASSET} not found in ${REPO}@v${SFW_VERSION}" >&2
+              exit 1
+            fi
             curl -fsSL -o "$SFW_BIN" "$DOWNLOAD_URL"
             ACTUAL_SHA256="$( (sha256sum "$SFW_BIN" 2>/dev/null || shasum -a 256 "$SFW_BIN") | cut -d' ' -f1 | tr -d '\\')"
             if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
-              echo "Checksum mismatch for ${ASSET}!" >&2
+              echo "Checksum mismatch for ${ASSET} (${REPO}@v${SFW_VERSION})!" >&2
               echo "  Expected: ${EXPECTED_SHA256}" >&2
               echo "  Actual:   ${ACTUAL_SHA256}" >&2
               rm -f "$SFW_BIN"


### PR DESCRIPTION
## Summary

Two small CI fixes for `v1.x`:

1. **Pin `sfw` / `sfw-free` downloads to a version tag** so upstream releases stop breaking our hardcoded checksums.
2. **Swap the `SOCKET_CLI_API_TOKEN` secret reference to `SOCKET_API_TOKEN`** to match the renamed repo secret.

## 1. Pin sfw download to a tag

- Our CI downloads `sfw` / `sfw-free` from the `releases/latest` endpoint, then checks it against a SHA256 we hardcoded. When a new `sfw` release ships upstream, `latest` starts returning new bytes but our hardcoded SHA256 still points at the old bytes, so every job fails with a checksum mismatch.
- This PR pins the download to a specific version tag (`v1.7.2`) so the bytes we download always match the SHA256 we're checking.
- Bumped the pinned checksums to the `v1.7.2` values so we're on the latest release.

### What changed

- Added `SFW_FREE_VERSION` and `SFW_ENTERPRISE_VERSION` variables at the top of each download step (both set to `1.7.2` right now).
- Changed the `gh api` call from `repos/.../releases/latest` to `repos/.../releases/tags/v${SFW_VERSION}`.
- Added a small check that errors out if the asset isn't found at that tag (before it would silently `curl` an empty URL).
- Updated all 10 SHA256s (5 platforms × 2 tracks) to the `v1.7.2` values.

### Where

Three workflows on `v1.x`:
- `.github/workflows/ci.yml` — 3 copies of the same download block (matrix jobs)
- `.github/workflows/provenance.yml` — 1 block
- `.github/workflows/e2e-tests.yml` — 1 block (free-only, no enterprise branch)

The duplication is on purpose on `v1.x` — we inlined everything to avoid pulling in shared/reusable workflow changes.

### Why this is safe

Next time someone bumps sfw, they have to update `SFW_FREE_VERSION` / `SFW_ENTERPRISE_VERSION` AND all the SHA256s in the same commit. If they forget one, CI fails on that commit instead of mysteriously breaking a week later when upstream ships.

## 2. Swap `SOCKET_CLI_API_TOKEN` secret ref to `SOCKET_API_TOKEN`

Repo-level secret was renamed to `SOCKET_API_TOKEN`. Only the `secrets.*` reference in `.github/workflows/e2e-tests.yml` changes — the env var name the CLI reads (`SOCKET_CLI_API_TOKEN`) stays the same.

## Test plan

- [ ] CI green on this PR (ci.yml exercises both enterprise and free paths)
- [ ] Provenance workflow runs fine on next publish
- [ ] E2E tests still run with the renamed secret
