### PR TITLE
chore(provenance): drop publish-without-sfw escape hatch

### DIFF
--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -16,11 +16,6 @@ on:
         options:
           - '0'
           - '1'
-      publish-without-sfw:
-        description: 'Publish directly to npm, bypassing Socket firewall shims'
-        required: false
-        default: false
-        type: boolean
 
 permissions:
   contents: read
@@ -205,19 +200,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --loglevel error
 
-      - name: Strip sfw shims for publishing
-        if: inputs.publish-without-sfw == true
-        run: |
-          echo "Bypassing Socket firewall shims for publishing"
-          # Rename shim files so real binaries resolve from PATH.
-          # Writing PATH to GITHUB_ENV doesn't work because GITHUB_PATH
-          # entries are prepended by the runner after GITHUB_ENV is applied.
-          if [ -n "$SFW_SHIM_DIR" ] && [ -d "$SFW_SHIM_DIR" ]; then
-            for SHIM in "$SFW_SHIM_DIR"/*; do
-              [ -f "$SHIM" ] && mv "$SHIM" "${SHIM}.disabled"
-            done
-          fi
-
       - run: INLINED_SOCKET_CLI_PUBLISHED_BUILD=1 pnpm run build:dist
       - run: npm publish --provenance --access public --tag "${NPM_DIST_TAG}"
         continue-on-error: true
@@ -243,11 +225,3 @@ jobs:
           NPM_DIST_TAG: ${{ inputs.dist-tag }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # zizmor: ignore[secrets-outside-env]
           SOCKET_CLI_DEBUG: ${{ inputs.debug }}
-      - name: Restore sfw shims after publishing
-        if: inputs.publish-without-sfw == true && always()
-        run: |
-          if [ -n "$SFW_SHIM_DIR" ] && [ -d "$SFW_SHIM_DIR" ]; then
-            for SHIM in "$SFW_SHIM_DIR"/*.disabled; do
-              [ -f "$SHIM" ] && mv "$SHIM" "${SHIM%.disabled}"
-            done
-          fi


### PR DESCRIPTION
## Summary

Removes the `publish-without-sfw` escape hatch from the provenance workflow on `v1.x`. With the sfw checksum/version pin from #1252 in place and `sfw-enterprise` live (via `SOCKET_API_TOKEN`), the firewall's `bypass` registry kind already covers github.com, codeload, and the release-asset CDNs — so publish flows don't need to strip shims anymore.

## What changed

`.github/workflows/provenance.yml`:
- Dropped the `publish-without-sfw` `workflow_dispatch` input.
- Dropped the **Strip sfw shims for publishing** step (renamed shim files to `*.disabled` before publish).
- Dropped the **Restore sfw shims after publishing** step (renamed them back).

Net: -26 lines, no behavior change for normal publishes — the escape hatch was off by default.

## Why now

The escape hatch existed because earlier sfw versions blocked legitimate publish traffic. That's no longer true — bypass covers what publish needs. Mirrors socket-registry's `d638c11f`.

## Test plan

- [ ] Next manual `workflow_dispatch` of "Publish to npm registry" no longer shows the `publish-without-sfw` checkbox.
- [ ] Publish run completes successfully (sfw stays in PATH the whole time).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow simplification: removes an optional publishing bypass path without changing the default publish behavior. Risk is limited to cases where publishes previously relied on disabling the `sfw` shims to succeed.
> 
> **Overview**
> Removes the `publish-without-sfw` manual input from the `provenance.yml` publish workflow and deletes the conditional steps that temporarily disabled and then restored `sfw` shim wrappers around publish.
> 
> Publishing now always runs with the `sfw` shims in place, eliminating the escape hatch while keeping the existing build and multi-variant `npm publish` steps unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ed63f3b89c7caf3e3e9c9686d1234598f764525. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->