### PR TITLE
docs(claude): add Error Messages four-ingredient strategy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,29 @@ Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). User-facing onl
 - Error handling: `InputError`/`AuthError` from `src/utils/errors.mts`; prefer `CResult<T>`; avoid `process.exit(1)`
 - GitHub API: Octokit from `src/utils/github.mts`, not raw fetch
 
+### Error Messages
+
+Errors are a UX surface. Every message must let the reader fix the problem without reading the source. Four ingredients, in order:
+
+1. **What**: the rule that was violated (the contract, not the symptom)
+2. **Where**: the exact flag, file, key, line, or record — never "somewhere in config"
+3. **Saw vs. wanted**: the offending value and the allowed shape/set
+4. **Fix**: one concrete action to resolve it
+
+- Imperative voice (`pass --limit=50`), not passive (`--limit was wrong`)
+- Never say "invalid" without what made it invalid. `Invalid ecosystem: "foo"` is a symptom; `--reach-ecosystems must be one of: npm, pypi, maven (saw: "foo")` is a rule
+- If two records collide, name both — not just the second one found
+- Suggest, don't auto-correct. An error that silently repairs state hides the bug in the next run
+
+**Examples:**
+
+- ✅ `throw new InputError('--pull-request must be a non-negative integer (saw: "abc"); pass a number like --pull-request=42')`
+- ✅ `` throw new InputError(`No .socket directory found in ${cwd}; run \`socket init\` to create one`) ``
+- ✅ `throw new AuthError('Socket API rejected the token (401); run `socket login` or set SOCKET_CLI_API_TOKEN')`
+- ❌ `throw new InputError('Invalid value for --limit: ${limit}')` (symptom, no rule, no fix)
+- ❌ `throw new Error('Authentication failed')` (no where, no fix, wrong error type)
+- ❌ `logger.error('Error occurred'); return` (doesn't set exit code)
+
 ### Command Pattern
 
 - Simple (<200 LOC, no subcommands): single `cmd-*.mts`


### PR DESCRIPTION
## Summary

Adds an **Error Messages** section to `CLAUDE.md` with the four-ingredient strategy we're using across the fleet (copied from `socket-repo-template`):

1. **What** — the rule that was violated (not the symptom)
2. **Where** — the exact flag / file / key (never "somewhere in config")
3. **Saw vs. wanted** — the offending value and the allowed shape
4. **Fix** — one concrete action to resolve it

Plus rules on imperative voice, naming colliding records, and not silently auto-correcting.

## Why

Right now socket-cli has a lot of errors like `Invalid value for --limit: foo` — true but not helpful. After this PR lands, the agent has a written rule to reach for so error messages are consistent and actionable.

## What's NOT in this PR

Zero source-code changes. This is just the strategy doc. The actual error-message cleanup across `src/` will land in follow-up PRs split by area (commands, dlx, utils, env, test, etc.) so each PR stays reviewable.

## Test plan

- [ ] Read the new section and make sure the examples feel right for socket-cli (some use `InputError`, one uses `AuthError`, each shows the 4 ingredients).
- [ ] Nothing else to test — docs only, no code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change to `CLAUDE.md` with no runtime or behavioral impact. Low risk aside from potentially influencing future error wording conventions.
> 
> **Overview**
> Adds a new **`### Error Messages`** section to `CLAUDE.md` that standardizes how CLI errors should be written using a four-part format (*what/where/saw-vs-wanted/fix*) and a few concrete rules (imperative voice, avoid vague “invalid”, name collisions explicitly, don’t silently auto-correct), with good/bad examples using `InputError`/`AuthError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31b74665e2887f91850bbba68d3b16e1a4f261f0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->