### PR TITLE
fix(cli): error messages for utils/update + utils/command + error library migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,26 +164,39 @@ Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). User-facing onl
 
 ### Error Messages
 
-Errors are a UX surface. Every message must let the reader fix the problem without reading the source. Four ingredients, in order:
+An error message is UI. The reader should be able to fix the problem from the message alone, without opening your source.
 
-1. **What**: the rule that was violated (the contract, not the symptom)
-2. **Where**: the exact flag, file, key, line, or record — never "somewhere in config"
-3. **Saw vs. wanted**: the offending value and the allowed shape/set
-4. **Fix**: one concrete action to resolve it
+Every message needs four ingredients, in order:
 
-- Imperative voice (`pass --limit=50`), not passive (`--limit was wrong`)
-- Never say "invalid" without what made it invalid. `Invalid ecosystem: "foo"` is a symptom; `--reach-ecosystems must be one of: npm, pypi, maven (saw: "foo")` is a rule
-- If two records collide, name both — not just the second one found
-- Suggest, don't auto-correct. An error that silently repairs state hides the bug in the next run
+1. **What** — the rule that was broken (e.g. "must be a non-negative integer"), not the fallout ("invalid").
+2. **Where** — the exact flag, file, line, key, or record. Not "somewhere in config".
+3. **Saw vs. wanted** — the bad value and the allowed shape or set.
+4. **Fix** — one concrete action, in imperative voice (`pass --limit=50`, not `--limit was wrong`).
 
-**Examples:**
+Length depends on the audience:
+
+- **Library API errors** (thrown from a published package): terse. Callers may match on the message text, so every word counts. All four ingredients often fit in one sentence.
+- **CLI / validator / config errors** (developer reading a terminal): verbose. Give each ingredient its own words so the reader can fix it without re-running the tool. Most `InputError`/`AuthError` cases land here.
+- **Programmatic errors** (internal assertions, invariant checks): terse, rule only. No end user will see it; short keeps the check readable.
+
+Rules for every message:
+
+- Imperative voice for the fix — `pass --limit=50`, not `--limit was wrong`.
+- Never "invalid" on its own. `Invalid ecosystem: "foo"` is fallout; `--reach-ecosystems must be one of: npm, pypi, maven (saw: "foo")` is a rule.
+- On a collision, name **both** sides, not just the second one found.
+- Suggest, don't auto-correct. Silently fixing state hides the bug next time.
+- Bloat check: if removing a word keeps the information, drop it.
+
+**CLI examples:**
 
 - ✅ `throw new InputError('--pull-request must be a non-negative integer (saw: "abc"); pass a number like --pull-request=42')`
 - ✅ `` throw new InputError(`No .socket directory found in ${cwd}; run \`socket init\` to create one`) ``
 - ✅ `throw new AuthError('Socket API rejected the token (401); run `socket login` or set SOCKET_CLI_API_TOKEN')`
-- ❌ `throw new InputError('Invalid value for --limit: ${limit}')` (symptom, no rule, no fix)
-- ❌ `throw new Error('Authentication failed')` (no where, no fix, wrong error type)
-- ❌ `logger.error('Error occurred'); return` (doesn't set exit code)
+- ❌ `throw new InputError('Invalid value for --limit: ${limit}')` — fallout, no rule, no fix
+- ❌ `throw new Error('Authentication failed')` — no where, no fix, wrong error type
+- ❌ `logger.error('Error occurred'); return` — doesn't set exit code
+
+See `docs/references/error-messages.md` for cross-fleet worked examples and anti-patterns.
 
 ### Command Pattern
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,7 @@ Rules for every message:
 - On a collision, name **both** sides, not just the second one found.
 - Suggest, don't auto-correct. Silently fixing state hides the bug next time.
 - Bloat check: if removing a word keeps the information, drop it.
+- For allowed-set / conflict lists, use `joinAnd` / `joinOr` from `@socketsecurity/lib/arrays` — `must be one of: ${joinOr(allowed)}` reads better than a hand-formatted list.
 
 **CLI examples:**
 

--- a/docs/references/error-messages.md
+++ b/docs/references/error-messages.md
@@ -80,6 +80,24 @@ terse keeps the assertion readable when you skim the code.
 - ✗ `The value provided for "timeout" is invalid because timeouts must be positive numbers and the value you provided was not a positive number.`
 - ✓ `timeout must be a positive number (saw: -5)`
 
+## Formatting lists of values
+
+When the error needs to show an allowed set, a list of conflicting
+records, or multiple missing fields, use the list formatters from
+`@socketsecurity/lib/arrays` rather than hand-joining with commas:
+
+- `joinAnd(['a', 'b', 'c'])` → `"a, b, and c"` — for conjunctions ("missing foo, bar, and baz")
+- `joinOr(['npm', 'pypi', 'maven'])` → `"npm, pypi, or maven"` — for disjunctions ("must be one of: …")
+
+Both wrap `Intl.ListFormat`, so the Oxford comma and one-/two-item cases come out right for free (`joinOr(['a'])` → `"a"`; `joinOr(['a', 'b'])` → `"a or b"`).
+
+- ✗ `--reach-ecosystems must be one of: npm, pypi, maven (saw: "foo")` — hand-joined, breaks if the list has one or two entries.
+- ✓ `` `--reach-ecosystems must be one of: ${joinOr(ALLOWED)} (saw: "foo")` ``
+- ✗ `missing keys: filename slug title` — no separators, no grammar.
+- ✓ `` `missing keys: ${joinAnd(missing)}` `` → `"missing keys: filename, slug, and title"`
+
+Use `joinOr` whenever the error is "must be one of X", `joinAnd` whenever it's "all of X are required / missing / in conflict".
+
 ## Voice & tone
 
 - Imperative for the fix: `rename`, `add`, `remove`, `set`.

--- a/docs/references/error-messages.md
+++ b/docs/references/error-messages.md
@@ -18,13 +18,13 @@ Every message needs, in order:
 Callers may match on the message text, so stability matters. Aim for one
 sentence.
 
-| ✗ / ✓ | Message | Notes |
-| --- | --- | --- |
-| ✗ | `Error: invalid component` | No rule, no saw, no where. |
-| ✗ | `The "name" component of type "npm" failed validation because the provided value "" is empty, which is not allowed because names are required; please provide a non-empty name.` | Restates the rule three times. |
-| ✓ | `npm "name" component is required` | Rule + where + implied saw (missing). Six words. |
-| ✗ | `Error: bad name` | No rule. |
-| ✓ | `name "__proto__" cannot start with an underscore` | Rule, where (`name`), saw (`__proto__`), fix implied. |
+| ✗ / ✓ | Message                                                                                                                                                                          | Notes                                                 |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| ✗     | `Error: invalid component`                                                                                                                                                       | No rule, no saw, no where.                            |
+| ✗     | `The "name" component of type "npm" failed validation because the provided value "" is empty, which is not allowed because names are required; please provide a non-empty name.` | Restates the rule three times.                        |
+| ✓     | `npm "name" component is required`                                                                                                                                               | Rule + where + implied saw (missing). Six words.      |
+| ✗     | `Error: bad name`                                                                                                                                                                | No rule.                                              |
+| ✓     | `name "__proto__" cannot start with an underscore`                                                                                                                               | Rule, where (`name`), saw (`__proto__`), fix implied. |
 
 ## Validator / config / build-tool errors (verbose)
 
@@ -42,7 +42,7 @@ Breakdown:
 - **Saw vs. wanted**: saw = missing; wanted = a single-word lowercase filename, with `"parsing"` as a concrete model.
 - **Fix**: `Add … to this part` — imperative, specific.
 
-The trailing `to route /<slug>/part/3 at publish time` is optional. Include a *why* clause only when the rule is non-obvious; skip it for rules the reader already knows (e.g. "names can't start with an underscore").
+The trailing `to route /<slug>/part/3 at publish time` is optional. Include a _why_ clause only when the rule is non-obvious; skip it for rules the reader already knows (e.g. "names can't start with an underscore").
 
 ## Programmatic errors (terse, rule only)
 
@@ -97,6 +97,62 @@ Both wrap `Intl.ListFormat`, so the Oxford comma and one-/two-item cases come ou
 - ✓ `` `missing keys: ${joinAnd(missing)}` `` → `"missing keys: filename, slug, and title"`
 
 Use `joinOr` whenever the error is "must be one of X", `joinAnd` whenever it's "all of X are required / missing / in conflict".
+
+## Working with caught values
+
+`catch (e)` binds `unknown`. The helpers in `@socketsecurity/lib/errors` cover the four patterns that recur everywhere:
+
+```ts
+import {
+  errorMessage,
+  errorStack,
+  isError,
+  isErrnoException,
+} from '@socketsecurity/lib/errors'
+```
+
+### `isError(value)` — replaces `value instanceof Error`
+
+Cross-realm-safe. Uses the native ES2025 `Error.isError` when the engine ships it, falls back to a spec-compliant shim otherwise. Catches Errors from worker threads, `vm` contexts, and iframes that same-realm `instanceof Error` silently misses.
+
+- ✗ `if (e instanceof Error) { … }`
+- ✓ `if (isError(e)) { … }`
+
+### `isErrnoException(value)` — replaces `'code' in err` guards
+
+Narrows to `NodeJS.ErrnoException` (an Error with a string `code` set by libuv/syscalls like `ENOENT`, `EACCES`, `EBUSY`, `EPERM`). Builds on `isError`, so it's also cross-realm-safe, and it checks that `code` is a string — a merely branded Error without a real errno code returns `false`.
+
+- ✗ `if (e && typeof e === 'object' && 'code' in e && e.code === 'ENOENT') { … }`
+- ✓ `if (isErrnoException(e) && e.code === 'ENOENT') { … }`
+
+### `errorMessage(value)` — replaces the `instanceof Error ? e.message : String(e)` pattern
+
+Walks the `cause` chain via `messageWithCauses`, coerces primitives and objects to string, and returns the shared `UNKNOWN_ERROR` sentinel (the string `'Unknown error'`) for `null`, `undefined`, empty strings, `[object Object]`, or Errors with no message.
+
+That last bullet is the important one: **every `|| 'Unknown error'` fallback in the fleet should collapse into a single `errorMessage(e)` call.**
+
+- ✗ `` `Failed: ${e instanceof Error ? e.message : String(e)}` ``
+- ✗ `` `Failed: ${(e as Error)?.message ?? 'Unknown error'}` ``
+- ✗ `` `Failed: ${e instanceof Error ? e.message : 'Unknown error'}` ``
+- ✓ `` `Failed: ${errorMessage(e)}` ``
+
+When you want to preserve the cause chain upstream (recommended), pair it with `{ cause }`:
+
+```ts
+try {
+  await readConfig(path)
+} catch (e) {
+  throw new Error(`Failed to read ${path}: ${errorMessage(e)}`, { cause: e })
+}
+```
+
+### `errorStack(value)` — cause-aware stack, or `undefined`
+
+Returns the cause-walking stack for Errors; returns `undefined` for non-Errors so logger calls stay safe:
+
+```ts
+logger.error(`rebuild failed: ${errorMessage(e)}`, { stack: errorStack(e) })
+```
 
 ## Voice & tone
 

--- a/docs/references/error-messages.md
+++ b/docs/references/error-messages.md
@@ -1,0 +1,92 @@
+# Error Messages — Worked Examples
+
+Companion to the `## Error Messages` section of `CLAUDE.md`. That section
+holds the rules; this file holds longer examples and anti-patterns that
+would bloat CLAUDE.md if inlined.
+
+## The four ingredients
+
+Every message needs, in order:
+
+1. **What** — the rule that was broken.
+2. **Where** — the exact file, line, key, field, or CLI flag.
+3. **Saw vs. wanted** — the bad value and the allowed shape or set.
+4. **Fix** — one concrete action, in imperative voice.
+
+## Library API errors (terse)
+
+Callers may match on the message text, so stability matters. Aim for one
+sentence.
+
+| ✗ / ✓ | Message | Notes |
+| --- | --- | --- |
+| ✗ | `Error: invalid component` | No rule, no saw, no where. |
+| ✗ | `The "name" component of type "npm" failed validation because the provided value "" is empty, which is not allowed because names are required; please provide a non-empty name.` | Restates the rule three times. |
+| ✓ | `npm "name" component is required` | Rule + where + implied saw (missing). Six words. |
+| ✗ | `Error: bad name` | No rule. |
+| ✓ | `name "__proto__" cannot start with an underscore` | Rule, where (`name`), saw (`__proto__`), fix implied. |
+
+## Validator / config / build-tool errors (verbose)
+
+The reader is looking at a file and wants to fix the record without
+re-running the tool. Give each ingredient its own words.
+
+✗ `Error: invalid tour config`
+
+✓ `tour.json: part 3 ("Parsing & Normalization") is missing "filename". Add a single-word lowercase filename (e.g. "parsing") to this part — one per part is required to route /<slug>/part/3 at publish time.`
+
+Breakdown:
+
+- **What**: `is missing "filename"` — the rule is "each part has a filename".
+- **Where**: `tour.json: part 3 ("Parsing & Normalization")` — file + record + human label.
+- **Saw vs. wanted**: saw = missing; wanted = a single-word lowercase filename, with `"parsing"` as a concrete model.
+- **Fix**: `Add … to this part` — imperative, specific.
+
+The trailing `to route /<slug>/part/3 at publish time` is optional. Include a *why* clause only when the rule is non-obvious; skip it for rules the reader already knows (e.g. "names can't start with an underscore").
+
+## Programmatic errors (terse, rule only)
+
+Internal assertions and invariant checks. No end user will read them;
+terse keeps the assertion readable when you skim the code.
+
+- ✓ `assert(queue.length > 0)` with message `queue drained before worker exit`
+- ✓ `pool size must be positive`
+- ✗ `An unexpected error occurred while trying to acquire a connection from the pool because the pool size was not positive.` — nothing a maintainer can act on that the rule itself doesn't already say.
+
+## Common anti-patterns
+
+**"Invalid X" with no rule.**
+
+- ✗ `Invalid filename 'My Part'`
+- ✓ `filename 'My Part' must be [a-z]+ (lowercase, no spaces)`
+
+**Passive voice on the fix.**
+
+- ✗ `"filename" was missing`
+- ✓ `add "filename" to part 3`
+
+**Naming only one side of a collision.**
+
+- ✗ `duplicate key "foo"` (which record won, which lost?)
+- ✓ `duplicate key "foo" in config.json (lines 12 and 47) — rename one`
+
+**Silently auto-correcting.**
+
+- ✗ Stripping a trailing slash from a URL and continuing. The next run will hit the same bug; nothing learned.
+- ✓ `url "https://api/" has a trailing slash — remove it`.
+
+**Bloat that restates the rule.**
+
+- ✗ `The value provided for "timeout" is invalid because timeouts must be positive numbers and the value you provided was not a positive number.`
+- ✓ `timeout must be a positive number (saw: -5)`
+
+## Voice & tone
+
+- Imperative for the fix: `rename`, `add`, `remove`, `set`.
+- Present tense for the rule: `must be`, `cannot`, `is required`.
+- No apology ("Sorry, …"), no blame ("You provided …"). State the rule and the fix.
+- Don't end with "please"; it doesn't add information and it makes the message feel longer than it is.
+
+## Bloat check
+
+Before shipping a message, cross out any word that, if removed, leaves the information intact. If only rhythm or politeness disappears, drop it.

--- a/packages/cli/src/cli-entry.mts
+++ b/packages/cli/src/cli-entry.mts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 // Set global Socket theme for consistent CLI branding.
+import { isError } from '@socketsecurity/lib/errors'
 import { setTheme } from '@socketsecurity/lib/themes'
 setTheme('socket')
 
@@ -266,7 +267,7 @@ process.on('unhandledRejection', async (reason, promise) => {
     }
 
     // Track CLI error for unhandled rejection.
-    const error = reason instanceof Error ? reason : new Error(String(reason))
+    const error = isError(reason) ? reason : new Error(String(reason))
     await trackCliError(process.argv, cliStartTime, error, 1)
 
     // Finalize telemetry before exit.

--- a/packages/cli/src/commands/analytics/AnalyticsRenderer.mts
+++ b/packages/cli/src/commands/analytics/AnalyticsRenderer.mts
@@ -5,6 +5,7 @@
  * This is a proof-of-concept implementation for the hybrid Ink/iocraft approach.
  */
 
+import { errorMessage } from '@socketsecurity/lib/errors'
 import { getDefaultLogger } from '@socketsecurity/lib/logger'
 
 import { Box, Text, print } from '../../utils/terminal/iocraft.mts'
@@ -118,7 +119,7 @@ export function displayAnalyticsWithIocraft(data: FormattedData): void {
     print(tree)
   } catch (e) {
     process.exitCode = 1
-    logger.error('Error rendering analytics:', e instanceof Error ? e.message : String(e))
+    logger.error('Error rendering analytics:', errorMessage(e))
     logger.warn('Falling back to plain text output')
     logger.log(`Top 5 Alert Types: ${Object.keys(data.top_five_alert_types).length} types`)
     logger.log(`Critical Alerts: ${Object.keys(data.total_critical_alerts).length} dates`)

--- a/packages/cli/src/commands/audit-log/AuditLogRenderer.mts
+++ b/packages/cli/src/commands/audit-log/AuditLogRenderer.mts
@@ -4,6 +4,7 @@
  * Non-interactive renderer for audit log data using iocraft native bindings.
  */
 
+import { errorMessage } from '@socketsecurity/lib/errors'
 import { getDefaultLogger } from '@socketsecurity/lib/logger'
 
 import { Box, Text, print } from '../../utils/terminal/iocraft.mts'
@@ -146,7 +147,7 @@ export function displayAuditLogWithIocraft({
     print(tree)
   } catch (e) {
     process.exitCode = 1
-    logger.error('Error rendering audit log:', e instanceof Error ? e.message : String(e))
+    logger.error('Error rendering audit log:', errorMessage(e))
     logger.warn('Falling back to plain text output')
     logger.log(`Organization: ${orgSlug}`)
     logger.log(`Entries: ${results.length}`)

--- a/packages/cli/src/commands/manifest/convert-gradle-to-maven.mts
+++ b/packages/cli/src/commands/manifest/convert-gradle-to-maven.mts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+import { errorMessage } from '@socketsecurity/lib/errors'
 import { getDefaultLogger } from '@socketsecurity/lib/logger'
 import { spawn } from '@socketsecurity/lib/spawn'
 import { getDefaultSpinner } from '@socketsecurity/lib/spinner'
@@ -128,13 +129,13 @@ export async function convertGradleToMaven({
       },
     }
   } catch (e) {
-    const errorMessage =
+    const summary =
       'There was an unexpected error while generating manifests' +
       (verbose ? '' : '  (use --verbose for details)')
 
     if (isTextMode) {
       process.exitCode = 1
-      logger.fail(errorMessage)
+      logger.fail(summary)
       if (verbose) {
         logger.group('[VERBOSE] error:')
         logger.log(e)
@@ -144,8 +145,8 @@ export async function convertGradleToMaven({
 
     return {
       ok: false,
-      message: errorMessage,
-      cause: e instanceof Error ? e.message : String(e),
+      message: summary,
+      cause: errorMessage(e),
     }
   }
 }

--- a/packages/cli/src/commands/manifest/convert-sbt-to-maven.mts
+++ b/packages/cli/src/commands/manifest/convert-sbt-to-maven.mts
@@ -1,3 +1,4 @@
+import { errorMessage } from '@socketsecurity/lib/errors'
 import { safeReadFile } from '@socketsecurity/lib/fs'
 import { getDefaultLogger } from '@socketsecurity/lib/logger'
 import { spawn } from '@socketsecurity/lib/spawn'
@@ -134,14 +135,14 @@ export async function convertSbtToMaven({
       },
     }
   } catch (e) {
-    const errorMessage =
+    const summary =
       'There was an unexpected error while running this' +
       (verbose ? '' : ' (use --verbose for details)')
 
     if (isTextMode) {
       process.exitCode = 1
       spinner?.stop()
-      logger.fail(errorMessage)
+      logger.fail(summary)
       if (verbose) {
         logger.group('[VERBOSE] error:')
         logger.log(e)
@@ -151,8 +152,8 @@ export async function convertSbtToMaven({
 
     return {
       ok: false,
-      message: errorMessage,
-      cause: e instanceof Error ? e.message : String(e),
+      message: summary,
+      cause: errorMessage(e),
     }
   }
 }

--- a/packages/cli/src/commands/threat-feed/ThreatFeedRenderer.mts
+++ b/packages/cli/src/commands/threat-feed/ThreatFeedRenderer.mts
@@ -4,6 +4,7 @@
  * Non-interactive renderer for threat feed data using iocraft native bindings.
  */
 
+import { errorMessage } from '@socketsecurity/lib/errors'
 import { getDefaultLogger } from '@socketsecurity/lib/logger'
 
 import { Box, Text, print } from '../../utils/terminal/iocraft.mts'
@@ -225,7 +226,7 @@ export function displayThreatFeedWithIocraft({
     print(tree)
   } catch (e) {
     process.exitCode = 1
-    logger.error('Error rendering threat feed:', e instanceof Error ? e.message : String(e))
+    logger.error('Error rendering threat feed:', errorMessage(e))
     logger.warn('Falling back to plain text output')
     logger.log(`Total threats: ${results.length}`)
     results.slice(0, 10).forEach((threat, i) => {

--- a/packages/cli/src/utils/basics/spawn.mts
+++ b/packages/cli/src/utils/basics/spawn.mts
@@ -10,6 +10,7 @@ import path from 'node:path'
 
 import { debug } from '@socketsecurity/lib/debug'
 import { normalizePath } from '@socketsecurity/lib/paths/normalize'
+import { errorMessage } from '@socketsecurity/lib/errors'
 import { spawn } from '@socketsecurity/lib/spawn'
 
 import { WIN32 } from '@socketsecurity/lib/constants/platform'
@@ -433,7 +434,7 @@ async function parseSocketFacts(factsPath: string): Promise<{
     } catch (parseError) {
       debug('error', 'Failed to parse socket facts JSON:', parseError)
       return {
-        error: `Invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
+        error: `Invalid JSON: ${errorMessage(parseError)}`,
       }
     }
 
@@ -447,7 +448,7 @@ async function parseSocketFacts(factsPath: string): Promise<{
   } catch (e) {
     debug('error', 'Failed to read socket facts file:', e)
     return {
-      error: `File read error: ${e instanceof Error ? e.message : String(e)}`,
+      error: `File read error: ${errorMessage(e)}`,
     }
   }
 }

--- a/packages/cli/src/utils/command/registry-core.mts
+++ b/packages/cli/src/utils/command/registry-core.mts
@@ -222,8 +222,11 @@ export class CommandRegistry implements ICommandRegistry {
 
     const dispatch = async (i: number): Promise<void> => {
       if (i <= index) {
+        // Each middleware[k] receives a next() closure that calls dispatch(k + 1);
+        // if that closure was invoked twice, dispatch(i) is re-entered and the
+        // offender is the middleware that held the closure — position i - 1.
         throw new Error(
-          `middleware at index ${index} called next() more than once (each middleware may invoke next() at most once); remove the extra next() call or split the middleware`,
+          `middleware at index ${i - 1} called next() more than once (each middleware may invoke next() at most once); remove the extra next() call or split the middleware`,
         )
       }
 

--- a/packages/cli/src/utils/command/registry-core.mts
+++ b/packages/cli/src/utils/command/registry-core.mts
@@ -9,7 +9,7 @@ import type {
   MiddlewareFn,
 } from './registry-types.mjs'
 import type { CResult } from '../../types.mts'
-
+import { errorMessage, errorStack } from '@socketsecurity/lib/errors'
 /**
  * Central registry for CLI commands.
  * Handles registration, discovery, execution, and middleware.
@@ -137,8 +137,8 @@ export class CommandRegistry implements ICommandRegistry {
     } catch (e) {
       return {
         ok: false,
-        message: e instanceof Error ? e.message : String(e),
-        cause: e instanceof Error ? e.stack : undefined,
+        message: errorMessage(e),
+        cause: errorStack(e),
       }
     }
 
@@ -171,8 +171,8 @@ export class CommandRegistry implements ICommandRegistry {
     } catch (e) {
       return {
         ok: false,
-        message: e instanceof Error ? e.message : String(e),
-        cause: e instanceof Error ? e.stack : undefined,
+        message: errorMessage(e),
+        cause: errorStack(e),
       }
     }
   }

--- a/packages/cli/src/utils/command/registry-core.mts
+++ b/packages/cli/src/utils/command/registry-core.mts
@@ -24,8 +24,9 @@ export class CommandRegistry implements ICommandRegistry {
    */
   register(command: CommandDefinition): void {
     if (this.commands.has(command.name)) {
+      const existing = this.commands.get(command.name)
       throw new Error(
-        `Command "${command.name}" is already registered. Use a unique name or unregister first.`,
+        `cannot register command "${command.name}": already registered (existing definition has name="${existing?.name}"); call registry.unregister("${command.name}") first or pick a different name`,
       )
     }
 
@@ -36,7 +37,7 @@ export class CommandRegistry implements ICommandRegistry {
       for (const alias of command.aliases) {
         if (this.commands.has(alias)) {
           throw new Error(
-            `Alias "${alias}" conflicts with existing command "${this.commands.get(alias)?.name}"`,
+            `cannot register command "${command.name}" alias "${alias}": conflicts with command "${this.commands.get(alias)?.name}"; rename the alias or unregister the conflicting command first`,
           )
         }
         // Store alias pointing to main command.
@@ -221,7 +222,9 @@ export class CommandRegistry implements ICommandRegistry {
 
     const dispatch = async (i: number): Promise<void> => {
       if (i <= index) {
-        throw new Error('next() called multiple times')
+        throw new Error(
+          `middleware at index ${index} called next() more than once (each middleware may invoke next() at most once); remove the extra next() call or split the middleware`,
+        )
       }
 
       index = i
@@ -287,7 +290,9 @@ export class CommandRegistry implements ICommandRegistry {
       } else {
         // --flag value format.
         if (i + 1 >= args.length) {
-          throw new Error(`Missing value for flag --${flagName}`)
+          throw new Error(
+            `flag --${flagName} requires a ${flagDef.type} value but none was provided; pass it as --${flagName}=<value> or --${flagName} <value>`,
+          )
         }
         value = args[++i]
       }
@@ -295,9 +300,12 @@ export class CommandRegistry implements ICommandRegistry {
       // Type conversion
       switch (flagDef.type) {
         case 'number': {
+          const raw = value
           value = Number(value)
           if (Number.isNaN(value)) {
-            throw new Error(`Invalid number value for --${flagName}: ${value}`)
+            throw new Error(
+              `flag --${flagName} requires a numeric value (saw: "${String(raw)}"); pass an integer or decimal like --${flagName}=42`,
+            )
           }
           break
         }
@@ -321,7 +329,9 @@ export class CommandRegistry implements ICommandRegistry {
     // Validate required flags
     for (const [name, def] of Object.entries(command.flags)) {
       if (def.isRequired && flags[name] === undefined) {
-        throw new Error(`Required flag --${name} is missing`)
+        throw new Error(
+          `command "${command.name}" requires --${name} but it was not provided; pass --${name}=<${def.type}-value>`,
+        )
       }
     }
 

--- a/packages/cli/src/utils/debug.mts
+++ b/packages/cli/src/utils/debug.mts
@@ -17,7 +17,6 @@
  * to reduce noise. Enable them explicitly when needed for deep debugging.
  */
 
-import { UNKNOWN_ERROR } from '@socketsecurity/lib/constants/core'
 import {
   debug,
   debugCache,
@@ -27,7 +26,7 @@ import {
   isDebug,
   isDebugNs,
 } from '@socketsecurity/lib/debug'
-
+import { errorMessage } from '@socketsecurity/lib/errors'
 export type ApiRequestDebugInfo = {
   durationMs?: number | undefined
   headers?: Record<string, string> | undefined
@@ -162,7 +161,7 @@ export function debugApiResponse(
       buildApiDebugDetails(
         {
           endpoint,
-          error: error instanceof Error ? error.message : UNKNOWN_ERROR,
+          error: errorMessage(error),
         },
         requestInfo,
       ),
@@ -192,7 +191,7 @@ export function debugFileOp(
     debugDir({
       operation,
       filepath,
-      error: error instanceof Error ? error.message : UNKNOWN_ERROR,
+      error: errorMessage(error),
     })
     /* c8 ignore next 3 */
   } else if (isDebugNs('silly')) {
@@ -246,7 +245,7 @@ export function debugConfig(
   if (error) {
     debugDir({
       source,
-      error: error instanceof Error ? error.message : UNKNOWN_ERROR,
+      error: errorMessage(error),
     })
   } else if (found) {
     debug(`Config loaded: ${source}`)

--- a/packages/cli/src/utils/error/display.mts
+++ b/packages/cli/src/utils/error/display.mts
@@ -2,7 +2,7 @@
 
 import colors from 'yoctocolors-cjs'
 
-import { messageWithCauses } from '@socketsecurity/lib/errors'
+import { errorMessage, isError, messageWithCauses } from '@socketsecurity/lib/errors'
 import { LOG_SYMBOLS } from '@socketsecurity/lib/logger'
 import { stripAnsi } from '@socketsecurity/lib/strings'
 
@@ -37,7 +37,7 @@ function appendCauseChain(baseMessage: string, cause: unknown): string {
     return baseMessage
   }
   const causeText =
-    cause instanceof Error ? messageWithCauses(cause) : String(cause)
+    isError(cause) ? messageWithCauses(cause) : String(cause)
   return `${baseMessage}: ${causeText}`
 }
 
@@ -92,7 +92,7 @@ export function formatErrorForDisplay(
     title = 'Invalid input'
     message = appendCauseChain(error.message, error.cause)
     body = error.body
-  } else if (error instanceof Error) {
+  } else if (isError(error)) {
     title = opts.title || 'Unexpected error'
     message = appendCauseChain(error.message, error.cause)
 
@@ -115,16 +115,14 @@ export function formatErrorForDisplay(
 
       while (currentCause && depth <= 5) {
         const causeMessage =
-          currentCause instanceof Error
-            ? currentCause.message
-            : String(currentCause)
+          errorMessage(currentCause)
 
         causeLines.push(
           `\n${colors.dim(`Caused by [${depth}]:`)} ${colors.yellow(causeMessage)}`,
         )
 
         if (
-          currentCause instanceof Error &&
+          isError(currentCause) &&
           currentCause.stack &&
           depth === 1
         ) {
@@ -137,7 +135,7 @@ export function formatErrorForDisplay(
         }
 
         currentCause =
-          currentCause instanceof Error ? currentCause.cause : undefined
+          isError(currentCause) ? currentCause.cause : undefined
         depth++
       }
 
@@ -166,7 +164,7 @@ export function formatErrorForDisplay(
  * Perfect for inline error display without overwhelming output.
  */
 export function formatErrorCompact(error: unknown): string {
-  if (error instanceof Error) {
+  if (isError(error)) {
     return error.message
   }
   if (typeof error === 'string') {
@@ -276,7 +274,7 @@ export function formatExternalCliError(
       .split('\n')
       .map(line => `  ${line}`)
     lines.push('', colors.dim('Error output:'), ...stderrLines)
-  } else if (error instanceof Error) {
+  } else if (isError(error)) {
     lines.push(`  ${error.message}`)
   }
 

--- a/packages/cli/src/utils/error/display.mts
+++ b/packages/cli/src/utils/error/display.mts
@@ -2,7 +2,7 @@
 
 import colors from 'yoctocolors-cjs'
 
-import { errorMessage, isError, messageWithCauses } from '@socketsecurity/lib/errors'
+import { isError, messageWithCauses } from '@socketsecurity/lib/errors'
 import { LOG_SYMBOLS } from '@socketsecurity/lib/logger'
 import { stripAnsi } from '@socketsecurity/lib/strings'
 
@@ -114,8 +114,13 @@ export function formatErrorForDisplay(
       let depth = 1
 
       while (currentCause && depth <= 5) {
-        const causeMessage =
-          errorMessage(currentCause)
+        // Use .message (or String coercion) here — errorMessage() walks
+        // the entire remaining cause chain via messageWithCauses, which
+        // would duplicate messages since the outer while loop is already
+        // iterating the chain level-by-level.
+        const causeMessage = isError(currentCause)
+          ? currentCause.message || String(currentCause)
+          : String(currentCause)
 
         causeLines.push(
           `\n${colors.dim(`Caused by [${depth}]:`)} ${colors.yellow(causeMessage)}`,

--- a/packages/cli/src/utils/error/errors.mts
+++ b/packages/cli/src/utils/error/errors.mts
@@ -26,6 +26,8 @@ import {
 } from '@socketsecurity/lib/constants/core'
 import { debugNs } from '@socketsecurity/lib/debug'
 
+import { isError, isErrnoException } from '@socketsecurity/lib/errors'
+export { isErrnoException } from '@socketsecurity/lib/errors'
 import {
   SOCKET_DASHBOARD_URL,
   SOCKET_PRICING_URL,
@@ -241,15 +243,6 @@ export function captureExceptionSync(
   return Sentry.captureException(exception, hint) as string
 }
 
-export function isErrnoException(
-  value: unknown,
-): value is NodeJS.ErrnoException {
-  if (!(value instanceof Error)) {
-    return false
-  }
-  return (value as NodeJS.ErrnoException).code !== undefined
-}
-
 /**
  * Type guard to check if an error has recovery suggestions.
  */
@@ -257,7 +250,7 @@ export function hasRecoverySuggestions(
   error: unknown,
 ): error is Error & { recovery: string[] } {
   return (
-    error instanceof Error &&
+    isError(error) &&
     'recovery' in error &&
     Array.isArray((error as any).recovery)
   )

--- a/packages/cli/src/utils/git/github.mts
+++ b/packages/cli/src/utils/git/github.mts
@@ -36,6 +36,7 @@ import { Octokit } from '@octokit/rest'
 import { LRUCache } from 'lru-cache'
 
 import { debugDirNs, debugNs, isDebugNs } from '@socketsecurity/lib/debug'
+import { errorMessage, isError } from '@socketsecurity/lib/errors'
 import { readJson, safeMkdir, writeJson } from '@socketsecurity/lib/fs'
 import { spawn } from '@socketsecurity/lib/spawn'
 import { parseUrl } from '@socketsecurity/lib/url'
@@ -564,7 +565,7 @@ export function handleGitHubApiError(
   }
 
   // Network errors (ECONNREFUSED, ETIMEDOUT, etc.).
-  if (e instanceof Error) {
+  if (isError(e)) {
     const code = (e as NodeJS.ErrnoException).code
     if (
       code === 'ECONNREFUSED' ||
@@ -588,7 +589,7 @@ export function handleGitHubApiError(
   return {
     ok: false,
     message: 'GitHub API error',
-    cause: `Unexpected error while ${context}: ${e instanceof Error ? e.message : String(e)}`,
+    cause: `Unexpected error while ${context}: ${errorMessage(e)}`,
   }
 }
 

--- a/packages/cli/src/utils/git/gitlab-provider.mts
+++ b/packages/cli/src/utils/git/gitlab-provider.mts
@@ -1,6 +1,7 @@
 import { Gitlab } from '@gitbeaker/rest'
 
 import { debug, debugDir } from '@socketsecurity/lib/debug'
+import { isError } from '@socketsecurity/lib/errors'
 import { isNonEmptyString } from '@socketsecurity/lib/strings'
 
 import { formatErrorWithDetail } from '../error/errors.mts'
@@ -62,7 +63,7 @@ export class GitLabProvider implements PrProvider {
         }
       } catch (e) {
         let message = `Failed to create merge request (attempt ${attempt}/${retries})`
-        if (e instanceof Error) {
+        if (isError(e)) {
           message += `: ${e.message}`
         }
 

--- a/packages/cli/src/utils/process/os.mts
+++ b/packages/cli/src/utils/process/os.mts
@@ -28,6 +28,7 @@
 
 import fs from 'node:fs'
 
+import { errorMessage } from '@socketsecurity/lib/errors'
 import { getDefaultLogger } from '@socketsecurity/lib/logger'
 import { spawn } from '@socketsecurity/lib/spawn'
 
@@ -235,7 +236,7 @@ async function clearQuarantine(filePath: string): Promise<void> {
     logger.log('Cleared quarantine attribute')
   } catch (e) {
     logger.log(
-      `Failed to clear quarantine: ${e instanceof Error ? e.message : String(e)}`,
+      `Failed to clear quarantine: ${errorMessage(e)}`,
     )
   }
 }
@@ -254,7 +255,7 @@ async function ensureExecutable(filePath: string): Promise<void> {
     logger.log('Set executable permissions')
   } catch (e) {
     logger.warn(
-      `Failed to set executable permissions: ${e instanceof Error ? e.message : String(e)}`,
+      `Failed to set executable permissions: ${errorMessage(e)}`,
     )
   }
 }

--- a/packages/cli/src/utils/telemetry/integration.mts
+++ b/packages/cli/src/utils/telemetry/integration.mts
@@ -43,6 +43,7 @@ import { homedir } from 'node:os'
 import process from 'node:process'
 
 import { debugNs } from '@socketsecurity/lib/debug'
+import { isError } from '@socketsecurity/lib/errors'
 import { escapeRegExp } from '@socketsecurity/lib/regexps'
 
 import { TelemetryService } from './service.mts'
@@ -218,7 +219,7 @@ function normalizeExitCode(
  * @returns Error object.
  */
 function normalizeError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error))
+  return isError(error) ? error : new Error(String(error))
 }
 
 /**

--- a/packages/cli/src/utils/telemetry/service.mts
+++ b/packages/cli/src/utils/telemetry/service.mts
@@ -51,6 +51,7 @@ import { setupSdk } from '../socket/sdk.mts'
 
 import type { TelemetryEvent } from './types.mts'
 import type { InspectOptions } from '@socketsecurity/lib/debug'
+import { errorMessage } from '@socketsecurity/lib/errors'
 import type { SocketSdkSuccessResult } from '@socketsecurity/sdk'
 
 type TelemetryConfig = SocketSdkSuccessResult<'getOrgTelemetryConfig'>['data']
@@ -349,11 +350,11 @@ export class TelemetryService {
       )
     } catch (e) {
       const flushDuration = Date.now() - flushStartTime
-      const errorMessage = e instanceof Error ? e.message : String(e)
+      const errMsg = errorMessage(e)
 
       // Check if this is a timeout error.
       if (
-        errorMessage.includes('timed out') ||
+        errMsg.includes('timed out') ||
         flushDuration >= TELEMETRY_SERVICE_CONFIG.flush_timeout
       ) {
         debug(
@@ -361,7 +362,7 @@ export class TelemetryService {
         )
         debug(`Failed to send ${eventsToSend.length} events due to timeout`)
       } else {
-        debug(`Error flushing telemetry: ${errorMessage}`)
+        debug(`Error flushing telemetry: ${errMsg}`)
         debug(`Failed to send ${eventsToSend.length} events due to error`)
       }
       // Events are discarded on error to prevent infinite growth.
@@ -457,11 +458,11 @@ export class TelemetryService {
         debug(`Events flushed successfully during destroy (${flushDuration}ms)`)
       } catch (e) {
         const flushDuration = Date.now() - flushStartTime
-        const errorMessage = e instanceof Error ? e.message : String(e)
+        const errMsg = errorMessage(e)
 
         // Check if this is a timeout error.
         if (
-          errorMessage.includes('timed out') ||
+          errMsg.includes('timed out') ||
           flushDuration >= TELEMETRY_SERVICE_CONFIG.flush_timeout
         ) {
           debug(
@@ -471,7 +472,7 @@ export class TelemetryService {
             `Failed to send ${eventsToFlush.length} events during destroy due to timeout`,
           )
         } else {
-          debug(`Error flushing telemetry during destroy: ${errorMessage}`)
+          debug(`Error flushing telemetry during destroy: ${errMsg}`)
           debug(
             `Failed to send ${eventsToFlush.length} events during destroy due to error`,
           )

--- a/packages/cli/src/utils/update/checker.mts
+++ b/packages/cli/src/utils/update/checker.mts
@@ -104,7 +104,7 @@ const NetworkUtils = {
   ): Promise<{ version?: string }> {
     if (!isNonEmptyString(url)) {
       throw new Error(
-        `UpdateChecker.fetch(url) requires a non-empty string (got: ${typeof url === 'string' ? '""' : typeof url}); pass a valid registry URL like https://registry.npmjs.org/<package>`,
+        `NetworkUtils.fetch(url) requires a non-empty string (got: ${typeof url === 'string' ? '""' : typeof url}); pass a valid registry URL like https://registry.npmjs.org/<package>`,
       )
     }
 

--- a/packages/cli/src/utils/update/checker.mts
+++ b/packages/cli/src/utils/update/checker.mts
@@ -26,6 +26,7 @@ import semver from 'semver'
 
 import { NPM_REGISTRY_URL } from '@socketsecurity/lib/constants/agents'
 import { debug } from '@socketsecurity/lib/debug'
+import { errorMessage } from '@socketsecurity/lib/errors'
 import { getDefaultLogger } from '@socketsecurity/lib/logger'
 import { onExit } from '@socketsecurity/lib/signal-exit'
 import { isNonEmptyString } from '@socketsecurity/lib/strings'
@@ -174,7 +175,7 @@ const NetworkUtils = {
               }
               reject(
                 new Error(
-                  `Failed to parse JSON response: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
+                  `Failed to parse JSON response: ${errorMessage(parseError)}`,
                 ),
               )
             }
@@ -251,7 +252,7 @@ const NetworkUtils = {
 
         if (isLastAttempt) {
           logger.warn(
-            `Failed to fetch version after ${maxAttempts} attempts: ${e instanceof Error ? e.message : String(e)}`,
+            `Failed to fetch version after ${maxAttempts} attempts: ${errorMessage(e)}`,
           )
           throw e
         }
@@ -259,7 +260,7 @@ const NetworkUtils = {
         // Exponential backoff with cap to prevent integer overflow.
         const delay = Math.min(baseDelay * 2 ** (attempts - 1), 60_000)
         logger.log(
-          `Attempt ${attempts} failed, retrying in ${delay}ms: ${e instanceof Error ? e.message : String(e)}`,
+          `Attempt ${attempts} failed, retrying in ${delay}ms: ${errorMessage(e)}`,
         )
 
         // eslint-disable-next-line no-await-in-loop
@@ -310,7 +311,7 @@ async function checkForUpdates(
     }
   } catch (e) {
     logger.log(
-      `Failed to check for updates: ${e instanceof Error ? e.message : String(e)}`,
+      `Failed to check for updates: ${errorMessage(e)}`,
     )
     throw e
   }

--- a/packages/cli/src/utils/update/checker.mts
+++ b/packages/cli/src/utils/update/checker.mts
@@ -103,7 +103,9 @@ const NetworkUtils = {
     timeoutMs = UPDATE_NOTIFIER_TIMEOUT,
   ): Promise<{ version?: string }> {
     if (!isNonEmptyString(url)) {
-      throw new Error('Invalid URL provided to fetch')
+      throw new Error(
+        `UpdateChecker.fetch(url) requires a non-empty string (got: ${typeof url === 'string' ? '""' : typeof url}); pass a valid registry URL like https://registry.npmjs.org/<package>`,
+      )
     }
 
     const { authInfo } = { __proto__: null, ...options } as FetchOptions
@@ -205,7 +207,9 @@ const NetworkUtils = {
     options: GetLatestVersionOptions = {},
   ): Promise<string | undefined> {
     if (!isNonEmptyString(name)) {
-      throw new Error('Package name must be a non-empty string')
+      throw new Error(
+        `getLatestVersion(name) requires a non-empty string (got: ${typeof name === 'string' ? '""' : typeof name}); pass an npm package name like "socket" or "@socketsecurity/cli"`,
+      )
     }
 
     const { authInfo, registryUrl = NPM_REGISTRY_URL } = {
@@ -214,7 +218,9 @@ const NetworkUtils = {
     } as GetLatestVersionOptions
 
     if (!isNonEmptyString(registryUrl)) {
-      throw new Error('Registry URL must be a non-empty string')
+      throw new Error(
+        `getLatestVersion options.registryUrl must be a non-empty string (got: ${typeof registryUrl === 'string' ? '""' : typeof registryUrl}); omit it to default to ${NPM_REGISTRY_URL}`,
+      )
     }
 
     let normalizedRegistryUrl: string
@@ -222,7 +228,9 @@ const NetworkUtils = {
       const url = new URL(registryUrl)
       normalizedRegistryUrl = url.toString()
     } catch {
-      throw new Error(`Invalid registry URL: ${registryUrl}`)
+      throw new Error(
+        `options.registryUrl "${registryUrl}" is not a valid URL (new URL() threw); pass an absolute http(s) URL like ${NPM_REGISTRY_URL}`,
+      )
     }
 
     const maybeSlash = normalizedRegistryUrl.endsWith('/') ? '' : '/'
@@ -241,7 +249,9 @@ const NetworkUtils = {
         )
 
         if (!json || !isNonEmptyString(json.version)) {
-          throw new Error('Invalid version data in registry response')
+          throw new Error(
+            `${latestUrl} responded without a .version string (got: ${JSON.stringify(json)?.slice(0, 200) ?? 'null'}); the registry may be misconfigured or ${name} may not exist — verify the URL in a browser`,
+          )
         }
 
         return json.version
@@ -284,11 +294,15 @@ async function checkForUpdates(
   } as UpdateCheckOptions
 
   if (!isNonEmptyString(name)) {
-    throw new Error('Package name must be a non-empty string')
+    throw new Error(
+      `checkForUpdates options.name requires a non-empty string (got: ${typeof name === 'string' ? '""' : typeof name}); pass an npm package name like "socket" or "@socketsecurity/cli"`,
+    )
   }
 
   if (!isNonEmptyString(version)) {
-    throw new Error('Current version must be a non-empty string')
+    throw new Error(
+      `checkForUpdates options.version requires a non-empty string (got: ${typeof version === 'string' ? '""' : typeof version}); pass the currently-installed semver like "1.2.3"`,
+    )
   }
 
   try {
@@ -298,7 +312,9 @@ async function checkForUpdates(
     })
 
     if (!isNonEmptyString(latest)) {
-      throw new Error('No version information available from registry')
+      throw new Error(
+        `registry returned no latest version for ${name} (getLatestVersion resolved to ${JSON.stringify(latest)}); check that ${name} exists on ${registryUrl || NPM_REGISTRY_URL}`,
+      )
     }
 
     const updateAvailable = isUpdateAvailable(version, latest)

--- a/packages/cli/src/utils/update/manager.mts
+++ b/packages/cli/src/utils/update/manager.mts
@@ -80,17 +80,23 @@ export async function checkForUpdates(
 
   // Validate required parameters.
   if (!isNonEmptyString(name)) {
-    loggerLocal.warn('Package name must be a non-empty string')
+    loggerLocal.warn(
+      `checkForUpdates options.name requires a non-empty string (got: ${typeof name === 'string' ? '""' : typeof name}); skipping update check`,
+    )
     return false
   }
 
   if (!isNonEmptyString(version)) {
-    loggerLocal.warn('Current version must be a non-empty string')
+    loggerLocal.warn(
+      `checkForUpdates options.version requires a non-empty string (got: ${typeof version === 'string' ? '""' : typeof version}); skipping update check`,
+    )
     return false
   }
 
   if (ttl < 0) {
-    loggerLocal.warn('TTL must be a non-negative number')
+    loggerLocal.warn(
+      `checkForUpdates options.ttl must be >= 0 (saw: ${ttl}); pass a positive number of milliseconds, e.g. 86_400_000 for 24h`,
+    )
     return false
   }
 

--- a/packages/cli/src/utils/update/manager.mts
+++ b/packages/cli/src/utils/update/manager.mts
@@ -26,6 +26,7 @@
  */
 
 import { dlxManifest } from '@socketsecurity/lib/dlx/manifest'
+import { errorMessage } from '@socketsecurity/lib/errors'
 import { getDefaultLogger } from '@socketsecurity/lib/logger'
 import { isNonEmptyString } from '@socketsecurity/lib/strings'
 
@@ -167,7 +168,7 @@ export async function checkForUpdates(
     }
   } catch (e) {
     loggerLocal.warn(
-      `Failed to access cache: ${e instanceof Error ? e.message : String(e)}`,
+      `Failed to access cache: ${errorMessage(e)}`,
     )
     record = undefined
   }
@@ -201,13 +202,13 @@ export async function checkForUpdates(
         })
       } catch (e) {
         loggerLocal.warn(
-          `Failed to update cache: ${e instanceof Error ? e.message : String(e)}`,
+          `Failed to update cache: ${errorMessage(e)}`,
         )
         // Continue anyway - cache update failure is not critical.
       }
     } catch (e) {
       loggerLocal.log(
-        `Failed to fetch latest version: ${e instanceof Error ? e.message : String(e)}`,
+        `Failed to fetch latest version: ${errorMessage(e)}`,
       )
 
       // Use cached version if available.
@@ -261,12 +262,12 @@ export async function checkForUpdates(
           })
         } catch (e) {
           loggerLocal.warn(
-            `Failed to update notification timestamp: ${e instanceof Error ? e.message : String(e)}`,
+            `Failed to update notification timestamp: ${errorMessage(e)}`,
           )
         }
       } catch (e) {
         loggerLocal.warn(
-          `Failed to set up notification: ${e instanceof Error ? e.message : String(e)}`,
+          `Failed to set up notification: ${errorMessage(e)}`,
         )
         // Notification failure is not critical - update is still available.
       }
@@ -299,7 +300,7 @@ export async function scheduleUpdateCheck(
   } catch (e) {
     // Silent failure - update checks should never block the main CLI.
     logger.log(
-      `Update check failed: ${e instanceof Error ? e.message : String(e)}`,
+      `Update check failed: ${errorMessage(e)}`,
     )
   }
 }

--- a/packages/cli/src/utils/update/notifier.mts
+++ b/packages/cli/src/utils/update/notifier.mts
@@ -24,6 +24,7 @@ import process from 'node:process'
 
 import colors from 'yoctocolors-cjs'
 
+import { errorMessage } from '@socketsecurity/lib/errors'
 import { getDefaultLogger } from '@socketsecurity/lib/logger'
 import { onExit } from '@socketsecurity/lib/signal-exit'
 import { isNonEmptyString } from '@socketsecurity/lib/strings'
@@ -135,7 +136,7 @@ export function scheduleExitNotification(
     onExit(notificationLogger)
   } catch (e) {
     logger.warn(
-      `Failed to schedule exit notification: ${e instanceof Error ? e.message : String(e)}`,
+      `Failed to schedule exit notification: ${errorMessage(e)}`,
     )
   }
 }

--- a/packages/cli/test/unit/utils/command/registry-core.test.mts
+++ b/packages/cli/test/unit/utils/command/registry-core.test.mts
@@ -60,7 +60,7 @@ describe('CommandRegistry', () => {
       registry.register(command)
 
       expect(() => registry.register(command)).toThrow(
-        'Command "test" is already registered',
+        /cannot register command "test": already registered/,
       )
     })
 
@@ -85,7 +85,7 @@ describe('CommandRegistry', () => {
       registry.register(cmd1)
 
       expect(() => registry.register(cmd2)).toThrow(
-        'Alias "test" conflicts with existing command "test"',
+        /cannot register command "other" alias "test": conflicts with command "test"/,
       )
     })
   })
@@ -349,7 +349,9 @@ describe('CommandRegistry', () => {
       const result = await registry.execute('test', [])
 
       expect(result.ok).toBe(false)
-      expect(result.message).toContain('Required flag --name is missing')
+      expect(result.message).toContain(
+        'command "test" requires --name but it was not provided',
+      )
     })
 
     it('should run validation function', async () => {
@@ -404,7 +406,9 @@ describe('CommandRegistry', () => {
       const result = await registry.execute('test', ['--name'])
 
       expect(result.ok).toBe(false)
-      expect(result.message).toContain('Missing value for flag --name')
+      expect(result.message).toContain(
+        'flag --name requires a string value but none was provided',
+      )
     })
 
     it('should error when number flag has invalid value', async () => {
@@ -427,7 +431,7 @@ describe('CommandRegistry', () => {
       const result = await registry.execute('test', ['--count', 'notanumber'])
 
       expect(result.ok).toBe(false)
-      expect(result.message).toContain('Invalid number value for --count')
+      expect(result.message).toContain('flag --count requires a numeric value')
     })
 
     it('should parse array flags', async () => {

--- a/packages/cli/test/unit/utils/debug.test.mts
+++ b/packages/cli/test/unit/utils/debug.test.mts
@@ -130,7 +130,10 @@ describe('debug utilities', () => {
 
       expect(mockDebugDirNs).toHaveBeenCalledWith('error', {
         endpoint: '/api/test',
-        error: 'Unknown error',
+        // @socketsecurity/lib/errors preserves non-empty primitives as-is;
+        // only empty strings / null / undefined / plain objects coerce to
+        // the Unknown error sentinel. A real string message passes through.
+        error: 'String error',
       })
     })
 

--- a/packages/cli/test/unit/utils/update/checker.test.mts
+++ b/packages/cli/test/unit/utils/update/checker.test.mts
@@ -122,7 +122,7 @@ describe('update/checker', () => {
   describe('NetworkUtils.fetch', () => {
     it('throws error for empty URL', async () => {
       await expect(NetworkUtils.fetch('')).rejects.toThrow(
-        'Invalid URL provided to fetch',
+        /UpdateChecker\.fetch\(url\) requires a non-empty string/,
       )
     })
 
@@ -264,14 +264,16 @@ describe('update/checker', () => {
   describe('NetworkUtils.getLatestVersion', () => {
     it('throws error for empty package name', async () => {
       await expect(NetworkUtils.getLatestVersion('')).rejects.toThrow(
-        'Package name must be a non-empty string',
+        /getLatestVersion\(name\) requires a non-empty string/,
       )
     })
 
     it('throws error for invalid registry URL', async () => {
       await expect(
         NetworkUtils.getLatestVersion('test', { registryUrl: 'not-a-url' }),
-      ).rejects.toThrow('Invalid registry URL: not-a-url')
+      ).rejects.toThrow(
+        /options\.registryUrl "not-a-url" is not a valid URL/,
+      )
     })
 
     it('returns latest version on success', async () => {
@@ -334,7 +336,7 @@ describe('update/checker', () => {
 
       await expect(
         NetworkUtils.getLatestVersion('test-package'),
-      ).rejects.toThrow('Invalid version data in registry response')
+      ).rejects.toThrow(/responded without a \.version string/)
     })
   })
 
@@ -342,13 +344,17 @@ describe('update/checker', () => {
     it('throws error for empty package name', async () => {
       await expect(
         checkForUpdates({ name: '', version: '1.0.0' }),
-      ).rejects.toThrow('Package name must be a non-empty string')
+      ).rejects.toThrow(
+        /checkForUpdates options\.name requires a non-empty string/,
+      )
     })
 
     it('throws error for empty version', async () => {
       await expect(
         checkForUpdates({ name: 'test', version: '' }),
-      ).rejects.toThrow('Current version must be a non-empty string')
+      ).rejects.toThrow(
+        /checkForUpdates options\.version requires a non-empty string/,
+      )
     })
 
     it('returns update check result when update is available', async () => {

--- a/packages/cli/test/unit/utils/update/checker.test.mts
+++ b/packages/cli/test/unit/utils/update/checker.test.mts
@@ -122,7 +122,7 @@ describe('update/checker', () => {
   describe('NetworkUtils.fetch', () => {
     it('throws error for empty URL', async () => {
       await expect(NetworkUtils.fetch('')).rejects.toThrow(
-        /UpdateChecker\.fetch\(url\) requires a non-empty string/,
+        /NetworkUtils\.fetch\(url\) requires a non-empty string/,
       )
     })
 

--- a/packages/cli/test/unit/utils/update/manager.test.mts
+++ b/packages/cli/test/unit/utils/update/manager.test.mts
@@ -92,7 +92,9 @@ describe('update manager', () => {
 
         expect(result).toBe(false)
         expect(mockLogger.warn).toHaveBeenCalledWith(
-          'Package name must be a non-empty string',
+          expect.stringContaining(
+            'checkForUpdates options.name requires a non-empty string',
+          ),
         )
       })
 
@@ -104,7 +106,9 @@ describe('update manager', () => {
 
         expect(result).toBe(false)
         expect(mockLogger.warn).toHaveBeenCalledWith(
-          'Current version must be a non-empty string',
+          expect.stringContaining(
+            'checkForUpdates options.version requires a non-empty string',
+          ),
         )
       })
 
@@ -117,7 +121,9 @@ describe('update manager', () => {
 
         expect(result).toBe(false)
         expect(mockLogger.warn).toHaveBeenCalledWith(
-          'TTL must be a non-negative number',
+          expect.stringContaining(
+            'checkForUpdates options.ttl must be >= 0 (saw: -1)',
+          ),
         )
       })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,7 +254,7 @@ overrides:
   '@octokit/graphql': 9.0.1
   '@octokit/request-error': 7.0.0
   '@sigstore/sign': 4.1.0
-  '@socketsecurity/lib': 5.21.0
+  '@socketsecurity/lib': 5.24.0
   aggregate-error: npm:@socketregistry/aggregate-error@^1.0.15
   ansi-regex: 6.2.2
   brace-expansion: 5.0.5
@@ -393,8 +393,8 @@ importers:
         specifier: 'catalog:'
         version: 3.0.1
       '@socketsecurity/lib':
-        specifier: 5.21.0
-        version: 5.21.0(typescript@5.9.3)
+        specifier: 5.24.0
+        version: 5.24.0(typescript@5.9.3)
       '@socketsecurity/registry':
         specifier: 'catalog:'
         version: 2.0.2(typescript@5.9.3)
@@ -573,8 +573,8 @@ importers:
         specifier: 'catalog:'
         version: 1.4.2
       '@socketsecurity/lib':
-        specifier: 5.21.0
-        version: 5.21.0(typescript@5.9.3)
+        specifier: 5.24.0
+        version: 5.24.0(typescript@5.9.3)
       '@socketsecurity/sdk':
         specifier: 'catalog:'
         version: 4.0.1
@@ -586,8 +586,8 @@ importers:
   .claude/hooks/setup-security-tools:
     dependencies:
       '@socketsecurity/lib':
-        specifier: 5.21.0
-        version: 5.21.0(typescript@5.9.3)
+        specifier: 5.24.0
+        version: 5.24.0(typescript@5.9.3)
 
   packages/build-infra:
     dependencies:
@@ -598,8 +598,8 @@ importers:
         specifier: 'catalog:'
         version: 7.28.4
       '@socketsecurity/lib':
-        specifier: 5.21.0
-        version: 5.21.0(typescript@5.9.3)
+        specifier: 5.24.0
+        version: 5.24.0(typescript@5.9.3)
       magic-string:
         specifier: 'catalog:'
         version: 0.30.19
@@ -655,8 +655,8 @@ importers:
         specifier: 'catalog:'
         version: 3.0.1
       '@socketsecurity/lib':
-        specifier: 5.21.0
-        version: 5.21.0(typescript@5.9.3)
+        specifier: 5.24.0
+        version: 5.24.0(typescript@5.9.3)
       '@socketsecurity/registry':
         specifier: 'catalog:'
         version: 2.0.2(typescript@5.9.3)
@@ -772,8 +772,8 @@ importers:
   packages/package-builder:
     dependencies:
       '@socketsecurity/lib':
-        specifier: 5.21.0
-        version: 5.21.0(typescript@5.9.3)
+        specifier: 5.24.0
+        version: 5.24.0(typescript@5.9.3)
       build-infra:
         specifier: workspace:*
         version: link:../build-infra
@@ -2151,6 +2151,7 @@ packages:
 
   '@socketaddon/iocraft@file:packages/package-builder/build/dev/out/socketaddon-iocraft':
     resolution: {directory: packages/package-builder/build/dev/out/socketaddon-iocraft, type: directory}
+    engines: {node: '>=18'}
 
   '@socketregistry/es-set-tostringtag@1.0.10':
     resolution: {integrity: sha512-btXmvw1JpA8WtSoXx9mTapo9NAyIDKRRzK84i48d8zc0X09M6ORfobVnHbgwhXf7CFhkRzhYrHG9dqbI9vpELQ==}
@@ -2209,8 +2210,8 @@ packages:
     resolution: {integrity: sha512-kLKdSqi4W7SDSm5z+wYnfVRnZCVhxzbzuKcdOZSrcHoEGOT4Gl844uzoaML+f5eiQMxY+nISiETwRph/aXrIaQ==}
     engines: {node: 18.20.7 || ^20.18.3 || >=22.14.0}
 
-  '@socketsecurity/lib@5.21.0':
-    resolution: {integrity: sha512-cSqdq2kOBSuH3u8rfDhViCrN7IJPqzAvzklUYrEFhohUgJkky0+YYQ/gbSwRehZDGY8mqv+6lKGrt4OKWnNsdQ==}
+  '@socketsecurity/lib@5.24.0':
+    resolution: {integrity: sha512-4Yar8oo4N12ESoNt/i2PNf08HRABUC0OcfUfwzIF3xjq89E5VMDN+aeOtnn6Oo4Y6u3TiuZRG7NgEBZ83LQ1Lw==}
     engines: {node: '>=22', pnpm: '>=11.0.0-rc.0'}
     peerDependencies:
       typescript: '>=5.0.0'
@@ -5699,7 +5700,7 @@ snapshots:
       pony-cause: 2.1.11
       yaml: 2.8.1
 
-  '@socketsecurity/lib@5.21.0(typescript@5.9.3)':
+  '@socketsecurity/lib@5.24.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,7 +47,7 @@ catalog:
   '@socketregistry/packageurl-js': 1.4.2
   '@socketregistry/yocto-spinner': 1.0.25
   '@socketsecurity/config': 3.0.1
-  '@socketsecurity/lib': 5.21.0
+  '@socketsecurity/lib': 5.24.0
   '@socketsecurity/registry': 2.0.2
   '@socketsecurity/sdk': 4.0.1
   '@types/adm-zip': 0.5.7


### PR DESCRIPTION
## Summary

Lands the **error-library migration + doctrine rewrite** together with the 4-ingredient error-message alignment for `utils/update/` and `utils/command/`. This PR supersedes #1261 — all of that PR's content is folded in via merge commit.

## What's in this PR

### 1. Error-message 4-ingredient alignment (original scope of #1257)

- `packages/cli/src/utils/command/registry-core.mts` — what/where/saw/fix format, correct offending-middleware index (bugbot #3125070395)
- `packages/cli/src/utils/update/checker.mts` — 4-ingredient format, `NetworkUtils.fetch(url)` in the error text (bugbot #3125070417)
- `packages/cli/src/utils/update/manager.mts` — 4-ingredient format
- Matching unit-test regex updates

### 2. Error-library migration (from #1261)

- `packages/cli/src/utils/error/errors.mts` + `display.mts` — adopt `@socketsecurity/lib/errors` helpers (`isError`, `errorMessage`, `errorStack`, `isErrnoException`) in place of ad-hoc `instanceof Error ? … : String(…)` patterns
- Removes the CLI-local `isErrnoException` implementation; the lib version is authoritative
- Propagated to: `cli-entry.mts`, `AnalyticsRenderer.mts`, `AuditLogRenderer.mts`, `convert-gradle-to-maven.mts`, `convert-sbt-to-maven.mts`, `ThreatFeedRenderer.mts`, `basics/spawn.mts`, `debug.mts`, `git/github.mts`, `git/gitlab-provider.mts`, `process/os.mts`, `telemetry/integration.mts`, `telemetry/service.mts`, `update/notifier.mts`
- `@socketsecurity/lib` bump in `pnpm-workspace.yaml` + `pnpm-lock.yaml`

### 3. Doctrine (from #1261)

- **CLAUDE.md** Error Messages section rewritten to match `socket-repo-template` fleet doctrine: four ingredients stay, audience-based length guidance added (library API terse / CLI verbose / programmatic rule-only), baseline rules tightened. Preserves the CLI-specific `InputError` / `AuthError` examples.
- **New `docs/references/error-messages.md`** (166 lines): cross-fleet worked examples and anti-patterns so CLAUDE.md stays under the 40 KB ceiling.

## Verification (local, on merged branch)

- `pnpm --filter @socketsecurity/cli run type` — clean
- `pnpm --filter @socketsecurity/cli run lint` — 0 warnings, 0 errors
- `pnpm --filter @socketsecurity/cli run build` — succeeds
- Unit tests: `test/unit/utils/update/` + `test/unit/utils/command/` + `test/unit/utils/error/` + `debug.test.mts` — **334 / 334 passed**

## Risk

Medium. Error-path refactor touches many callers; `@socketsecurity/lib` bump could shift surfaced error/cause strings and debug/telemetry output subtly. No business-logic changes.

## Related PRs (sibling error-message batches)

- #1255 — `commands/*` (14 files)
- #1256 — `utils/dlx/*`
- #1258 — `env/` + `constants/` + sea-build scripts
- #1260 — `utils/` misc (flags, fs, git, npm, promise, terminal)

## Supersedes

- #1261 (`chore/error-messages-doctrine`) — folded in via merge commit

## Test plan

- [x] CI type-check + lint + build green on the merged branch
- [x] Affected unit tests pass (334/334)
- [ ] Reviewer spot-check: `utils/error/errors.mts` API surface unchanged for external callers
- [ ] Reviewer spot-check: CLAUDE.md Error Messages section reads at junior-dev level