### PR TITLE
fix(cli): align test/ error messages with 4-ingredient strategy

### DIFF
--- a/packages/cli/src/test/json-output-validation.mts
+++ b/packages/cli/src/test/json-output-validation.mts
@@ -47,7 +47,7 @@ export function validateSocketJson<T = unknown>(
     parsed = JSON.parse(jsonString)
   } catch (e) {
     throw new Error(
-      `command output is not valid JSON (JSON.parse threw: ${(e as Error).message}); got: ${preview} — check for unclosed braces, trailing commas, or non-JSON text mixed into stdout`,
+      `command output is not valid JSON (JSON.parse threw: ${e instanceof Error ? e.message : String(e)}); got: ${preview} — check for unclosed braces, trailing commas, or non-JSON text mixed into stdout`,
     )
   }
 

--- a/packages/cli/src/test/json-output-validation.mts
+++ b/packages/cli/src/test/json-output-validation.mts
@@ -37,17 +37,24 @@ export function validateSocketJson<T = unknown>(
 ): SocketJsonResponse<T> {
   let parsed: any
 
+  // Truncate to keep error messages readable; full payload goes in the message.
+  const preview = jsonString.length > 200
+    ? `${jsonString.slice(0, 200)}...`
+    : jsonString
+
   // Check if it's valid JSON.
   try {
     parsed = JSON.parse(jsonString)
-  } catch (_e) {
-    throw new Error(`Invalid JSON output: ${jsonString}`)
+  } catch (e) {
+    throw new Error(
+      `command output is not valid JSON (JSON.parse threw: ${(e as Error).message}); got: ${preview} — check for unclosed braces, trailing commas, or non-JSON text mixed into stdout`,
+    )
   }
 
   // Check for required ok field.
   if (typeof parsed.ok !== 'boolean') {
     throw new Error(
-      `JSON output missing required 'ok' boolean field: ${jsonString}`,
+      `Socket JSON contract violation: missing boolean "ok" field (contract: {ok: boolean, data?: any, message?: string}); got: ${preview} — add ok:true for success, ok:false for failure in the output handler`,
     )
   }
 
@@ -55,31 +62,31 @@ export function validateSocketJson<T = unknown>(
   if (expectedExitCode === 0) {
     if (parsed.ok !== true) {
       throw new Error(
-        `JSON output 'ok' should be true when exit code is 0: ${jsonString}`,
+        `Socket JSON contract violation: exit code is 0 but "ok" is ${JSON.stringify(parsed.ok)} (expected true); got: ${preview} — set ok:true when the command succeeds, or return a non-zero exit code`,
       )
     }
     // Success response must have data field.
     if (parsed.data === undefined || parsed.data === null) {
       throw new Error(
-        `JSON output missing required 'data' field when ok is true: ${jsonString}`,
+        `Socket JSON contract violation: ok:true must include a non-null "data" field (got: ${JSON.stringify(parsed.data)}); full output: ${preview} — return an empty object or array instead of undefined/null`,
       )
     }
   } else {
     if (parsed.ok !== false) {
       throw new Error(
-        `JSON output 'ok' should be false when exit code is non-zero: ${jsonString}`,
+        `Socket JSON contract violation: exit code is ${expectedExitCode} but "ok" is ${JSON.stringify(parsed.ok)} (expected false); got: ${preview} — set ok:false on failure, or exit 0 on success`,
       )
     }
     // Error response must have message field.
     if (typeof parsed.message !== 'string' || !parsed.message.length) {
       throw new Error(
-        `JSON output missing required 'message' field when ok is false: ${jsonString}`,
+        `Socket JSON contract violation: ok:false must include a non-empty "message" string (got: ${JSON.stringify(parsed.message)}); full output: ${preview} — provide a user-facing error description`,
       )
     }
     // If code exists, it must be a number.
     if (parsed.code !== undefined && typeof parsed.code !== 'number') {
       throw new Error(
-        `JSON output 'code' field must be a number: ${jsonString}`,
+        `Socket JSON contract violation: "code" field must be a number when present (got: ${typeof parsed.code} ${JSON.stringify(parsed.code)}); full output: ${preview} — drop the field or set it to an integer`,
       )
     }
   }

--- a/packages/cli/src/test/mocks/socket-auth.mts
+++ b/packages/cli/src/test/mocks/socket-auth.mts
@@ -40,7 +40,9 @@ export function mockInteractiveLogin(options?: { shouldSucceed?: boolean }) {
         },
       }
     }
-    throw new Error('Authentication failed')
+    throw new Error(
+      `mock interactive-login rejected (configured with shouldSucceed:false); this is a test fixture — flip shouldSucceed to true when testing the happy path`,
+    )
   })
 }
 
@@ -118,7 +120,9 @@ export function mockOAuthPoller(options?: {
         token: MOCK_API_TOKEN,
       }
     }
-    throw new Error('OAuth timeout')
+    throw new Error(
+      `mock OAuth poller rejected after ${pollCount} polls (configured with shouldSucceed:false); this is a test fixture — set shouldSucceed:true or adjust pollCount to test the happy path`,
+    )
   })
 }
 

--- a/packages/cli/test/json-output-validation.mts
+++ b/packages/cli/test/json-output-validation.mts
@@ -41,10 +41,18 @@ export function validateSocketJson(output: string, exitCode: number) {
     }
     return {
       ok: false,
-      message: parsed.message || parsed.error || 'Unknown error',
+      message:
+        parsed.message ||
+        parsed.error ||
+        `command exited with code ${exitCode} but returned JSON had no .message or .error field`,
     }
-  } catch (_e) {
+  } catch (e) {
     // If not valid JSON, return error.
-    return { ok: false, message: 'Invalid JSON output' }
+    const preview =
+      output.length > 200 ? `${output.slice(0, 200)}...` : output
+    return {
+      ok: false,
+      message: `command output is not valid JSON (JSON.parse: ${(e as Error).message}); got: ${preview}`,
+    }
   }
 }

--- a/packages/cli/test/json-output-validation.mts
+++ b/packages/cli/test/json-output-validation.mts
@@ -52,7 +52,7 @@ export function validateSocketJson(output: string, exitCode: number) {
       output.length > 200 ? `${output.slice(0, 200)}...` : output
     return {
       ok: false,
-      message: `command output is not valid JSON (JSON.parse: ${(e as Error).message}); got: ${preview}`,
+      message: `command output is not valid JSON (JSON.parse: ${e instanceof Error ? e.message : String(e)}); got: ${preview}`,
     }
   }
 }

--- a/packages/cli/test/smoke.sh
+++ b/packages/cli/test/smoke.sh
@@ -93,7 +93,7 @@ validate_json() {
 
     # First check if it's valid JSON
     if ! echo "$json_output" | jq . > /dev/null 2>&1; then
-        echo -e "${RED}✗ Invalid JSON output${NC}"
+        echo -e "${RED}✗ command output is not valid JSON (jq rejected it); stdout may contain progress text mixed with the payload${NC}"
         echo -e "Received:"
         echo -e "$json_output"
         return 1
@@ -115,13 +115,13 @@ validate_json() {
 
     # Check if ok field matches expected exit code
     if [ "$expected_exit" -eq 0 ] && [ "$ok_field" != "true" ]; then
-        echo -e "${RED}✗ JSON output 'ok' should be true when exit code is 0${NC}"
+        echo -e "${RED}✗ Socket JSON contract violation: exit code 0 but \"ok\" is \"$ok_field\" (expected true); set ok:true on success${NC}"
         echo -e "Received:"
         echo -e "$json_output"
         return 1
     fi
     if [ "$expected_exit" -ne 0 ] && [ "$ok_field" != "false" ]; then
-        echo -e "${RED}✗ JSON output 'ok' should be false when exit code is non-zero${NC}"
+        echo -e "${RED}✗ Socket JSON contract violation: exit code $expected_exit but \"ok\" is \"$ok_field\" (expected false); set ok:false on failure${NC}"
         echo -e "Received:"
         echo -e "$json_output"
         return 1
@@ -129,7 +129,7 @@ validate_json() {
 
     # Check if data field exists (required when ok is true, optional when false)
     if [ "$ok_field" = "true" ] && [ "$data_field" = "null" ]; then
-        echo -e "${RED}✗ JSON output missing required 'data' field when ok is true${NC}"
+        echo -e "${RED}✗ Socket JSON contract violation: ok:true must include a non-null \"data\" field; return an empty object/array if there's no payload${NC}"
         echo -e "Received:"
         echo -e "$json_output"
         return 1
@@ -137,7 +137,7 @@ validate_json() {
 
     # If ok is false, message is required
     if [ "$ok_field" = "false" ] && [ -z "$message_field" ]; then
-        echo -e "${RED}✗ JSON output missing required 'message' field when ok is false${NC}"
+        echo -e "${RED}✗ Socket JSON contract violation: ok:false must include a non-empty \"message\" string; provide a user-facing error description${NC}"
         echo -e "Received:"
         echo -e "$json_output"
         return 1
@@ -145,7 +145,7 @@ validate_json() {
 
     # If code exists, it must be a number
     if [ -n "$code_field" ] && ! [[ "$code_field" =~ ^[0-9]+$ ]]; then
-        echo -e "${RED}✗ JSON output 'code' field must be a number${NC}"
+        echo -e "${RED}✗ Socket JSON contract violation: \"code\" field must be a number when present (got: \"$code_field\"); drop the field or set it to an integer${NC}"
         echo -e "Received:"
         echo -e "$json_output"
         return 1


### PR DESCRIPTION
## Summary

PR 6 of the error-message series. Covers test utilities: **`packages/cli/src/test/`** (the Socket-JSON contract validator + auth-flow mocks, which are shared across the test suite) and **`packages/cli/test/`** (the bash smoke harness + its JS counterpart).

~16 messages across 4 files. Full test suite (343 files / 5225 tests) still passes.

## What's fixed

### `src/test/json-output-validation.mts` (6 throws)

Socket CLI guarantees a JSON output contract: `{ok: true, data: ...}` on success or `{ok: false, message: ...}` on failure. This file's validator is the guardrail. Before, it said things like "JSON output missing required 'ok' boolean field" which didn't tell a failing test author what the full contract looked like or how to satisfy it.

Before: `JSON output 'ok' should be true when exit code is 0: {full payload...}`
After: `` Socket JSON contract violation: exit code is 0 but "ok" is false (expected true); got: {preview}... — set ok:true when the command succeeds, or return a non-zero exit code ``

Long payloads are now truncated to 200 chars in the message so stacktraces stay readable.

### `src/test/mocks/socket-auth.mts` (2 throws)

`throw new Error('Authentication failed')` and `throw new Error('OAuth timeout')` — before, a test failure here looked like a real auth outage. Now both errors explicitly identify themselves as test fixtures and point at the config flag that controls them.

### `test/json-output-validation.mts` (2 non-throwing returns)

This is a lighter shim that returns `{ok: false, message: ...}` instead of throwing. Updated to match the throw-path messages so a failing integration test shows the parse error and a stdout preview.

### `test/smoke.sh` (6 label strings)

The bash smoke harness duplicates the JS validator's logic in shell. Updated its labels to mirror the new wording so the two harnesses produce consistent errors.

## Tests

Nothing else needed updating — `grep` confirmed the "Authentication failed" and "Unknown error" hits elsewhere are unrelated (tests constructing their own `new AuthError('Authentication failed')` as test data, or matching on a distinct production error in `src/utils/socket/api.mts`).

Full suite: **5225/5225 tests pass**.

## Test plan

- [ ] CI green
- [ ] Sanity: break the JSON output of any `--json` command and verify the new validator message points at the contract violation clearly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test utilities and smoke harness messaging, with no production logic impact aside from clearer failures when tests detect malformed JSON or misconfigured mocks.
> 
> **Overview**
> Tightens and standardizes test-time validation of the Socket CLI `--json` output contract by upgrading error messages to explicitly call out *contract violations*, include actionable guidance, and show a truncated stdout preview for readability.
> 
> Updates the auth-flow test mocks to throw fixture-specific failures (instead of generic auth errors), and aligns both the JS integration validator and `test/smoke.sh` labels with the same clearer parse/contract diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8efd4f9d8472cc7b8c9762fbbabf7a824a48c2a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->