### PR TITLE
chore: replace fs.rm with safeDelete

### DIFF
--- a/.claude/hooks/setup-security-tools/index.mts
+++ b/.claude/hooks/setup-security-tools/index.mts
@@ -18,6 +18,7 @@ import { fileURLToPath } from 'node:url'
 
 import { whichSync } from '@socketsecurity/lib/bin'
 import { downloadBinary } from '@socketsecurity/lib/dlx/binary'
+import { safeDelete } from '@socketsecurity/lib/fs'
 import { getDefaultLogger } from '@socketsecurity/lib/logger'
 import { getSocketHomePath } from '@socketsecurity/lib/paths/socket'
 import { spawn, spawnSync } from '@socketsecurity/lib/spawn'
@@ -161,7 +162,7 @@ async function setupZizmor(): Promise<boolean> {
     await fs.copyFile(extractedBin, binPath)
     await fs.chmod(binPath, 0o755)
   } finally {
-    await fs.rm(extractDir, { recursive: true, force: true }).catch(() => {})
+    await safeDelete(extractDir).catch(() => {})
   }
 
   logger.log(`Installed to ${binPath}`)

--- a/packages/cli/scripts/sync-checksums.mts
+++ b/packages/cli/scripts/sync-checksums.mts
@@ -28,6 +28,8 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { pipeline } from 'node:stream/promises'
 
+import { safeDelete } from '@socketsecurity/lib/fs'
+
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const packageRoot = path.join(__dirname, '..')
@@ -135,7 +137,7 @@ async function fetchGitHubReleaseChecksums(
       const checksums = parseChecksums(content)
 
       // Clean up.
-      await fs.rm(tempDir, { recursive: true })
+      await safeDelete(tempDir)
 
       console.log(
         `  Parsed ${Object.keys(checksums).length} checksums from checksums.txt`,
@@ -143,7 +145,7 @@ async function fetchGitHubReleaseChecksums(
       return checksums
     } catch (error) {
       console.log(`  Failed to download checksums.txt: ${error.message}`)
-      await fs.rm(tempDir, { recursive: true }).catch(() => {})
+      await safeDelete(tempDir).catch(() => {})
       // Fall through to download assets.
     }
   }
@@ -183,7 +185,7 @@ async function fetchGitHubReleaseChecksums(
       await fs.unlink(assetPath)
     }
   } finally {
-    await fs.rm(tempDir, { recursive: true }).catch(() => {})
+    await safeDelete(tempDir).catch(() => {})
   }
 
   return checksums


### PR DESCRIPTION
## Summary

CLAUDE.md forbids \`fs.rm\` / \`fs.rmSync\` / \`rm -rf\` in our code — use \`safeDelete\` from \`@socketsecurity/lib/fs\`.

Fixes:
- \`packages/cli/scripts/sync-checksums.mts\` — 3 call sites (cleanup after parsing checksums.txt + error path + finally block).
- \`.claude/hooks/setup-security-tools/index.mts\` — 1 call site (zizmor extract-dir cleanup).

## Test plan

- [ ] \`pnpm run lint\` + \`pnpm run type\` clean.
- [ ] \`node packages/cli/scripts/sync-checksums.mts --dry-run\` still works.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor: only changes temp directory cleanup in two scripts, with no impact to core business logic beyond how deletions are performed.
> 
> **Overview**
> Replaces recursive temp-directory cleanup using `fs.rm(..., { recursive: true })` with `safeDelete` from `@socketsecurity/lib/fs`.
> 
> This updates cleanup paths in the `zizmor` extraction flow (`.claude/hooks/setup-security-tools/index.mts`) and in the checksum sync script (`packages/cli/scripts/sync-checksums.mts`), including normal, error, and `finally` cleanup branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0ccde5cb40b2672ff5917474090c6601499dcc5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->