### PR TITLE
style: rename catch (err|error) identifiers to catch (e)

### DIFF
--- a/packages/cli/scripts/build-js.mts
+++ b/packages/cli/scripts/build-js.mts
@@ -45,8 +45,8 @@ async function main() {
     }
 
     logger.success('Build completed successfully')
-  } catch (error) {
-    logger.error(`Build failed: ${error.message}`)
+  } catch (e) {
+    logger.error(`Build failed: ${e.message}`)
     process.exitCode = 1
   }
 }

--- a/packages/cli/scripts/build.mts
+++ b/packages/cli/scripts/build.mts
@@ -282,12 +282,12 @@ async function main() {
       printSuccess('Build completed')
       printFooter()
     }
-  } catch (error) {
+  } catch (e) {
     if (!quiet) {
-      printError(`Build failed: ${error.message}`)
+      printError(`Build failed: ${e.message}`)
     }
     if (verbose) {
-      logger.error(error)
+      logger.error(e)
     }
     process.exitCode = 1
   }

--- a/packages/cli/scripts/cover.mts
+++ b/packages/cli/scripts/cover.mts
@@ -304,12 +304,12 @@ async function main() {
         }
       }
     }
-  } catch (error) {
+  } catch (e) {
     if (!quiet) {
-      printError(`Coverage failed: ${error.message}`)
+      printError(`Coverage failed: ${e.message}`)
     }
     if (verbose) {
-      logger.error(error)
+      logger.error(e)
     }
     process.exitCode = 1
   }

--- a/packages/cli/scripts/download-assets.mts
+++ b/packages/cli/scripts/download-assets.mts
@@ -125,11 +125,11 @@ async function downloadAsset(config) {
     logger.groupEnd()
     logger.success(`${name} extraction complete`)
     return { name, ok: true }
-  } catch (error) {
+  } catch (e) {
     logger.groupEnd()
-    logger.error(`Failed to extract ${name}: ${error.message}`)
-    await logTransientErrorHelp(error)
-    return { error, name, ok: false }
+    logger.error(`Failed to extract ${name}: ${e.message}`)
+    await logTransientErrorHelp(e)
+    return { e, name, ok: false }
   }
 }
 

--- a/packages/cli/scripts/download-assets.mts
+++ b/packages/cli/scripts/download-assets.mts
@@ -129,7 +129,7 @@ async function downloadAsset(config) {
     logger.groupEnd()
     logger.error(`Failed to extract ${name}: ${e.message}`)
     await logTransientErrorHelp(e)
-    return { e, name, ok: false }
+    return { error: e, name, ok: false }
   }
 }
 

--- a/packages/cli/scripts/restore-cache.mts
+++ b/packages/cli/scripts/restore-cache.mts
@@ -261,9 +261,9 @@ async function restoreCache(repo, cacheKey) {
 
     logger.success('Cache restored successfully!')
     return true
-  } catch (error) {
+  } catch (e) {
     if (isVerbose()) {
-      logger.error(`Cache restoration failed: ${error.message}`)
+      logger.error(`Cache restoration failed: ${e.message}`)
     }
     return false
   } finally {

--- a/packages/cli/scripts/sync-checksums.mts
+++ b/packages/cli/scripts/sync-checksums.mts
@@ -143,8 +143,8 @@ async function fetchGitHubReleaseChecksums(
         `  Parsed ${Object.keys(checksums).length} checksums from checksums.txt`,
       )
       return checksums
-    } catch (error) {
-      console.log(`  Failed to download checksums.txt: ${error.message}`)
+    } catch (e) {
+      console.log(`  Failed to download checksums.txt: ${e.message}`)
       await safeDelete(tempDir).catch(() => {})
       // Fall through to download assets.
     }
@@ -282,8 +282,8 @@ async function main() {
       const newCount = Object.keys(newChecksums).length
       console.log(`  Updated: ${oldCount} -> ${newCount} checksums\n`)
       updated++
-    } catch (error) {
-      console.log(`  Error: ${error.message}\n`)
+    } catch (e) {
+      console.log(`  Error: ${e.message}\n`)
       failed++
     }
   }

--- a/packages/cli/scripts/test-asset-manager.mts
+++ b/packages/cli/scripts/test-asset-manager.mts
@@ -136,16 +136,16 @@ async function main() {
     console.log('')
     console.log('Phase 1 (Foundation) complete. Ready for Phase 2 (Migration).')
     console.log('')
-  } catch (error) {
+  } catch (e) {
     console.error('\n' + '='.repeat(60))
     console.error('❌ TEST FAILED')
     console.error('='.repeat(60))
     console.error('')
-    console.error('Error:', error.message)
+    console.error('Error:', e.message)
     console.error('')
-    if (error.stack) {
+    if (e.stack) {
       console.error('Stack trace:')
-      console.error(error.stack)
+      console.error(e.stack)
     }
     process.exitCode = 1
   }

--- a/packages/cli/scripts/utils/patches.mts
+++ b/packages/cli/scripts/utils/patches.mts
@@ -229,12 +229,12 @@ export async function createPatch(patchDef) {
 
     // Commit the patch.
     await commitPatch(patchPath, packageName)
-  } catch (error) {
-    logger.error(`Error creating patch for ${packageName}:`, error.message)
+  } catch (e) {
+    logger.error(`Error creating patch for ${packageName}:`, e.message)
     // Cleanup temp directory on error.
     if (patchPath && existsSync(patchPath)) {
       rmSync(patchPath, { force: true, recursive: true })
     }
-    throw error
+    throw e
   }
 }

--- a/packages/cli/scripts/validate-bundle.mts
+++ b/packages/cli/scripts/validate-bundle.mts
@@ -81,8 +81,8 @@ async function main() {
     logger.log('')
 
     process.exitCode = 1
-  } catch (error) {
-    logger.fail(`Validation failed: ${error.message}`)
+  } catch (e) {
+    logger.fail(`Validation failed: ${e.message}`)
     process.exitCode = 1
   }
 }

--- a/packages/cli/src/commands/scan/output-diff-scan.mts
+++ b/packages/cli/src/commands/scan/output-diff-scan.mts
@@ -91,9 +91,9 @@ async function handleJson(
     try {
       await fs.writeFile(file, json, 'utf8')
       logger.success(`Data successfully written to \`${fileLink(file)}\``)
-    } catch (err) {
+    } catch (e) {
       logger.fail(`Writing to \`${file}\` failed...`)
-      logger.error(err)
+      logger.error(e)
       process.exitCode = 1
     }
     logger.info(dashboardMessage)

--- a/packages/cli/src/utils/telemetry/integration.mts
+++ b/packages/cli/src/utils/telemetry/integration.mts
@@ -369,9 +369,9 @@ export async function trackEvent(
         await telemetry.flush()
       }
     }
-  } catch (err) {
+  } catch (e) {
     // Telemetry errors should never block CLI execution.
-    debug(`Failed to track event ${eventType}: ${err}`)
+    debug(`Failed to track event ${eventType}: ${e}`)
   }
 }
 


### PR DESCRIPTION
## Summary

Mechanical rename across 11 files to match the CLAUDE.md \`catch (e)\` convention. 12 catch clauses converted. Body references renamed (including inside template literal interpolations); property keys and member-access expressions (\`logger.error\`, \`console.error\`) are left untouched.

## Test plan

- [ ] \`tsgo --noEmit\` clean (already verified locally).
- [ ] CI green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical rename of `catch` binding identifiers and corresponding references in CLI scripts/utilities; no control-flow or behavioral changes expected beyond error logging variable names.
> 
> **Overview**
> Standardizes error-handling style across CLI scripts and a couple runtime modules by renaming `catch (error|err)` bindings to `catch (e)` and updating all `*.message`/stack/log references accordingly.
> 
> Also adjusts one returned error object in `download-assets.mts` to keep the key `error` while storing the caught value (`{ error: e, ... }`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c80133eb4f9ea581772edb0f36852eeda6ccdc6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->