### PR TITLE
fix(fix): fail when .socket.facts.json is present in manifest files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.86](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.86) - 2026-04-24
+
+### Changed
+- `socket fix` now fails with a clear error when a `.socket.facts.json` analysis artifact is present alongside manifest files, prompting you to delete it before re-running
+
 ## [1.1.85](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.85) - 2026-04-20
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.85",
+  "version": "1.1.86",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",

--- a/src/commands/fix/coana-fix.mts
+++ b/src/commands/fix/coana-fix.mts
@@ -169,13 +169,25 @@ export async function coanaFix(
     config: socketConfig,
     cwd,
   })
-  // Exclude any .socket.facts.json files that happen to be in the scan
-  // folder before the analysis was run.
-  const filepathsToUpload = scanFilepaths.filter(
-    p => path.basename(p).toLowerCase() !== DOT_SOCKET_DOT_FACTS_JSON,
+  // Fail if any .socket.facts.json files are present in the scan folder.
+  // These are analysis artifacts and must be removed before re-running fix.
+  const factsFiles = scanFilepaths.filter(
+    p => path.basename(p).toLowerCase() === DOT_SOCKET_DOT_FACTS_JSON,
   )
+  if (factsFiles.length) {
+    if (!silence) {
+      spinner?.stop()
+    }
+    return {
+      ok: false,
+      message: `Found ${DOT_SOCKET_DOT_FACTS_JSON} in manifest files`,
+      cause:
+        `Delete the following ${pluralize('file', factsFiles.length)} before running socket fix again:\n` +
+        factsFiles.map(p => `  - ${p}`).join('\n'),
+    }
+  }
   const uploadCResult = await handleApiCall(
-    sockSdk.uploadManifestFiles(orgSlug, filepathsToUpload, cwd),
+    sockSdk.uploadManifestFiles(orgSlug, scanFilepaths, cwd),
     {
       description: 'upload manifests',
       spinner,


### PR DESCRIPTION
## Summary
- `socket fix` now fails fast with a clear error when `.socket.facts.json` (a Coana analysis artifact) is found alongside collected manifest files, listing the offending paths and asking the user to delete them before re-running. Previously these files were silently filtered out before upload.
- Bumps version to `1.1.86` and adds a changelog entry.

## Test plan
- [ ] `pnpm check` passes
- [x] Manual: run `socket fix` in a dir containing `.socket.facts.json`, verify error is clear and actionable
- [x] Manual: run `socket fix` in a dir without `.socket.facts.json`, verify the command behaves as before

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small CLI behavior change limited to pre-upload validation and user-facing messaging, plus a routine version/changelog bump.
> 
> **Overview**
> **`socket fix` now hard-fails if any `.socket.facts.json` files are discovered during manifest collection**, returning a clear, actionable error that lists offending paths and instructs users to delete them before retrying (previously these files were silently filtered out before upload).
> 
> Bumps the CLI version to `1.1.86` and adds a corresponding changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a332e1df2fb205747d9681784b73946a0846e1e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->