### PR TITLE
feat(claude): add public-surface-reminder + token-hygiene hooks

### DIFF
--- a/.claude/hooks/public-surface-reminder/README.md
+++ b/.claude/hooks/public-surface-reminder/README.md
@@ -1,0 +1,36 @@
+# public-surface-reminder
+
+`PreToolUse` hook that **never blocks**. On every `Bash` command that would
+publish text to a public Git/GitHub surface, writes a short reminder to
+stderr so the model re-reads the command with the two rules freshly in
+mind:
+
+1. **No real customer or company names.** Use `Acme Inc`. No exceptions.
+2. **No internal work-item IDs or tracker URLs.** No `SOC-123` /
+   `ENG-456` / `ASK-789` / similar, no `linear.app` / `sentry.io` URLs.
+
+Attention priming, not enforcement. The model is responsible for actually
+applying the rule — the hook just ensures the rule is in the active
+context at the moment the command is about to fire.
+
+## What counts as "public surface"
+
+- `git commit` (including `--amend`)
+- `git push`
+- `gh pr (create|edit|comment|review)`
+- `gh issue (create|edit|comment)`
+- `gh api -X POST|PATCH|PUT`
+- `gh release (create|edit)`
+
+Any other `Bash` command passes through silently.
+
+## Why no denylist
+
+Because a denylist is itself a customer leak. A file named
+`customers.txt` that enumerates "these are our customers" is worse than
+the bug it tries to prevent. Recognition and replacement happen at write
+time, done by the model, every time.
+
+## Exit code
+
+Always `0`. The hook prints a reminder and steps aside.

--- a/.claude/hooks/public-surface-reminder/index.mts
+++ b/.claude/hooks/public-surface-reminder/index.mts
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// Claude Code PreToolUse hook — public-surface reminder.
+//
+// Never blocks. On every Bash command that would publish text to a public
+// Git/GitHub surface (git commit, git push, gh pr/issue/api/release write),
+// writes a short reminder to stderr so the model re-reads the command with
+// the two rules freshly in mind:
+//
+//   1. No real customer/company names — ever. Use `Acme Inc` instead.
+//   2. No internal work-item IDs or tracker URLs — no `SOC-123`, `ENG-456`,
+//      `ASK-789`, `linear.app`, `sentry.io`, etc.
+//
+// Exit code is always 0. This is attention priming, not enforcement. The
+// model is responsible for actually applying the rule — the hook just makes
+// sure the rule is in the active context at the moment the command is about
+// to fire.
+//
+// Deliberately carries no list of customer names. Recognition and
+// replacement happen at write time, not via enumeration.
+//
+// Reads a Claude Code PreToolUse JSON payload from stdin:
+//   { "tool_name": "Bash", "tool_input": { "command": "..." } }
+
+import { readFileSync } from 'node:fs'
+
+type ToolInput = {
+  tool_name?: string
+  tool_input?: {
+    command?: string
+  }
+}
+
+// Commands that can publish content outside the local machine.
+// Keep broad — better to remind on an extra read than miss a write.
+const PUBLIC_SURFACE_PATTERNS: RegExp[] = [
+  /\bgit\s+commit\b/,
+  /\bgit\s+push\b/,
+  /\bgh\s+pr\s+(create|edit|comment|review)\b/,
+  /\bgh\s+issue\s+(create|edit|comment)\b/,
+  /\bgh\s+api\b[^|]*-X\s*(POST|PATCH|PUT)\b/i,
+  /\bgh\s+release\s+(create|edit)\b/,
+]
+
+function isPublicSurface(command: string): boolean {
+  const normalized = command.replace(/\s+/g, ' ')
+  return PUBLIC_SURFACE_PATTERNS.some(re => re.test(normalized))
+}
+
+function main(): void {
+  let raw = ''
+  try {
+    raw = readFileSync(0, 'utf8')
+  } catch {
+    return
+  }
+
+  let input: ToolInput
+  try {
+    input = JSON.parse(raw)
+  } catch {
+    return
+  }
+
+  if (input.tool_name !== 'Bash') {
+    return
+  }
+  const command = input.tool_input?.command
+  if (!command || typeof command !== 'string') {
+    return
+  }
+  if (!isPublicSurface(command)) {
+    return
+  }
+
+  const lines = [
+    '[public-surface-reminder] This command writes to a public Git/GitHub surface.',
+    '  • Re-read the commit message / PR body / comment BEFORE it sends.',
+    '  • No real customer or company names — use `Acme Inc`. No exceptions.',
+    '  • No internal work-item IDs or tracker URLs (linear.app, sentry.io, SOC-/ENG-/ASK-/etc.).',
+    '  • If you spot one, cancel and rewrite the text first.',
+  ]
+  process.stderr.write(lines.join('\n') + '\n')
+}
+
+main()

--- a/.claude/hooks/public-surface-reminder/package.json
+++ b/.claude/hooks/public-surface-reminder/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@socketsecurity/hook-public-surface-reminder",
+  "private": true,
+  "type": "module",
+  "main": "./index.mts",
+  "exports": {
+    ".": "./index.mts"
+  },
+  "devDependencies": {
+    "@types/node": "24.9.2"
+  }
+}

--- a/.claude/hooks/token-hygiene/README.md
+++ b/.claude/hooks/token-hygiene/README.md
@@ -1,0 +1,57 @@
+# token-hygiene
+
+Claude Code `PreToolUse` hook that refuses Bash tool calls that would leak secrets to tool output. Mandatory across the Socket fleet — every repo ships this file byte-for-byte via `scripts/sync-scaffolding.mjs`.
+
+## What it blocks
+
+| Rule | Example | Fix |
+|------|---------|-----|
+| Literal token in command | `echo vtwn_abc123…` | Rotate the exposed token; read tokens from `.env.local` at spawn time, never inline them |
+| `env`/`printenv`/`export -p`/`set` dumping everything | `env \| grep FOO` (unredacted) | `env \| sed 's/=.*/=<redacted>/'` or filter specific keys |
+| `.env*` read without redactor | `cat .env.local` | `sed 's/=.*/=<redacted>/' .env.local` or `grep -v '^#' .env.local \| cut -d= -f1` |
+| `curl -H "Authorization:"` with unfiltered stdout | `curl -H "Authorization: Bearer $TOKEN" api.example.com` | Redirect to file/`/dev/null`, or pipe to `jq`/`grep`/`head`/`wc`/`cut`/`awk` |
+| References sensitive env var name writing unredacted to stdout | `echo $API_KEY` | Same as above |
+
+## What it allows
+
+- Any write to a file (`>`, `>>`, `tee`)
+- Any pipe through `jq`, `grep`, `head`, `tail`, `wc`, `cut`, `awk`, `sed s/=.*/=<redacted>/`, `python3 -m json.tool`
+- Legitimate `git`/`pnpm`/`npm`/`node`/`tsc`/`oxfmt`/`oxlint` invocations that happen to reference env var names but don't echo values
+- Any curl call that does not carry an `Authorization:` header
+
+## Detected token shapes
+
+Literal value patterns caught in-command:
+
+- Val Town — `vtwn_`
+- Linear — `lin_api_`
+- OpenAI / Anthropic — `sk-` (20+ chars)
+- Stripe — `sk_live_`, `sk_test_`, `pk_live_`, `rk_live_`
+- GitHub — `ghp_`, `gho_`, `ghs_`, `ghu_`, `ghr_`, `github_pat_`
+- GitLab — `glpat-`
+- AWS — `AKIA…`
+- Slack — `xoxb-`, `xoxa-`, `xoxp-`, `xoxr-`, `xoxs-`
+- Google — `AIza…`
+- JWTs — three-segment `eyJ…`
+
+## Control flow
+
+The hook reads the tool-use payload from stdin, type-checks `tool_name === 'Bash'`, and runs `check(command)`. Any rule violation `throw`s a typed `BlockError`; a single top-level `try/catch` in `main()` writes the block message to stderr and sets `process.exitCode = 2`. Hook bugs fail **open** — a crash in the hook writes a log line and returns exit 0 so legitimate work isn't blocked on a bad deploy.
+
+## Testing
+
+```bash
+pnpm --filter @socketsecurity/hook-token-hygiene test
+```
+
+Adding new token-shape detections: update `LITERAL_TOKEN_PATTERNS` in `index.mts`, add a positive and negative test in `test/token-hygiene.test.mts`.
+
+## Updating across the fleet
+
+This file is in `IDENTICAL_FILES` in `scripts/sync-scaffolding.mjs`. After editing, run from `socket-repo-template`:
+
+```bash
+node scripts/sync-scaffolding.mjs --all --fix
+```
+
+to propagate the change to every fleet repo.

--- a/.claude/hooks/token-hygiene/index.mts
+++ b/.claude/hooks/token-hygiene/index.mts
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+// Claude Code PreToolUse hook — token-hygiene firewall.
+//
+// Blocks Bash commands that would echo token-bearing env vars into
+// tool output. This fires BEFORE the command runs; exit code 2 makes
+// Claude Code refuse the tool call. The model sees the rejection
+// reason on stderr and retries with a redacted formulation.
+//
+// Blocked patterns:
+//   - Literal token shapes in the command string (vtwn_, lin_api_,
+//     sk-, ghp_, AKIA, xox, AIza, JWT, etc.) — hardest block, logs
+//     a redacted message and urges rotation
+//   - `env`, `printenv`, `export -p`, `set` with no filter pipeline
+//   - `cat` / `head` / `tail` / `less` / `more` of .env* files
+//     without a redaction step
+//   - `curl -H "Authorization: ..."` with output going to unfiltered
+//     stdout (not /dev/null, not a file, not piped to jq/grep/etc.)
+//   - Commands referencing a sensitive env var name (*TOKEN*,
+//     *SECRET*, *PASSWORD*, *API_KEY*, *SIGNING_KEY*, *PRIVATE_KEY*,
+//     *AUTH*, *CREDENTIAL*) that write to stdout without redaction
+//
+// Control flow uses a `BlockError` thrown from check helpers so every
+// short-circuit path goes through a single `process.exitCode = 2`
+// drop at the top-level catch — no scattered `process.exit(2)` that
+// can race with buffered stderr.
+
+import process from 'node:process'
+
+// Name fragments matched case-insensitively against the command.
+const SENSITIVE_ENV_NAMES = [
+  'TOKEN',
+  'SECRET',
+  'PASSWORD',
+  'PASS',
+  'API_KEY',
+  'APIKEY',
+  'SIGNING_KEY',
+  'PRIVATE_KEY',
+  'AUTH',
+  'CREDENTIAL',
+]
+
+// Pipelines that "launder" earlier-stage secrets into safe output.
+const REDACTION_MARKERS = [
+  /\bsed\b[^|]*s[/|#][^/|#]*=[^/|#]*<?redact/i,
+  /\bsed\b[^|]*s[/|#][^/|#]*[A-Z_]+=[^/|#]*\*+/i,
+  /\|\s*cut\b[^|]*-d['"]?=['"]?\s*-f\s*1/i,
+  /\|\s*awk\b[^|]*-F\s*['"]?=['"]?/i,
+  />\s*\/dev\/null/,
+  />>\s*[^|]/,
+  />\s*[^|]/,
+]
+
+// Commands that dump all env vars to stdout with no filter.
+const ALWAYS_DANGEROUS = [
+  /^\s*env\s*(?:\||&&|;|$)/,
+  /^\s*env\s*$/,
+  /^\s*printenv\s*(?:\||&&|;|$)/,
+  /^\s*printenv\s*$/,
+  /^\s*export\s+-p\s*(?:\||&&|;|$)/,
+  /^\s*set\s*(?:\||&&|;|$)/,
+]
+
+// Plain reads of .env files that would dump values to stdout.
+const ENV_FILE_READ = /\b(?:cat|head|tail|less|more|bat)\b[^|]*\.env[^/\s|]*/
+
+// curl calls that include an Authorization header.
+const CURL_WITH_AUTH =
+  /\bcurl\b(?:[^|]|\|(?!\s*(?:sed|grep|head|tail|jq)))*(?:-H|--header)\s*['"]?Authorization:/i
+
+// Literal token-shape patterns — if any match in the command string,
+// a real token has been pasted somewhere it shouldn't have been.
+const LITERAL_TOKEN_PATTERNS: Array<[RegExp, string]> = [
+  [/\bvtwn_[A-Za-z0-9_-]{8,}/, 'Val Town token (vtwn_)'],
+  [/\blin_api_[A-Za-z0-9_-]{8,}/, 'Linear API token (lin_api_)'],
+  [/\bsk-[A-Za-z0-9_-]{20,}/, 'OpenAI/Anthropic-style secret key (sk-)'],
+  [/\bsk_live_[A-Za-z0-9_-]{16,}/, 'Stripe live secret (sk_live_)'],
+  [/\bsk_test_[A-Za-z0-9_-]{16,}/, 'Stripe test secret (sk_test_)'],
+  [/\bpk_live_[A-Za-z0-9_-]{16,}/, 'Stripe live publishable (pk_live_)'],
+  [/\brk_live_[A-Za-z0-9_-]{16,}/, 'Stripe live restricted (rk_live_)'],
+  [/\bghp_[A-Za-z0-9]{30,}/, 'GitHub personal access token (ghp_)'],
+  [/\bgho_[A-Za-z0-9]{30,}/, 'GitHub OAuth token (gho_)'],
+  [/\bghs_[A-Za-z0-9]{30,}/, 'GitHub app server token (ghs_)'],
+  [/\bghu_[A-Za-z0-9]{30,}/, 'GitHub user access token (ghu_)'],
+  [/\bghr_[A-Za-z0-9]{30,}/, 'GitHub refresh token (ghr_)'],
+  [/\bgithub_pat_[A-Za-z0-9_]{20,}/, 'GitHub fine-grained PAT'],
+  [/\bglpat-[A-Za-z0-9_-]{16,}/, 'GitLab PAT (glpat-)'],
+  [/\bAKIA[0-9A-Z]{16}/, 'AWS access key ID (AKIA)'],
+  [/\bxox[baprs]-[A-Za-z0-9-]{10,}/, 'Slack token (xox_-)'],
+  [/\bAIza[0-9A-Za-z_-]{35}/, 'Google API key (AIza)'],
+  [/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/, 'JWT'],
+]
+
+class BlockError extends Error {
+  public readonly rule: string
+  public readonly suggestion: string
+  public readonly showCommand: boolean
+  constructor(rule: string, suggestion: string, showCommand = true) {
+    super(rule)
+    this.name = 'BlockError'
+    this.rule = rule
+    this.suggestion = suggestion
+    this.showCommand = showCommand
+  }
+}
+
+const stdin = (): Promise<string> =>
+  new Promise(resolve => {
+    let buf = ''
+    process.stdin.setEncoding('utf8')
+    process.stdin.on('data', chunk => (buf += chunk))
+    process.stdin.on('end', () => resolve(buf))
+  })
+
+type ToolInput = {
+  tool_name?: string
+  tool_input?: { command?: string }
+}
+
+const hasRedaction = (command: string): boolean =>
+  REDACTION_MARKERS.some(re => re.test(command))
+
+const referencesSensitiveEnv = (command: string): boolean => {
+  const upper = command.toUpperCase()
+  return SENSITIVE_ENV_NAMES.some(frag => upper.includes(frag))
+}
+
+const matchesAlwaysDangerous = (command: string): RegExp | null => {
+  for (const re of ALWAYS_DANGEROUS) {
+    if (re.test(command)) {
+      return re
+    }
+  }
+  return null
+}
+
+const check = (command: string): void => {
+  // 0. Literal token-shape in the command string — hardest block.
+  // A real token value already landed in the command, which itself is
+  // logged. We refuse to echo it further and urge rotation.
+  for (const [pattern, label] of LITERAL_TOKEN_PATTERNS) {
+    if (pattern.test(command)) {
+      throw new BlockError(
+        `literal ${label} found in command string`,
+        'Rotate the exposed token immediately. Never paste tokens into commands; read them from .env.local or a keychain at subprocess spawn time.',
+        false,
+      )
+    }
+  }
+
+  // 1. Always-dangerous patterns.
+  const dangerous = matchesAlwaysDangerous(command)
+  if (dangerous) {
+    throw new BlockError(
+      `\`${dangerous.source}\` dumps env to stdout`,
+      'Pipe through redaction, e.g. `env | sed "s/=.*/=<redacted>/"` or filter specific keys.',
+    )
+  }
+
+  // 2. .env file reads without redaction.
+  if (ENV_FILE_READ.test(command) && !hasRedaction(command)) {
+    throw new BlockError(
+      '.env file read without a redaction pipeline',
+      'Use `sed "s/=.*/=<redacted>/" .env.local` or `grep -v "^#" .env.local | cut -d= -f1` for key names only.',
+    )
+  }
+
+  // 3. curl with Authorization header and unsanitized stdout.
+  const curlHasAuth = CURL_WITH_AUTH.test(command)
+  const curlOutputSafe =
+    />\s*\/dev\/null|>\s*[^|&]/.test(command) ||
+    /\|\s*(?:jq|grep|head|tail|wc|cut|awk|python3?\s+-m\s+json\.tool)\b/.test(
+      command,
+    )
+  if (curlHasAuth && !curlOutputSafe) {
+    throw new BlockError(
+      'curl with Authorization header and unsanitized stdout',
+      'Redirect response to /dev/null, pipe to jq/grep/head, or save to a file.',
+    )
+  }
+
+  // 4. References a sensitive env var name and writes to stdout
+  // without a redaction step. Skip when curl-with-auth passed — that
+  // rule already evaluated the same pipeline.
+  if (
+    !curlHasAuth &&
+    referencesSensitiveEnv(command) &&
+    !hasRedaction(command)
+  ) {
+    const isPureWrite = /^\s*(?:git|pnpm|npm|node|tsc|oxfmt|oxlint)\b/.test(
+      command,
+    )
+    if (!isPureWrite) {
+      throw new BlockError(
+        'command references sensitive env var name and writes to stdout without redaction',
+        'Redirect to a file, pipe through `sed "s/=.*/=<redacted>/"`, or ensure only key names (not values) are printed.',
+      )
+    }
+  }
+}
+
+const emitBlock = (command: string, err: BlockError): void => {
+  const safeCommand = err.showCommand
+    ? command.slice(0, 200) + (command.length > 200 ? '…' : '')
+    : '<command suppressed to avoid re-logging the literal token>'
+  process.stderr.write(
+    `\n[token-hygiene] Blocked: ${err.rule}\n` +
+      `  Command: ${safeCommand}\n` +
+      `  Fix: ${err.suggestion}\n\n`,
+  )
+}
+
+const main = async (): Promise<void> => {
+  const raw = await stdin()
+  if (!raw) {
+    return
+  }
+  let payload: ToolInput
+  try {
+    payload = JSON.parse(raw) as ToolInput
+  } catch {
+    return
+  }
+  if (payload.tool_name !== 'Bash') {
+    return
+  }
+  const command = payload.tool_input?.command ?? ''
+  if (!command) {
+    return
+  }
+
+  try {
+    check(command)
+  } catch (e) {
+    if (e instanceof BlockError) {
+      emitBlock(command, e)
+      process.exitCode = 2
+      return
+    }
+    throw e
+  }
+}
+
+main().catch(e => {
+  // Never block a tool call due to a bug in the hook itself. Log it
+  // so we notice, but fail open.
+  process.stderr.write(`[token-hygiene] hook error (allowing): ${e}\n`)
+  process.exitCode = 0
+})

--- a/.claude/hooks/token-hygiene/package.json
+++ b/.claude/hooks/token-hygiene/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@socketsecurity/hook-token-hygiene",
+  "private": true,
+  "type": "module",
+  "main": "./index.mts",
+  "exports": {
+    ".": "./index.mts"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mts"
+  },
+  "devDependencies": {
+    "@socketsecurity/lib": "catalog:",
+    "@types/node": "24.9.2"
+  }
+}

--- a/.claude/hooks/token-hygiene/test/token-hygiene.test.mts
+++ b/.claude/hooks/token-hygiene/test/token-hygiene.test.mts
@@ -1,0 +1,206 @@
+/**
+ * @fileoverview Tests for the token-hygiene hook.
+ *
+ * Runs the hook as a subprocess (node --test), piping a tool-use
+ * payload on stdin and asserting on the exit code + stderr. Exit 2
+ * means the hook refused the command; exit 0 means it passed it
+ * through.
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { whichSync } from '@socketsecurity/lib/bin'
+import { spawnSync } from '@socketsecurity/lib/spawn'
+
+const hookScript = new URL('../index.mts', import.meta.url).pathname
+const nodeBin = whichSync('node')
+if (!nodeBin) {
+  throw new Error('"node" not found on PATH')
+}
+
+function runHook(command: string, toolName = 'Bash'): {
+  code: number | null
+  stdout: string
+  stderr: string
+} {
+  const input = JSON.stringify({
+    tool_name: toolName,
+    tool_input: { command },
+  })
+  const result = spawnSync(nodeBin, [hookScript], {
+    input,
+    timeout: 5_000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+  return {
+    code: result.status,
+    stdout: (result.stdout || '').toString(),
+    stderr: (result.stderr || '').toString(),
+  }
+}
+
+describe('token-hygiene hook', () => {
+  describe('allows safe commands', () => {
+    it('plain echo', () => {
+      assert.equal(runHook('echo hello').code, 0)
+    })
+    it('git log', () => {
+      assert.equal(runHook('git log -1 --oneline').code, 0)
+    })
+    it('pnpm install', () => {
+      assert.equal(runHook('pnpm install').code, 0)
+    })
+    it('node script', () => {
+      assert.equal(runHook('node scripts/build.mts').code, 0)
+    })
+    it('sed with redaction on .env', () => {
+      assert.equal(
+        runHook("sed 's/=.*/=<redacted>/' .env.local").code,
+        0,
+      )
+    })
+    it('grep key-names-only on .env', () => {
+      assert.equal(
+        runHook("grep -v '^#' .env.local | cut -d= -f1").code,
+        0,
+      )
+    })
+    it('curl without Authorization header', () => {
+      assert.equal(runHook('curl -sS https://api.example.com').code, 0)
+    })
+    it('curl with auth piped to jq', () => {
+      assert.equal(
+        runHook(
+          'curl -sS -H "Authorization: Bearer $TOKEN" https://api.example.com | jq .name',
+        ).code,
+        0,
+      )
+    })
+    it('curl with auth redirected to file', () => {
+      assert.equal(
+        runHook(
+          'curl -sS -H "Authorization: Bearer $TOKEN" https://api.example.com > out.json',
+        ).code,
+        0,
+      )
+    })
+    it('non-Bash tool is always allowed', () => {
+      assert.equal(runHook('env', 'Edit').code, 0)
+    })
+  })
+
+  describe('blocks literal token shapes', () => {
+    it('Val Town token', () => {
+      const r = runHook('echo vtwn_ABCDEFGHIJKL')
+      assert.equal(r.code, 2)
+      assert.match(r.stderr, /Val Town token/)
+    })
+    it('Linear API token', () => {
+      const r = runHook('echo lin_api_ABCDEFGHIJKLMNOP')
+      assert.equal(r.code, 2)
+      assert.match(r.stderr, /Linear API token/)
+    })
+    it('GitHub PAT', () => {
+      const r = runHook(
+        'echo ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcd1234',
+      )
+      assert.equal(r.code, 2)
+      assert.match(r.stderr, /GitHub personal access token/)
+    })
+    it('AWS access key', () => {
+      const r = runHook('echo AKIAIOSFODNN7EXAMPLE')
+      assert.equal(r.code, 2)
+      assert.match(r.stderr, /AWS access key/)
+    })
+    it('Stripe test secret', () => {
+      const r = runHook('echo sk_test_ABCDEFGHIJKLMNOP')
+      assert.equal(r.code, 2)
+      assert.match(r.stderr, /Stripe test secret/)
+    })
+    it('JWT', () => {
+      const r = runHook(
+        'echo eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+      )
+      assert.equal(r.code, 2)
+      assert.match(r.stderr, /JWT/)
+    })
+    it('redacts the command in stderr so the literal token is not re-logged', () => {
+      const r = runHook('echo vtwn_SECRETVALUE')
+      assert.equal(r.code, 2)
+      assert.doesNotMatch(r.stderr, /SECRETVALUE/)
+      assert.match(r.stderr, /suppressed/)
+    })
+  })
+
+  describe('blocks env/printenv dumps', () => {
+    it('bare env', () => {
+      assert.equal(runHook('env').code, 2)
+    })
+    it('env piped without redactor', () => {
+      assert.equal(runHook('env | grep FOO').code, 2)
+    })
+    it('printenv', () => {
+      assert.equal(runHook('printenv').code, 2)
+    })
+    it('export -p', () => {
+      assert.equal(runHook('export -p').code, 2)
+    })
+  })
+
+  describe('blocks .env reads without redaction', () => {
+    it('cat .env.local', () => {
+      assert.equal(runHook('cat .env.local').code, 2)
+    })
+    it('head .env', () => {
+      assert.equal(runHook('head .env').code, 2)
+    })
+    it('less .env.production', () => {
+      assert.equal(runHook('less .env.production').code, 2)
+    })
+  })
+
+  describe('blocks curl with auth to unfiltered stdout', () => {
+    it('plain curl -H Authorization', () => {
+      const r = runHook(
+        'curl -sS -H "Authorization: Bearer $TOKEN" https://api.example.com',
+      )
+      assert.equal(r.code, 2)
+      assert.match(r.stderr, /Authorization header and unsanitized stdout/)
+    })
+  })
+
+  describe('blocks sensitive-env-name references without redaction', () => {
+    it('echoing $API_KEY', () => {
+      assert.equal(runHook('echo $API_KEY').code, 2)
+    })
+    it('ruby -e with $TOKEN', () => {
+      assert.equal(
+        runHook('ruby -e "puts ENV[\'ACCESS_TOKEN\']"').code,
+        2,
+      )
+    })
+  })
+
+  describe('fails open on malformed input', () => {
+    it('empty stdin', () => {
+      const r = spawnSync(nodeBin, [hookScript], {
+        input: '',
+        timeout: 5_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
+      assert.equal(r.status, 0)
+    })
+    it('non-JSON stdin', () => {
+      const r = spawnSync(nodeBin, [hookScript], {
+        input: 'not json',
+        timeout: 5_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
+      assert.equal(r.status, 0)
+    })
+    it('empty command', () => {
+      assert.equal(runHook('').code, 0)
+    })
+  })
+})

--- a/.claude/hooks/token-hygiene/tsconfig.json
+++ b/.claude/hooks/token-hygiene/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "declarationMap": false,
+    "erasableSyntaxOnly": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noEmit": true,
+    "rewriteRelativeImportExtensions": true,
+    "skipLibCheck": true,
+    "sourceMap": false,
+    "strict": true,
+    "target": "esnext",
+    "verbatimModuleSyntax": true
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,15 @@
             "command": "node .claude/hooks/check-new-deps/index.mts"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/public-surface-reminder/index.mts"
+          }
+        ]
       }
     ]
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,6 +16,10 @@
           {
             "type": "command",
             "command": "node .claude/hooks/public-surface-reminder/index.mts"
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/token-hygiene/index.mts"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,8 @@ The umbrella rule: never run a git command that mutates state belonging to a pat
 - Never create files unless necessary; always prefer editing existing files
 - Forbidden to create docs unless requested
 - 🚨 **NEVER use `npx`, `pnpm dlx`, or `yarn dlx`** — use `pnpm exec <package>` or `pnpm run <script>`
+- **NEVER reference Linear issues** (e.g. `SOC-123`, `ENG-456`, `ASK-789`, Linear URLs) in code, code comments, or PR titles/descriptions/review comments. Linear tracking lives in Linear; keep the codebase and PR history tool-agnostic.
+- 🚨 **NEVER write a real customer or company name into any commit, PR, issue, GitHub comment, or release note.** When about to write any name, stop and ask: "is this a real company?" If yes, replace it with `Acme Inc` (or drop the reference entirely). No enumerated denylist exists anywhere — a denylist is itself a leak. Recognition is done at write time, every time. The `.claude/hooks/public-surface-reminder` hook re-prints this rule on every public-surface `git`/`gh` command as a priming nudge; the rule still applies when the hook is not installed.
 
 ## EVOLUTION
 
@@ -115,6 +117,7 @@ If user repeats instruction 2+ times, ask: "Should I add this to CLAUDE.md?"
 - `Promise.race` / `Promise.any`: NEVER pass a long-lived promise (interrupt signal, pool member) into a race inside a loop. Each call re-attaches `.then` handlers to every arm; handlers accumulate on surviving promises until they settle. For concurrency limiters, use a single-waiter "slot available" signal (resolved by each task's `.then`) instead of re-racing `executing[]`. See nodejs/node#17469 and `@watchable/unpromise`. Race with two fresh arms (e.g. one-shot `withTimeout`) is safe.
 - File existence: ALWAYS `existsSync` from `node:fs`. NEVER `fs.access`, `fs.stat`-for-existence, or an async `fileExists` wrapper. Import: `import { existsSync, promises as fs } from 'node:fs'`.
 - Stream discipline: stdout carries ONLY the data the command was asked to produce (JSON payload, report, fix output — the thing a script pipes into `jq` or redirects to a file). stderr carries everything else: progress, spinners, status, warnings, errors, dry-run previews, context, banners, prompts. Test: would `command | jq` or `command > file` make sense with only the stdout content? If no, it belongs on stderr. Under `--json` / `--markdown`, stdout MUST parse as the declared format with no prefix/suffix text.
+- Replying to Cursor Bugbot: reply on the inline review-comment thread, not as a detached PR comment, so the reply threads under the bot's finding. Use `gh api repos/{owner}/{repo}/pulls/{pr}/comments/{comment_id}/replies -X POST -f body=...`. Find the `{comment_id}` via `gh api repos/{owner}/{repo}/pulls/{pr}/comments -q '.[] | select(.user.login == "cursor[bot]") | {id, path, line, body: (.body|.[0:200])}'`. Detached `gh pr comment` is wrong for bot findings.
 
 ### Documentation Policy
 


### PR DESCRIPTION
## Summary

Adds two Claude Code `PreToolUse` hooks under `.claude/hooks/`, both matched to `Bash`, with different intents:

- **`public-surface-reminder`** — *never blocks*. On every `git commit`, `git push`, `gh pr …`, `gh issue …`, `gh api -X POST|PATCH|PUT`, or `gh release …`, prints a short reminder to stderr re-stating the two rules the model must apply before the command runs:
  1. No real customer / company names — use `Acme Inc`.
  2. No internal tracker IDs or URLs (`SOC-123`, `ENG-456`, linear.app, sentry.io, etc.).

  Attention priming, not enforcement. Exit code is always 0.

- **`token-hygiene`** — *hard-blocks on exit 2*. Refuses `Bash` commands that would exfiltrate secrets to tool output:
  - Literal token-shaped strings pasted into a command (`vtwn_…`, `lin_api_…`, `sk-…`, `ghp_…`, `AKIA…`, Slack `xox…`, Google `AIza…`, JWTs, etc.) — hardest block; the command is suppressed from the rejection log and rotation is urged.
  - `env` / `printenv` / `export -p` / `set` with no filter pipeline.
  - `cat` / `head` / `tail` / `less` / `more` of `.env*` files without a redaction step.
  - `curl -H "Authorization: …"` whose stdout isn't `/dev/null`, a file, or piped to `jq`/`grep`/`head`/etc.
  - Commands referencing a sensitive env var name (`*TOKEN*`, `*SECRET*`, `*PASSWORD*`, `*API_KEY*`, `*SIGNING_KEY*`, `*PRIVATE_KEY*`, `*AUTH*`, `*CREDENTIAL*`) that write to stdout without redaction.

Both hooks ship in [`socket-repo-template`](https://github.com/SocketDev/socket-repo-template) and are being rolled out fleet-wide.

## CLAUDE.md addition

The file-write/absolute-rules block in `CLAUDE.md` already documents the customer-name and tracker-ID rules; `public-surface-reminder` re-prints them to stderr as a priming nudge at command time, and `token-hygiene` supplies the actual block for the token exfiltration case.

## Template parity fix

The template's `token-hygiene/test/token-hygiene.test.mts` imports `@socketsecurity/lib` (for `whichSync` + `spawnSync`) but the hook's `package.json` never declared the dep. Adding `@socketsecurity/lib: "catalog:"` under `devDependencies` in this PR; a matching fix will go back to the template so future copies are clean out of the box.

## Test plan

- [x] `settings.json` parses as valid JSON; both hooks wired under the `Bash` matcher.
- [x] Hook dirs (`public-surface-reminder/`, `token-hygiene/`) contain `index.mts`, `package.json`, `README.md` at minimum; `token-hygiene` also carries `tsconfig.json` and `test/` for the subprocess-level test.
- [x] `node_modules/` not committed (gitignored by `**/node_modules/`).
- [ ] CI green on the full suite.
- [ ] Manual: after merge, run a command that matches `token-hygiene`'s rule — e.g. `cat .env.local` — and confirm the hook blocks with exit 2 and stderr explanation.
- [ ] Manual: run `git commit` and confirm `public-surface-reminder` prints the three-rule reminder to stderr without blocking.