### PR TITLE
chore(test): move vitest cache to node_modules/.cache

### DIFF
--- a/.config/vitest.config.base.mts
+++ b/.config/vitest.config.base.mts
@@ -28,7 +28,10 @@ const isCoverageEnabled =
 const projectRoot = path.resolve(import.meta.dirname, '..')
 
 export default defineConfig({
-  cacheDir: path.resolve(projectRoot, '.cache/vitest'), // Explicit cache directory for consistent behavior.
+  // `pnpm install` wipes `node_modules/` on every install,
+  // giving us free cache invalidation without a dedicated
+  // clean step.
+  cacheDir: path.resolve(projectRoot, 'node_modules/.cache/vitest'),
   test: {
     globals: false,
     environment: 'node',

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ yarn-error.log*
 # ============================================================================
 **/.build-checkpoints
 **/*.build-signature
-**/.cache/
 /.rollup.cache
 **/.type-coverage/
 **/build/


### PR DESCRIPTION
## Summary

- Vitest's `cacheDir` moves from `<repo>/.cache/vitest` to `<repo>/node_modules/.cache/vitest` in the shared vitest base config. The isolated config extends from it, so it picks up the change automatically.
- `pnpm install` already wipes `node_modules/` (and its `.cache/` subdir), so this buys us free cache invalidation on every install — no dedicated clean step needed.
- Matches the pattern just applied in `../socket-packageurl-js`, `../socket-sdk-js` (#616), and `../meander`.
- Drops `**/.cache/` from `.gitignore` since nothing writes to a top-level `.cache/` anymore.

## Test plan

- [ ] CI runs `pnpm lint` + `pnpm test` + `pnpm run build`.
- Local `pnpm install` / `pnpm test` — not run here; the worktree I authored this from had a pre-existing `packages/package-builder/build/…` workspace-link issue that blocked install. The pre-commit hook's docstring expressly allows `--no-verify` for local bypass while the pre-push hook continues to enforce security checks, so the commit was made with `--no-verify` knowing CI will fully verify. Nothing in the diff would be affected by the skipped local check (it's a 2-line config change + gitignore cleanup).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes test runner cache location and a gitignore pattern, with no runtime or production code impact.
> 
> **Overview**
> Vitest now writes its cache to `node_modules/.cache/vitest` (instead of a top-level `.cache/vitest`), relying on `pnpm install` to naturally invalidate caches by wiping `node_modules/`.
> 
> `.gitignore` is tightened by removing the broad `**/.cache/` ignore since the repo no longer uses a top-level `.cache/` directory for Vitest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 021b8ace53a2f6824dbbc671a42b5a48201160e5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->