### PR TITLE
chore(pnpm): declare defaults in pnpm-workspace.yaml; drop dead .npmrc trust-policy

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,3 @@
 # npm v11+ settings (not pnpm — pnpm v11 only reads auth/registry from .npmrc).
 ignore-scripts=true
 min-release-age=7
-trust-policy=no-downgrade
-trust-policy-exclude[]=undici@6.21.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -216,6 +216,15 @@ overrides:
   yaml: 'catalog:'
   yargs-parser: 'catalog:'
 
+# Auto-install missing peer deps (pnpm default). Declared explicitly
+# so a future default flip can't silently change install behavior.
+autoInstallPeers: true
+
+# Run pre/post lifecycle scripts on the workspace root (e.g.
+# prepare -> husky). This is the pnpm default; declared explicitly
+# so a future default flip can't silently disable husky setup.
+enablePrePostScripts: true
+
 # Patched dependencies (migrated from package.json pnpm.patchedDependencies).
 patchedDependencies:
   '@npmcli/run-script@10.0.4': patches/@npmcli__run-script@10.0.4.patch


### PR DESCRIPTION
## Summary

Two config hygiene fixes grouped into one PR.

### 1. Declare pnpm defaults in `pnpm-workspace.yaml`

pnpm v11 reads settings from `pnpm-workspace.yaml` (and the npm-compat subset from `.npmrc`), **not from `.pnpmrc`**. My earlier version of this PR added a `.pnpmrc` file; that file would have been silently ignored.

Instead, declare the two relevant pnpm defaults explicitly in `pnpm-workspace.yaml`:

- `autoInstallPeers: true` — pnpm default, declared explicitly so a silent default flip can't change install behavior.
- `enablePrePostScripts: true` — pnpm default, declared explicitly so a silent flip can't quietly disable husky's `prepare` hook.

### 2. Drop dead `trust-policy` lines from `.npmrc`

socket-cli's `.npmrc` carried:

```
trust-policy=no-downgrade
trust-policy-exclude[]=undici@6.21.3
```

These are not npm settings — the [npm v11 config reference](https://docs.npmjs.com/cli/v11/using-npm/config) has no `trust-policy` key, and pnpm reads `trustPolicy` from `pnpm-workspace.yaml`, not from `.npmrc`. The entries were silent no-ops. socket-cli already has the correct pnpm-side values:

```yaml
trustPolicy: no-downgrade
trustPolicyExclude:
  - undici@6.21.3
```

so the real policy was being applied the whole time. Removing the dead duplicates.

## No behavioral change

Install/resolve/build work identically. This just puts each setting in the file the relevant tool actually reads.

## Test plan

- [x] `pnpm install` succeeds locally.
- [ ] CI green.