### PR TITLE
chore(deps): bump postcss to >=8.5.10 (GHSA-qx2v-qp2m-jg93)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,7 @@ overrides:
   npm-package-arg: 13.0.0
   packageurl-js: npm:@socketregistry/packageurl-js@^1.4.2
   path-parse: npm:@socketregistry/path-parse@^1.0.8
+  postcss: '>=8.5.10'
   qs: '>=6.15.1'
   safe-buffer: npm:@socketregistry/safe-buffer@^1.0.9
   safer-buffer: npm:@socketregistry/safer-buffer@^1.0.10
@@ -2175,7 +2176,6 @@ packages:
 
   '@socketaddon/iocraft@file:packages/package-builder/build/dev/out/socketaddon-iocraft':
     resolution: {directory: packages/package-builder/build/dev/out/socketaddon-iocraft, type: directory}
-    engines: {node: '>=18'}
 
   '@socketregistry/es-set-tostringtag@1.0.10':
     resolution: {integrity: sha512-btXmvw1JpA8WtSoXx9mTapo9NAyIDKRRzK84i48d8zc0X09M6ORfobVnHbgwhXf7CFhkRzhYrHG9dqbI9vpELQ==}
@@ -3785,8 +3785,8 @@ packages:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
 
-  postcss@8.5.9:
-    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postject@1.0.0-alpha.6:
@@ -7337,7 +7337,7 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.9:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -7937,7 +7937,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.9
+      postcss: 8.5.10
       rollup: 4.60.1
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -196,6 +196,7 @@ overrides:
   npm-package-arg: 'catalog:'
   packageurl-js: 'catalog:'
   path-parse: 'catalog:'
+  postcss: '>=8.5.10'
   qs: '>=6.15.1'
   safe-buffer: 'catalog:'
   safer-buffer: 'catalog:'


### PR DESCRIPTION
## Summary

Fixes https://github.com/SocketDev/socket-cli/security/dependabot/134.

postcss < 8.5.10 does not escape `</style>` sequences when stringifying CSS ASTs. When user-submitted CSS is re-stringified for embedding in HTML `<style>` tags, `</style>` in CSS values breaks out of the style context and allows XSS via a following `<script>`. See [GHSA-qx2v-qp2m-jg93](https://github.com/postcss/postcss/security/advisories/GHSA-qx2v-qp2m-jg93) / [CVE-2026-41305](https://nvd.nist.gov/vuln/detail/CVE-2026-41305). CVSS v3.1 6.1 (medium).

## What's changed

- `pnpm-workspace.yaml`: add `postcss: '>=8.5.10'` to the overrides block.
- `pnpm-lock.yaml`: regenerated — postcss bumped `8.5.9 → 8.5.10` (both importers: the direct resolution and the vite transitive).

## Why an override vs. dep bump

postcss is a transitive dev-scope dep (via vite@7.3.2). The overrides block is the right tool here — matches the existing shape (`defu: '>=6.1.7'`, `glob: '>=13.0.6'`, `qs: '>=6.15.1'` are the same pattern for the same reason). Overriding sets a floor without pinning exact, so future patch bumps land organically.

## Test plan

- [ ] Dependabot alert auto-resolves after merge (floor now >= 8.5.10).
- [ ] CI green.
- [ ] `pnpm install` in a clean clone succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: dependency override plus lockfile regen to pick up a patch release; main risk is minor build/CSS tooling behavior differences from the PostCSS patch update.
> 
> **Overview**
> **Security-driven dependency update:** adds a pnpm `overrides` floor of `postcss: '>=8.5.10'` in `pnpm-workspace.yaml`.
> 
> Regenerates `pnpm-lock.yaml` so `postcss` resolves to `8.5.10` (including the `vite` transitive), addressing the advisory affecting older PostCSS versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de68c95d65acc0520fcc57fdbee82ad4ab4ef1ff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->