### PR TITLE
chore(ci): cascade socket-registry pin to ea1986b8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
         with:
           checkout: 'false'
 
@@ -168,7 +168,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
         with:
           checkout: 'false'
 
@@ -234,7 +234,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
         with:
           checkout: 'false'
           node-version: ${{ matrix.node-version }}
@@ -317,7 +317,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
         with:
           checkout: 'false'
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
         with:
           checkout: 'false'
 
@@ -91,7 +91,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
         with:
           checkout: 'false'
           registry-url: 'https://registry.npmjs.org'
@@ -141,7 +141,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
         with:
           checkout: 'false'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
         with:
           checkout: 'false'
 
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
         with:
           checkout: 'false'
 
@@ -79,7 +79,7 @@ jobs:
           git checkout -b "$BRANCH_NAME" HEAD~1
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -332,7 +332,7 @@ jobs:
             test.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
         if: always()
 
   notify:


### PR DESCRIPTION
## Summary

Bumps every `SocketDev/socket-registry@<sha>` reference from `b9918c72` to `ea1986b8`. This is the cascade for socket-registry's Layer 3 merge that landed the hardened external-tools.json reads + new `lib/*.mjs` helpers (jq, platform, install-tool, semver) and added full musl + multi-flavor SFW support.

## Why

Eliminates the `cp: cannot stat ''` failure shape — empty `SOCKET_TOOL_*` env exports from the registry's setup/checkout/install actions are no longer reachable, since all JSON path reads now go through `node lib/jq.mjs` which exits non-zero on missing/empty values, and `set -e` propagates.

## Test plan

- [ ] CI pipeline runs against the new pin and passes
- [ ] Provenance publish path remains unaffected
- [ ] Weekly update job still resolves

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the pinned SHA for shared `SocketDev/socket-registry` GitHub Actions used by CI, publish/provenance, and weekly-update workflows; risk is mainly that behavior changes in the external action could impact installs or release automation.
> 
> **Overview**
> Bumps all `SocketDev/socket-registry` action pins from `b9918c72…` to `ea1986b80…` across the `ci.yml`, `provenance.yml`, and `weekly-update.yml` workflows.
> 
> No workflow logic changes beyond switching the referenced action revisions (including `setup-and-install`, plus weekly update’s `setup-git-signing`/`cleanup-git-signing`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19ff07cb77aeb84622f38b532018eab1a1e04ba3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->