### PR TITLE
upgrading coana to version 14.12.222

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.87](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.87) - 2026-04-28
+
+### Changed
+- Updated the Coana CLI to v `14.12.222`.
+
 ## [1.1.86](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.86) - 2026-04-24
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.86",
+  "version": "1.1.87",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -97,7 +97,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "14.12.219",
+    "@coana-tech/cli": "14.12.222",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 14.12.219
-        version: 14.12.219
+        specifier: 14.12.222
+        version: 14.12.222
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@14.12.219':
-    resolution: {integrity: sha512-66zjhIEY+Of1RY4WOAxup1lDUWxTxrcguGvcAIKdlWubHjNU3gim6dICtUCZpwxsGVuOBVPqHGw+1E2yfEUwkg==}
+  '@coana-tech/cli@14.12.222':
+    resolution: {integrity: sha512-loRzorTOCuTigI5wLwZThIMHTlZfRBgnTR4FyoV/Dtfx0I61Kz+av3qpEqWIJFgLEf+kR7fbLQCsLL3Kzc01Tg==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5385,7 +5385,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@14.12.219': {}
+  '@coana-tech/cli@14.12.222': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 14.12.219 to 14.12.222

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency bump to the Coana CLI can change reachability/fix analysis behavior even though no first-party logic is modified.
> 
> **Overview**
> Bumps the CLI version to **`1.1.87`** and updates the bundled **Coana CLI** dependency (`@coana-tech/cli`) from `14.12.219` to `14.12.222` (including lockfile updates).
> 
> Updates `CHANGELOG.md` with the new release entry reflecting the Coana upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0735359f160e1c45cfc8fcdd4e9c7b2f050ee25. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->