### PR TITLE
fix(glob): strip trailing slash from gitignore-derived ignore patterns

### DIFF
--- a/src/utils/glob.mts
+++ b/src/utils/glob.mts
@@ -135,6 +135,22 @@ function ignorePatternToMinimatch(pattern: string): string {
   return `${negatedPrefix}${matchEverywherePrefix}${escapedPatternWithoutLeadingSlash}${matchInsideSuffix}`
 }
 
+// fast-glob silently discards `ignore` entries that end in `/` (it
+// treats them as literal directory paths, not glob patterns). The
+// gitignore convention of writing directory entries as `dist/` lands
+// here as `**/dist/` after `ignorePatternToMinimatch`, which fast-glob
+// then drops — defeating the entire ignore. Strip the trailing slash
+// so fast-glob actually honors the pattern.
+function stripTrailingSlash(pattern: string): string {
+  if (
+    pattern.length > 1 &&
+    pattern.charCodeAt(pattern.length - 1) === 47 /*'/'*/
+  ) {
+    return pattern.slice(0, -1)
+  }
+  return pattern
+}
+
 function workspacePatternToGlobPattern(workspace: string): string {
   const { length } = workspace
   if (!length) {
@@ -252,7 +268,9 @@ export async function globWithGitIgnore(
     absolute: true,
     cwd,
     dot: true,
-    ignore: hasNegatedPattern ? defaultIgnore : [...ignores],
+    ignore: hasNegatedPattern
+      ? defaultIgnore
+      : [...ignores].map(stripTrailingSlash),
     ...additionalOptions,
   } as GlobOptions
 

--- a/src/utils/glob.test.mts
+++ b/src/utils/glob.test.mts
@@ -182,6 +182,25 @@ describe('glob utilities', () => {
       ])
     })
 
+    it('should skip directories ignored via trailing-slash patterns', async () => {
+      // fast-glob silently drops `ignore` entries that end in `/`, so
+      // the pattern produced for `dist/` (`**/dist/`) used to do
+      // nothing at the walk level and dist contents leaked through.
+      mockTestFs({
+        [`${mockFixturePath}/.gitignore`]: 'dist/\n',
+        [`${mockFixturePath}/package.json`]: '{}',
+        [`${mockFixturePath}/dist/a.json`]: '{}',
+      })
+
+      const results = await globWithGitIgnore(['**/*.json'], {
+        cwd: mockFixturePath,
+      })
+
+      expect(results.map(normalizePath).sort()).toEqual([
+        `${mockFixturePath}/package.json`,
+      ])
+    })
+
     it('should combine filter with negated gitignore patterns', async () => {
       mockTestFs({
         [`${mockFixturePath}/.gitignore`]: 'build/**\n!build/manifest.json',


### PR DESCRIPTION
## Summary

TL;DR Buggy glob pattern generation caused traversal of ignored trees. 

- fast-glob silently discards `ignore` entries that end in `/` — the underlying micromatch matcher treats a trailing slash as a literal character that requires a matching trailing slash on the input path, and `readdir` entries never carry one. Validated this (to me non-obvious) behavior locally:
```
$ cat probe.mjs
import fg from 'fast-glob'

for (const pat of ['**/dist/', '**/dist', '**/dist/**']) {
  console.log(pat, await fg.glob(['**/*'], { cwd: 'fixture', ignore: [pat] }))
}

$ ls -T fixture/
fixture
├── a.txt
└── dist
    └── b.txt
$ node probe.mjs
**/dist/ [ 'a.txt', 'dist/b.txt' ]
**/dist [ 'a.txt' ]
**/dist/** [ 'a.txt' ]
```
 
- The standard gitignore convention of writing directory entries as `dist/` arrives at fast-glob as `**/dist/` after `ignorePatternToMinimatch`, so fast-glob walks the directory anyway and the result has to be filtered out post-walk — wasting a `readdir` of the entire subtree on every call.
- Strip the trailing slash before passing positives to fast-glob's `ignore` so the pattern actually matches.

## Test plan

- [x] New regression test: directory ignored via trailing-slash pattern is correctly excluded.
- [x] All pre-existing `globWithGitIgnore` tests still pass (11 total: 10 existing + 1 new).
- [x] `pnpm check:tsc` clean.
- [x] \`pnpm check:lint` clean on changed files.
- [x] End-to-end: `socket fix` against a fixture with a 300 000-file gitignored `dist/` and `--max-old-space-size=128` no longer OOMs and proceeds past the glob walk in well under a second.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes globbing ignore behavior for gitignore-derived directory entries, which can alter which files are scanned/returned. Low implementation complexity, but impacts filesystem traversal and results in tooling that relies on `globWithGitIgnore`.
> 
> **Overview**
> Fixes `globWithGitIgnore` so gitignore directory patterns written with a trailing slash (e.g. `dist/`) actually prevent `fast-glob` from walking those directories by normalizing ignore patterns via a new `stripTrailingSlash` helper.
> 
> Adds a regression test confirming that `dist/` in `.gitignore` excludes files under `dist/` from glob results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee428794c3ac8c6fa6341ba03bf5b0afaded939b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->