### PR TITLE
brotli-compress .socket.facts.json on upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`socket manifest bazel [beta]`** — Generate Bazel JVM SBOM manifests by running `bazel query` against discovered Maven repos in a Bazel workspace. Closes the inline-Maven-declaration gap that lockfile-only parsing misses for repos like envoy, ray, tensorflow, tink-java, and or-tools. Auto-detects Bzlmod and legacy `WORKSPACE`.
 - **`socket scan create --auto-manifest`** now covers Bazel workspaces in addition to Gradle/Scala/Kotlin/Conda. Repos with `MODULE.bazel`, `WORKSPACE`, or `WORKSPACE.bazel` are detected automatically and their Maven dependencies extracted as part of the standard scan-create flow.
 
+## [1.1.98](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.98) - 2026-05-20
+
+### Changed
+- `socket scan create --reach` now uploads the reachability facts file as brotli on the wire, shrinking mono-repo upload sizes by roughly 85% with no change to the on-disk or stored format. Faster scan submissions on slow connections.
+
 ## [1.1.97](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.97) - 2026-05-18
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.97",
+  "version": "1.1.98",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",

--- a/src/commands/scan/handle-create-new-scan.mts
+++ b/src/commands/scan/handle-create-new-scan.mts
@@ -15,6 +15,7 @@ import { outputCreateNewScan } from './output-create-new-scan.mts'
 import { performReachabilityAnalysis } from './perform-reachability-analysis.mts'
 import constants from '../../constants.mts'
 import { checkCommandInput } from '../../utils/check-input.mts'
+import { compressSocketFactsForUpload } from '../../utils/coana.mts'
 import { findSocketYmlSync } from '../../utils/config.mts'
 import { getPackageFilesForScan } from '../../utils/path-resolve.mts'
 import { readOrDefaultSocketJson } from '../../utils/socket-json.mts'
@@ -279,28 +280,40 @@ export async function handleCreateNewScan({
     tier1ReachabilityScanId = reachResult.data?.tier1ReachabilityScanId
   }
 
-  const fullScanCResult = await fetchCreateOrgFullScan(
-    scanPaths,
-    orgSlug,
-    {
-      commitHash,
-      commitMessage,
-      committers,
-      pullRequest,
-      repoName,
-      branchName,
-      scanType: reach.runReachabilityAnalysis
-        ? constants.SCAN_TYPE_SOCKET_TIER1
-        : constants.SCAN_TYPE_SOCKET,
-      workspace,
-    },
-    {
-      cwd,
-      defaultBranch,
-      pendingHead,
-      tmp,
-    },
-  )
+  // Brotli-compress any .socket.facts.json paths in scanPaths just before
+  // upload. depscan's api-v0 multipart boundary streams brotli decode based
+  // on the .br filename suffix. Coana keeps writing plain .socket.facts.json
+  // on disk, so the local read paths (extractTier1ReachabilityScanId,
+  // extractReachabilityErrors) stay correct. The cleanup() in the finally
+  // block removes the temp dirs whether the upload succeeded or threw.
+  const compressed = await compressSocketFactsForUpload(scanPaths)
+  let fullScanCResult: Awaited<ReturnType<typeof fetchCreateOrgFullScan>>
+  try {
+    fullScanCResult = await fetchCreateOrgFullScan(
+      compressed.paths,
+      orgSlug,
+      {
+        commitHash,
+        commitMessage,
+        committers,
+        pullRequest,
+        repoName,
+        branchName,
+        scanType: reach.runReachabilityAnalysis
+          ? constants.SCAN_TYPE_SOCKET_TIER1
+          : constants.SCAN_TYPE_SOCKET,
+        workspace,
+      },
+      {
+        cwd,
+        defaultBranch,
+        pendingHead,
+        tmp,
+      },
+    )
+  } finally {
+    await compressed.cleanup()
+  }
 
   const scanId = fullScanCResult.ok ? fullScanCResult.data?.id : undefined
 

--- a/src/utils/coana.mts
+++ b/src/utils/coana.mts
@@ -3,6 +3,11 @@
  * Manages reachability analysis via Coana tech CLI.
  *
  * Key Functions:
+ * - compressSocketFactsForUpload: Brotli-compress any .socket.facts.json
+ *   entries in scanPaths just before upload, returning swapped paths plus a
+ *   cleanup callback. Coana keeps writing plain JSON; the on-the-wire form
+ *   to depscan is brotli (api-v0 decodes at the multipart boundary).
+ * - extractReachabilityErrors: Extract per-component reachability errors
  * - extractTier1ReachabilityScanId: Extract scan ID from socket facts file
  *
  * Integration:
@@ -11,7 +16,84 @@
  * - Extracts tier 1 reachability scan identifiers
  */
 
+import { createReadStream, createWriteStream, existsSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import path from 'node:path'
+import { pipeline } from 'node:stream/promises'
+import { createBrotliCompress } from 'node:zlib'
+
 import { readJsonSync } from '@socketsecurity/registry/lib/fs'
+
+import constants from '../constants.mts'
+
+const { DOT_SOCKET_DOT_FACTS_JSON } = constants
+
+export type CompressedScanPaths = {
+  paths: string[]
+  cleanup: () => Promise<void>
+}
+
+/**
+ * For each `.socket.facts.json` in `scanPaths`, stream-brotli-compress a
+ * `.socket.facts.json.br` into a fresh temp dir SIDE-BY-SIDE with the
+ * original file (inside the source's parent directory) and swap its path
+ * in. Other paths pass through unchanged. Missing files also pass through
+ * unchanged (the upload will fail downstream with the same error it would
+ * have).
+ *
+ * Streaming + worker-thread compression keeps the event loop responsive:
+ * default brotli quality (11) on a 60+MB facts file takes multiple seconds
+ * of CPU, which would otherwise freeze the spinner / signal handlers /
+ * any concurrent work.
+ *
+ * The temp dir lives next to the source rather than under the OS temp dir
+ * because depscan's multipart ingest (`addStreamEntry`) rejects entries
+ * whose names contain `..` traversal segments. The SDK computes the
+ * multipart entry name via `path.relative(cwd, brPath)`, so an OS-tmpdir
+ * temp path turns into `../../../var/folders/...` and gets dropped as
+ * `unmatchedFiles`. Keeping the temp file inside cwd-or-below keeps the
+ * relative path traversal-free.
+ *
+ * Each compressed file gets its own `mkdtemp` directory so the filename
+ * stays `.socket.facts.json.br` (no index/suffix collision) and
+ * concurrent scans against the same source dir don't race on the same
+ * path. The api-v0 boundary uses the `.br` filename suffix to trigger
+ * streaming decode.
+ *
+ * Caller MUST `await cleanup()` (typically in a `finally` block) once the
+ * upload completes — successful or not — to remove the temp dirs.
+ */
+export async function compressSocketFactsForUpload(
+  scanPaths: string[],
+): Promise<CompressedScanPaths> {
+  const tmpDirs: string[] = []
+  const paths = await Promise.all(
+    scanPaths.map(async p => {
+      if (path.basename(p) !== DOT_SOCKET_DOT_FACTS_JSON) {
+        return p
+      }
+      if (!existsSync(p)) {
+        return p
+      }
+      const td = await mkdtemp(path.join(path.dirname(p), '.socket-br-'))
+      tmpDirs.push(td)
+      const brPath = path.join(td, `${DOT_SOCKET_DOT_FACTS_JSON}.br`)
+      await pipeline(
+        createReadStream(p),
+        createBrotliCompress(),
+        createWriteStream(brPath),
+      )
+      return brPath
+    }),
+  )
+  const cleanup = async () => {
+    const dirs = tmpDirs.splice(0)
+    await Promise.all(
+      dirs.map(d => rm(d, { recursive: true, force: true })),
+    )
+  }
+  return { paths, cleanup }
+}
 
 export type ReachabilityError = {
   componentName: string

--- a/src/utils/coana.mts
+++ b/src/utils/coana.mts
@@ -17,7 +17,7 @@
  */
 
 import { createReadStream, createWriteStream, existsSync } from 'node:fs'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { rm } from 'node:fs/promises'
 import path from 'node:path'
 import { pipeline } from 'node:stream/promises'
 import { createBrotliCompress } from 'node:zlib'
@@ -35,38 +35,38 @@ export type CompressedScanPaths = {
 
 /**
  * For each `.socket.facts.json` in `scanPaths`, stream-brotli-compress a
- * `.socket.facts.json.br` into a fresh temp dir SIDE-BY-SIDE with the
- * original file (inside the source's parent directory) and swap its path
- * in. Other paths pass through unchanged. Missing files also pass through
- * unchanged (the upload will fail downstream with the same error it would
- * have).
+ * sibling `.socket.facts.json.br` next to the original file and swap its
+ * path in. Other paths pass through unchanged. Missing files also pass
+ * through unchanged (the upload will fail downstream with the same error
+ * it would have).
  *
  * Streaming + worker-thread compression keeps the event loop responsive:
  * default brotli quality (11) on a 60+MB facts file takes multiple seconds
  * of CPU, which would otherwise freeze the spinner / signal handlers /
  * any concurrent work.
  *
- * The temp dir lives next to the source rather than under the OS temp dir
+ * The `.br` lives next to the source rather than under the OS temp dir
  * because depscan's multipart ingest (`addStreamEntry`) rejects entries
  * whose names contain `..` traversal segments. The SDK computes the
  * multipart entry name via `path.relative(cwd, brPath)`, so an OS-tmpdir
  * temp path turns into `../../../var/folders/...` and gets dropped as
- * `unmatchedFiles`. Keeping the temp file inside cwd-or-below keeps the
- * relative path traversal-free.
+ * `unmatchedFiles`. Sibling-write keeps the relative path inside cwd, and
+ * keeps the directory shape symmetric with the plain `.socket.facts.json`
+ * upload (depscan strips only the `.br` suffix at ingest, so
+ * `<dir>/.socket.facts.json.br` and `<dir>/.socket.facts.json` resolve to
+ * the same storage path).
  *
- * Each compressed file gets its own `mkdtemp` directory so the filename
- * stays `.socket.facts.json.br` (no index/suffix collision) and
- * concurrent scans against the same source dir don't race on the same
- * path. The api-v0 boundary uses the `.br` filename suffix to trigger
- * streaming decode.
+ * Concurrent scans against the same source directory are already racy on
+ * `.socket.facts.json` itself (coana writes to a single path), so the
+ * sibling `.br` doesn't introduce a new race.
  *
  * Caller MUST `await cleanup()` (typically in a `finally` block) once the
- * upload completes — successful or not — to remove the temp dirs.
+ * upload completes — successful or not — to remove the sibling files.
  */
 export async function compressSocketFactsForUpload(
   scanPaths: string[],
 ): Promise<CompressedScanPaths> {
-  const tmpDirs: string[] = []
+  const brPaths: string[] = []
   const paths = await Promise.all(
     scanPaths.map(async p => {
       if (path.basename(p) !== DOT_SOCKET_DOT_FACTS_JSON) {
@@ -75,21 +75,20 @@ export async function compressSocketFactsForUpload(
       if (!existsSync(p)) {
         return p
       }
-      const td = await mkdtemp(path.join(path.dirname(p), '.socket-br-'))
-      tmpDirs.push(td)
-      const brPath = path.join(td, `${DOT_SOCKET_DOT_FACTS_JSON}.br`)
+      const brPath = `${p}.br`
       await pipeline(
         createReadStream(p),
         createBrotliCompress(),
         createWriteStream(brPath),
       )
+      brPaths.push(brPath)
       return brPath
     }),
   )
   const cleanup = async () => {
-    const dirs = tmpDirs.splice(0)
+    const targets = brPaths.splice(0)
     await Promise.all(
-      dirs.map(d => rm(d, { recursive: true, force: true })),
+      targets.map(t => rm(t, { force: true })),
     )
   }
   return { paths, cleanup }

--- a/src/utils/coana.mts
+++ b/src/utils/coana.mts
@@ -67,7 +67,20 @@ export async function compressSocketFactsForUpload(
   scanPaths: string[],
 ): Promise<CompressedScanPaths> {
   const brPaths: string[] = []
-  const paths = await Promise.all(
+  const cleanup = async () => {
+    const targets = brPaths.splice(0)
+    // `recursive: true` defends against the (defensive) case where a sibling
+    // path was somehow created as a directory — `rm` would otherwise throw
+    // on the first such entry and skip the rest. `force: true` no-ops on
+    // missing paths so the function stays idempotent.
+    await Promise.all(targets.map(t => rm(t, { recursive: true, force: true })))
+  }
+  // Use `allSettled` (not `all`) so a failure in one entry doesn't leak the
+  // others' in-flight pipelines past our `catch`. If we used `all`, the
+  // first rejection would bubble out while sibling pipelines were still
+  // writing bytes — `cleanup()` would race with those writes and could
+  // remove a `.br` only to have it re-created after we returned.
+  const results = await Promise.allSettled(
     scanPaths.map(async p => {
       if (path.basename(p) !== DOT_SOCKET_DOT_FACTS_JSON) {
         return p
@@ -76,21 +89,29 @@ export async function compressSocketFactsForUpload(
         return p
       }
       const brPath = `${p}.br`
+      // Track the sibling path BEFORE the pipeline starts so a
+      // partially-written `.br` is removed even if the pipeline rejects.
+      // `rm({ force: true })` no-ops on missing files, so tracking before
+      // creation is safe.
+      brPaths.push(brPath)
       await pipeline(
         createReadStream(p),
         createBrotliCompress(),
         createWriteStream(brPath),
       )
-      brPaths.push(brPath)
       return brPath
     }),
   )
-  const cleanup = async () => {
-    const targets = brPaths.splice(0)
-    await Promise.all(
-      targets.map(t => rm(t, { force: true })),
-    )
+  const failure = results.find(
+    (r): r is PromiseRejectedResult => r.status === 'rejected',
+  )
+  if (failure) {
+    // All pipelines have settled, so cleanup() can safely remove every
+    // `.br` we tracked (succeeded or partial) without racing live writes.
+    await cleanup()
+    throw failure.reason
   }
+  const paths = results.map(r => (r as PromiseFulfilledResult<string>).value)
   return { paths, cleanup }
 }
 

--- a/src/utils/coana.test.mts
+++ b/src/utils/coana.test.mts
@@ -1,0 +1,278 @@
+/**
+ * Unit tests for Coana facts-file utilities.
+ *
+ * Test Coverage:
+ * - compressSocketFactsForUpload: swaps .socket.facts.json paths for
+ *   brotli-compressed .br temps, leaves other paths alone, cleans up.
+ * - extractTier1ReachabilityScanId: plain JSON + edge cases.
+ * - extractReachabilityErrors: plain JSON + missing + malformed.
+ *
+ * Related Files:
+ * - utils/coana.mts (implementation)
+ */
+
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { brotliDecompressSync } from 'node:zlib'
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+  compressSocketFactsForUpload,
+  extractReachabilityErrors,
+  extractTier1ReachabilityScanId,
+} from './coana.mts'
+
+describe('coana facts-file utils', () => {
+  let tmpDir: string
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'socket-coana-facts-'))
+  })
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function writePlain(name: string, body: unknown): string {
+    const filePath = path.join(tmpDir, name)
+    writeFileSync(filePath, JSON.stringify(body))
+    return filePath
+  }
+
+  describe('compressSocketFactsForUpload', () => {
+    it('swaps a .socket.facts.json path for a brotli .br temp file', async () => {
+      const wrapDir = mkdtempSync(path.join(tmpdir(), 'socket-coana-wrap-'))
+      const inputPath = path.join(wrapDir, '.socket.facts.json')
+      const payload = { tier1ReachabilityScanId: 'compress-test', a: 1, b: 2 }
+      writeFileSync(inputPath, JSON.stringify(payload))
+
+      const result = await compressSocketFactsForUpload([inputPath])
+      const swappedPath = result.paths[0]!
+      try {
+        expect(result.paths).toHaveLength(1)
+        expect(swappedPath).not.toBe(inputPath)
+        expect(path.basename(swappedPath)).toBe('.socket.facts.json.br')
+        expect(existsSync(swappedPath)).toBe(true)
+        // Temp file lives in a subdir of the source's parent directory, NOT
+        // under tmpdir(). This keeps `path.relative(cwd, swappedPath)`
+        // traversal-free so depscan's multipart ingest accepts the entry.
+        expect(path.dirname(path.dirname(swappedPath))).toBe(wrapDir)
+        // The temp file is real brotli that round-trips to the original JSON.
+        const roundTripped = brotliDecompressSync(
+          readFileSync(swappedPath),
+        ).toString('utf8')
+        expect(JSON.parse(roundTripped)).toEqual(payload)
+      } finally {
+        await result.cleanup()
+        rmSync(wrapDir, { recursive: true, force: true })
+      }
+      // Cleanup removes the temp .br file.
+      expect(existsSync(swappedPath)).toBe(false)
+    })
+
+    it('leaves non-facts paths unchanged', async () => {
+      const wrapDir = mkdtempSync(path.join(tmpdir(), 'socket-coana-wrap-'))
+      const lock = path.join(wrapDir, 'package-lock.json')
+      const pkg = path.join(wrapDir, 'package.json')
+      writeFileSync(lock, '{}')
+      writeFileSync(pkg, '{}')
+
+      const result = await compressSocketFactsForUpload([lock, pkg])
+      try {
+        expect(result.paths).toEqual([lock, pkg])
+      } finally {
+        await result.cleanup()
+        rmSync(wrapDir, { recursive: true, force: true })
+      }
+    })
+
+    it('leaves a missing .socket.facts.json path unchanged', async () => {
+      const wrapDir = mkdtempSync(path.join(tmpdir(), 'socket-coana-wrap-'))
+      const missingFacts = path.join(wrapDir, '.socket.facts.json')
+      // Note: no writeFileSync — file does not exist.
+
+      const result = await compressSocketFactsForUpload([missingFacts])
+      try {
+        expect(result.paths).toEqual([missingFacts])
+      } finally {
+        await result.cleanup()
+        rmSync(wrapDir, { recursive: true, force: true })
+      }
+    })
+
+    it('mixes facts and non-facts entries correctly', async () => {
+      const wrapDir = mkdtempSync(path.join(tmpdir(), 'socket-coana-wrap-'))
+      const facts = path.join(wrapDir, '.socket.facts.json')
+      const lock = path.join(wrapDir, 'package-lock.json')
+      writeFileSync(facts, JSON.stringify({ tier1ReachabilityScanId: 'mix' }))
+      writeFileSync(lock, '{"name":"x"}')
+
+      const result = await compressSocketFactsForUpload([lock, facts])
+      try {
+        expect(result.paths[0]).toBe(lock)
+        expect(result.paths[1]).not.toBe(facts)
+        expect(path.basename(result.paths[1]!)).toBe('.socket.facts.json.br')
+        const roundTripped = JSON.parse(
+          brotliDecompressSync(readFileSync(result.paths[1]!)).toString('utf8'),
+        )
+        expect(roundTripped.tier1ReachabilityScanId).toBe('mix')
+      } finally {
+        await result.cleanup()
+        rmSync(wrapDir, { recursive: true, force: true })
+      }
+    })
+
+    it('cleanup is idempotent (safe to call twice)', async () => {
+      const wrapDir = mkdtempSync(path.join(tmpdir(), 'socket-coana-wrap-'))
+      const facts = path.join(wrapDir, '.socket.facts.json')
+      writeFileSync(facts, JSON.stringify({ tier1ReachabilityScanId: 'idem' }))
+
+      const result = await compressSocketFactsForUpload([facts])
+      await result.cleanup()
+      await expect(result.cleanup()).resolves.not.toThrow()
+      rmSync(wrapDir, { recursive: true, force: true })
+    })
+  })
+
+  describe('extractTier1ReachabilityScanId', () => {
+    it('reads scan ID from plain JSON file', () => {
+      const file = writePlain('plain-id.json', {
+        tier1ReachabilityScanId: 'scan-123',
+      })
+
+      expect(extractTier1ReachabilityScanId(file)).toBe('scan-123')
+    })
+
+    it('returns undefined for missing file', () => {
+      expect(
+        extractTier1ReachabilityScanId(path.join(tmpDir, 'missing.json')),
+      ).toBeUndefined()
+    })
+
+    it('returns undefined when tier1ReachabilityScanId is missing', () => {
+      const file = writePlain('missing-field.json', { otherField: 'value' })
+
+      expect(extractTier1ReachabilityScanId(file)).toBeUndefined()
+    })
+
+    it('returns undefined for null scan ID', () => {
+      const file = writePlain('null-id.json', { tier1ReachabilityScanId: null })
+
+      expect(extractTier1ReachabilityScanId(file)).toBeUndefined()
+    })
+
+    it('returns undefined for empty / whitespace scan ID', () => {
+      const blank = writePlain('blank-id.json', {
+        tier1ReachabilityScanId: '   ',
+      })
+      const empty = writePlain('empty-id.json', {
+        tier1ReachabilityScanId: '',
+      })
+
+      expect(extractTier1ReachabilityScanId(blank)).toBeUndefined()
+      expect(extractTier1ReachabilityScanId(empty)).toBeUndefined()
+    })
+
+    it('trims whitespace from scan ID', () => {
+      const file = writePlain('padded-id.json', {
+        tier1ReachabilityScanId: '  scan-456  ',
+      })
+
+      expect(extractTier1ReachabilityScanId(file)).toBe('scan-456')
+    })
+
+    it('coerces numeric scan ID to string', () => {
+      const file = writePlain('numeric-id.json', {
+        tier1ReachabilityScanId: 12345,
+      })
+
+      expect(extractTier1ReachabilityScanId(file)).toBe('12345')
+    })
+  })
+
+  describe('extractReachabilityErrors', () => {
+    const errorComponentsBody = {
+      components: [
+        {
+          name: 'lodash',
+          version: '4.17.21',
+          reachability: [
+            {
+              ghsa_id: 'GHSA-aaaa-bbbb-cccc',
+              reachability: [
+                { type: 'error', subprojectPath: 'packages/web' },
+                { type: 'reachable', subprojectPath: 'packages/api' },
+              ],
+            },
+          ],
+        },
+        {
+          name: 'axios',
+          version: '1.4.0',
+          reachability: [
+            {
+              ghsa_id: 'GHSA-xxxx-yyyy-zzzz',
+              reachability: [{ type: 'error', subprojectPath: 'packages/api' }],
+            },
+          ],
+        },
+      ],
+    }
+
+    const expectedErrors = [
+      {
+        componentName: 'lodash',
+        componentVersion: '4.17.21',
+        ghsaId: 'GHSA-aaaa-bbbb-cccc',
+        subprojectPath: 'packages/web',
+      },
+      {
+        componentName: 'axios',
+        componentVersion: '1.4.0',
+        ghsaId: 'GHSA-xxxx-yyyy-zzzz',
+        subprojectPath: 'packages/api',
+      },
+    ]
+
+    it('extracts errors from plain JSON', () => {
+      const file = writePlain('errors-plain.json', errorComponentsBody)
+
+      expect(extractReachabilityErrors(file)).toEqual(expectedErrors)
+    })
+
+    it('returns empty array for missing file', () => {
+      expect(
+        extractReachabilityErrors(path.join(tmpDir, 'missing-errors.json')),
+      ).toEqual([])
+    })
+
+    it('returns empty array when components is missing', () => {
+      const file = writePlain('errors-no-components.json', { other: true })
+
+      expect(extractReachabilityErrors(file)).toEqual([])
+    })
+
+    it('skips components with no reachability arrays', () => {
+      const file = writePlain('errors-skip.json', {
+        components: [
+          { name: 'just-name', version: '1.0.0' },
+          {
+            name: 'no-inner',
+            version: '1.0.0',
+            reachability: [{ ghsa_id: 'GHSA-1' }],
+          },
+        ],
+      })
+
+      expect(extractReachabilityErrors(file)).toEqual([])
+    })
+  })
+})

--- a/src/utils/coana.test.mts
+++ b/src/utils/coana.test.mts
@@ -48,34 +48,33 @@ describe('coana facts-file utils', () => {
   }
 
   describe('compressSocketFactsForUpload', () => {
-    it('swaps a .socket.facts.json path for a brotli .br temp file', async () => {
+    it('writes brotli .br as a sibling of the source file', async () => {
       const wrapDir = mkdtempSync(path.join(tmpdir(), 'socket-coana-wrap-'))
       const inputPath = path.join(wrapDir, '.socket.facts.json')
       const payload = { tier1ReachabilityScanId: 'compress-test', a: 1, b: 2 }
       writeFileSync(inputPath, JSON.stringify(payload))
 
-      const result = await compressSocketFactsForUpload([inputPath])
-      const swappedPath = result.paths[0]!
       try {
+        const result = await compressSocketFactsForUpload([inputPath])
+        const swappedPath = result.paths[0]!
+
         expect(result.paths).toHaveLength(1)
-        expect(swappedPath).not.toBe(inputPath)
-        expect(path.basename(swappedPath)).toBe('.socket.facts.json.br')
+        expect(swappedPath).toBe(`${inputPath}.br`)
         expect(existsSync(swappedPath)).toBe(true)
-        // Temp file lives in a subdir of the source's parent directory, NOT
-        // under tmpdir(). This keeps `path.relative(cwd, swappedPath)`
-        // traversal-free so depscan's multipart ingest accepts the entry.
-        expect(path.dirname(path.dirname(swappedPath))).toBe(wrapDir)
-        // The temp file is real brotli that round-trips to the original JSON.
+        // The sibling file is real brotli that round-trips to the original
+        // JSON.
         const roundTripped = brotliDecompressSync(
           readFileSync(swappedPath),
         ).toString('utf8')
         expect(JSON.parse(roundTripped)).toEqual(payload)
-      } finally {
+
+        // Cleanup removes the sibling .br file but leaves the source intact.
         await result.cleanup()
+        expect(existsSync(swappedPath)).toBe(false)
+        expect(existsSync(inputPath)).toBe(true)
+      } finally {
         rmSync(wrapDir, { recursive: true, force: true })
       }
-      // Cleanup removes the temp .br file.
-      expect(existsSync(swappedPath)).toBe(false)
     })
 
     it('leaves non-facts paths unchanged', async () => {
@@ -118,8 +117,7 @@ describe('coana facts-file utils', () => {
       const result = await compressSocketFactsForUpload([lock, facts])
       try {
         expect(result.paths[0]).toBe(lock)
-        expect(result.paths[1]).not.toBe(facts)
-        expect(path.basename(result.paths[1]!)).toBe('.socket.facts.json.br')
+        expect(result.paths[1]).toBe(`${facts}.br`)
         const roundTripped = JSON.parse(
           brotliDecompressSync(readFileSync(result.paths[1]!)).toString('utf8'),
         )

--- a/src/utils/coana.test.mts
+++ b/src/utils/coana.test.mts
@@ -138,6 +138,33 @@ describe('coana facts-file utils', () => {
       await expect(result.cleanup()).resolves.not.toThrow()
       rmSync(wrapDir, { recursive: true, force: true })
     })
+
+    it('removes partial .br siblings if compression fails mid-batch', async () => {
+      // Two facts files; B's `.br` destination is pre-occupied by a
+      // directory so `createWriteStream` open() fails with EISDIR. The
+      // whole batch rejects, but A's `.br` must not be orphaned.
+      const { mkdirSync } = await import('node:fs')
+      const wrapDirA = mkdtempSync(path.join(tmpdir(), 'socket-coana-wrap-a-'))
+      const wrapDirB = mkdtempSync(path.join(tmpdir(), 'socket-coana-wrap-b-'))
+      const factsA = path.join(wrapDirA, '.socket.facts.json')
+      const factsB = path.join(wrapDirB, '.socket.facts.json')
+      writeFileSync(factsA, JSON.stringify({ tier1ReachabilityScanId: 'A' }))
+      writeFileSync(factsB, JSON.stringify({ tier1ReachabilityScanId: 'B' }))
+      mkdirSync(`${factsB}.br`, { recursive: true })
+
+      try {
+        await expect(
+          compressSocketFactsForUpload([factsA, factsB]),
+        ).rejects.toThrow()
+        // A's sibling must not be on disk; sources must still exist.
+        expect(existsSync(`${factsA}.br`)).toBe(false)
+        expect(existsSync(factsA)).toBe(true)
+        expect(existsSync(factsB)).toBe(true)
+      } finally {
+        rmSync(wrapDirA, { recursive: true, force: true })
+        rmSync(wrapDirB, { recursive: true, force: true })
+      }
+    })
   })
 
   describe('extractTier1ReachabilityScanId', () => {


### PR DESCRIPTION
## Summary

Brotli-compress `.socket.facts.json` at upload time. Coana keeps writing plain JSON; only the wire bytes between socket-cli and depscan change. ~85% reduction on the simple-npm fixture; production mono-repo payloads see 60+ MB → ~10 MB.

## How

- New `compressSocketFactsForUpload(scanPaths)` in `src/utils/coana.mts` — async + streaming (`createReadStream → createBrotliCompress → createWriteStream` via `pipeline`). For any `.socket.facts.json` in scanPaths, writes a sibling `.socket.facts.json.br` next to the source file. Returns swapped paths + cleanup callback.
- `handle-create-new-scan.mts` wraps `fetchCreateOrgFullScan` in `try { compress; upload; } finally { cleanup; }`.

## Why sibling-write (not `os.tmpdir()`, not a temp subdir)

The SDK passes `path.relative(cwd, brPath)` as the multipart name. depscan's `addStreamEntry` rejects entries with `..` traversal — a tmpdir path resolves to `../../../var/folders/...` and gets dropped to `unmatchedFiles`. Sibling-write keeps the relative path inside cwd, and keeps directory shape symmetric with the plain `.socket.facts.json` upload (depscan strips the `.br` suffix at ingest, so `<dir>/.socket.facts.json.br` and `<dir>/.socket.facts.json` resolve to the same storage path).

Concurrent scans against the same source dir already collide on `.socket.facts.json` itself (coana writes to a single path), so the sibling `.br` doesn't introduce a new race.

## Tests

- 16 unit cases in `src/utils/coana.test.mts` (sibling-path round-trip, passthrough, idempotent cleanup that leaves the source intact, plus the existing `extractTier1ReachabilityScanId` / `extractReachabilityErrors` matrix).
- e2e `socket scan create --reach` against `simple-npm`: `scan_type=socket_tier1`, `unmatchedFiles: []`, root manifest entries are `.socket.facts.json` and `package.json` (storage path matches the plain upload — dir-preservation symmetry holds).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the scan creation upload pipeline to rewrite `.socket.facts.json` inputs into temporary Brotli-compressed `.br` siblings, which could break or alter scan uploads if path handling or cleanup fails.
> 
> **Overview**
> **Scan uploads now Brotli-compress Coana facts files.** `handleCreateNewScan` calls new `compressSocketFactsForUpload()` to replace any `.socket.facts.json` entries in `scanPaths` with sibling `.socket.facts.json.br` files for the `fetchCreateOrgFullScan` multipart upload, then always removes those `.br` files in a `finally` block.
> 
> **Adds a streaming compressor utility + tests.** `utils/coana.mts` implements the brotli streaming pipeline and returns `{ paths, cleanup }`, and `utils/coana.test.mts` adds unit coverage for path swapping, passthrough behavior, missing files, brotli round-trip, and idempotent cleanup (plus edge cases for the existing extractors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb966857067305d13c4252d51856194bafab4ce5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->