### PR TITLE
feat(scan): expose --reach-continue-on-* flags in help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.91](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.91) - 2026-05-01
+
+### Added
+- New `socket scan create` and `socket scan reach` flags let you keep reachability analysis going when it would otherwise halt: `--reach-continue-on-analysis-errors`, `--reach-continue-on-install-errors`, `--reach-continue-on-missing-lock-files`, and `--reach-continue-on-no-source-files`. Each falls back to precomputed (Tier 2) results so you still get a scan when individual workspaces hit timeouts, install failures, missing lock files, or empty source trees.
+
 ## [1.1.90](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.90) - 2026-04-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.90",
+  "version": "1.1.91",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",

--- a/src/commands/scan/cmd-scan-create.test.mts
+++ b/src/commands/scan/cmd-scan-create.test.mts
@@ -58,6 +58,10 @@ describe('socket scan create', async () => {
             --reach-analysis-memory-limit  The maximum memory in MB to use for the reachability analysis. The default is 8192MB.
             --reach-analysis-timeout  Set timeout for the reachability analysis. Split analysis runs may cause the total scan time to exceed this timeout significantly.
             --reach-concurrency  Set the maximum number of concurrent reachability analysis runs. It is recommended to choose a concurrency level that ensures each analysis run has at least the --reach-analysis-memory-limit amount of memory available. NPM reachability analysis does not support concurrent execution, so the concurrency level is ignored for NPM.
+            --reach-continue-on-analysis-errors  Continue reachability analysis when errors occur (timeouts, OOM, parse errors, etc.), falling back to precomputed (Tier 2) results. By default, the CLI halts on analysis errors.
+            --reach-continue-on-install-errors  Continue reachability analysis when package installation fails, falling back to precomputed (Tier 2) results. By default, the CLI halts on installation errors.
+            --reach-continue-on-missing-lock-files  Continue reachability analysis when a Gradle or SBT project is missing its lock file (or version catalog / pre-generated SBOM). By default, the CLI halts.
+            --reach-continue-on-no-source-files  Continue reachability analysis when a workspace contains no source files for its ecosystem. By default, the CLI halts.
             --reach-debug       Enable debug mode for reachability analysis. Provides verbose logging from the reachability CLI.
             --reach-detailed-analysis-log-file  A log file with detailed analysis logs is written to root of each analyzed workspace.
             --reach-disable-analytics  Disable reachability analytics sharing with Socket. Also disables caching-based optimizations.

--- a/src/commands/scan/cmd-scan-reach.test.mts
+++ b/src/commands/scan/cmd-scan-reach.test.mts
@@ -40,6 +40,10 @@ describe('socket scan reach', async () => {
             --reach-analysis-memory-limit  The maximum memory in MB to use for the reachability analysis. The default is 8192MB.
             --reach-analysis-timeout  Set timeout for the reachability analysis. Split analysis runs may cause the total scan time to exceed this timeout significantly.
             --reach-concurrency  Set the maximum number of concurrent reachability analysis runs. It is recommended to choose a concurrency level that ensures each analysis run has at least the --reach-analysis-memory-limit amount of memory available. NPM reachability analysis does not support concurrent execution, so the concurrency level is ignored for NPM.
+            --reach-continue-on-analysis-errors  Continue reachability analysis when errors occur (timeouts, OOM, parse errors, etc.), falling back to precomputed (Tier 2) results. By default, the CLI halts on analysis errors.
+            --reach-continue-on-install-errors  Continue reachability analysis when package installation fails, falling back to precomputed (Tier 2) results. By default, the CLI halts on installation errors.
+            --reach-continue-on-missing-lock-files  Continue reachability analysis when a Gradle or SBT project is missing its lock file (or version catalog / pre-generated SBOM). By default, the CLI halts.
+            --reach-continue-on-no-source-files  Continue reachability analysis when a workspace contains no source files for its ecosystem. By default, the CLI halts.
             --reach-debug       Enable debug mode for reachability analysis. Provides verbose logging from the reachability CLI.
             --reach-detailed-analysis-log-file  A log file with detailed analysis logs is written to root of each analyzed workspace.
             --reach-disable-analytics  Disable reachability analytics sharing with Socket. Also disables caching-based optimizations.

--- a/src/commands/scan/reachability-flags.mts
+++ b/src/commands/scan/reachability-flags.mts
@@ -28,28 +28,24 @@ export const reachabilityFlags: MeowFlags = {
   reachContinueOnAnalysisErrors: {
     type: 'boolean',
     default: false,
-    hidden: true,
     description:
       'Continue reachability analysis when errors occur (timeouts, OOM, parse errors, etc.), falling back to precomputed (Tier 2) results. By default, the CLI halts on analysis errors.',
   },
   reachContinueOnInstallErrors: {
     type: 'boolean',
     default: false,
-    hidden: true,
     description:
       'Continue reachability analysis when package installation fails, falling back to precomputed (Tier 2) results. By default, the CLI halts on installation errors.',
   },
   reachContinueOnMissingLockFiles: {
     type: 'boolean',
     default: false,
-    hidden: true,
     description:
       'Continue reachability analysis when a Gradle or SBT project is missing its lock file (or version catalog / pre-generated SBOM). By default, the CLI halts.',
   },
   reachContinueOnNoSourceFiles: {
     type: 'boolean',
     default: false,
-    hidden: true,
     description:
       'Continue reachability analysis when a workspace contains no source files for its ecosystem. By default, the CLI halts.',
   },


### PR DESCRIPTION
## Summary
- Removes `hidden: true` from the four `--reach-continue-on-*` flags in `src/commands/scan/reachability-flags.mts` so they show up in `socket scan create --help` and `socket scan reach --help`.
- Updates inline help snapshots in `cmd-scan-create.test.mts` and `cmd-scan-reach.test.mts` to include the now-visible flag lines.
- Bumps the CLI to `1.1.91` and adds a `Changed` entry to the changelog.

The flags themselves were added in #1251 as hidden until Coana v15 became the default; v15 is now the default (#1289), so they can be surfaced.

## Test plan
- [x] `npx vitest run src/commands/scan/cmd-scan-create.test.mts src/commands/scan/cmd-scan-reach.test.mts` — 79 passed
- [x] `pnpm check:tsc` — clean
- [x] `pnpm check:lint` for the touched files — clean (pre-existing errors elsewhere unrelated to this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this mostly surfaces previously-hidden reachability flags in CLI help and updates test snapshots, with a routine version/changelog bump and no change to scan execution logic.
> 
> **Overview**
> Surfaces four reachability resilience flags (the `--reach-continue-on-*` options) in `socket scan create` and `socket scan reach` help output by un-hiding them in `reachability-flags.mts`.
> 
> Updates the help snapshot tests to include the newly-visible flag lines, and bumps the CLI version to `1.1.91` with a corresponding `CHANGELOG.md` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c775c8dbb7848c5e87a8f11a3ecaaa18307d021. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->