### PR TITLE
feat(scan): add Tier 1 exclude paths flag

### DIFF
--- a/src/commands/ci/handle-ci.mts
+++ b/src/commands/ci/handle-ci.mts
@@ -51,6 +51,7 @@ export async function handleCi(autoManifest: boolean): Promise<void> {
     pendingHead: true,
     pullRequest: 0,
     reach: {
+      excludePaths: [],
       reachAnalysisMemoryLimit: 0,
       reachAnalysisTimeout: 0,
       reachConcurrency: 1,

--- a/src/commands/scan/cmd-scan-create.mts
+++ b/src/commands/scan/cmd-scan-create.mts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import { joinAnd } from '@socketsecurity/registry/lib/arrays'
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import { assertNoNegationPatterns } from './exclude-paths.mts'
 import { handleCreateNewScan } from './handle-create-new-scan.mts'
 import { outputCreateNewScan } from './output-create-new-scan.mts'
 import { reachabilityFlags } from './reachability-flags.mts'
@@ -279,6 +280,7 @@ async function run(
     setAsAlertsPage: boolean
     tmp: boolean
     // Reachability flags.
+    excludePaths: string[] | undefined
     reach: boolean
     reachAnalysisMemoryLimit: number
     reachAnalysisTimeout: number
@@ -463,9 +465,14 @@ async function run(
     logger.error('')
   }
 
+  const excludePaths = cmdFlagValueToArray(cli.flags['excludePaths'])
+  assertNoNegationPatterns(excludePaths)
+
   const reachExcludePaths = cmdFlagValueToArray(cli.flags['reachExcludePaths'])
 
   // Validation helpers for better readability.
+  const hasExcludePaths = excludePaths.length > 0
+
   const hasReachEcosystems = reachEcosystems.length > 0
 
   const hasReachExcludePaths = reachExcludePaths.length > 0
@@ -488,6 +495,7 @@ async function run(
     reachVersion !== reachabilityFlags['reachVersion']?.default
 
   const isUsingAnyReachabilityFlags =
+    hasExcludePaths ||
     hasReachEcosystems ||
     hasReachExcludePaths ||
     isUsingNonDefaultAnalytics ||
@@ -608,6 +616,7 @@ async function run(
     pendingHead: Boolean(pendingHead),
     pullRequest: Number(pullRequest),
     reach: {
+      excludePaths,
       reachAnalysisMemoryLimit: Number(reachAnalysisMemoryLimit),
       reachAnalysisTimeout: Number(reachAnalysisTimeout),
       reachConcurrency: Number(reachConcurrency),

--- a/src/commands/scan/cmd-scan-create.test.mts
+++ b/src/commands/scan/cmd-scan-create.test.mts
@@ -55,6 +55,7 @@ describe('socket scan create', async () => {
             --workspace         The workspace in the Socket Organization that the repository is in to associate with the full scan.
 
           Reachability Options (when --reach is used)
+            --exclude-paths     List of glob patterns to exclude from the entire Tier 1 scan, including SCA/SBOM manifest discovery. Patterns are matched relative to the project root. Bare directory names are auto-extended to recursive globs (e.g. `tests` becomes `tests/**`). Trailing slashes are stripped. Negation patterns (`!path`) are not supported. Accepts a comma-separated value or multiple flags.
             --reach-analysis-memory-limit  The maximum memory in MB to use for the reachability analysis. The default is 8192MB.
             --reach-analysis-timeout  Set timeout for the reachability analysis. Split analysis runs may cause the total scan time to exceed this timeout significantly.
             --reach-concurrency  Set the maximum number of concurrent reachability analysis runs. It is recommended to choose a concurrency level that ensures each analysis run has at least the --reach-analysis-memory-limit amount of memory available. NPM reachability analysis does not support concurrent execution, so the concurrency level is ignored for NPM.
@@ -171,6 +172,38 @@ describe('socket scan create', async () => {
       '{"apiToken":"fakeToken"}',
     ],
     'should fail when --reach-disable-analytics is used without --reach',
+    async cmd => {
+      const { code, stderr, stdout } = await spawnSocketCli(binCliPath, cmd)
+      const output = stdout + stderr
+      expect(output).toContain(
+        'Reachability analysis flags require --reach to be enabled',
+      )
+      expect(output).toContain('add --reach flag to use --reach-* options')
+      expect(
+        code,
+        'should exit with non-zero code when validation fails',
+      ).not.toBe(0)
+    },
+  )
+
+  cmdit(
+    [
+      'scan',
+      'create',
+      FLAG_ORG,
+      'fakeOrg',
+      'target',
+      FLAG_DRY_RUN,
+      '--repo',
+      'xyz',
+      '--branch',
+      'abc',
+      '--exclude-paths',
+      'tests',
+      FLAG_CONFIG,
+      '{"apiToken":"fakeToken"}',
+    ],
+    'should fail when --exclude-paths is used without --reach',
     async cmd => {
       const { code, stderr, stdout } = await spawnSocketCli(binCliPath, cmd)
       const output = stdout + stderr
@@ -434,6 +467,32 @@ describe('socket scan create', async () => {
         code,
         'should exit with code 0 when comma-separated values are used',
       ).toBe(0)
+    },
+  )
+
+  cmdit(
+    [
+      'scan',
+      'create',
+      FLAG_ORG,
+      'fakeOrg',
+      'test/fixtures/commands/scan/simple-npm',
+      FLAG_DRY_RUN,
+      '--repo',
+      'xyz',
+      '--branch',
+      'abc',
+      '--reach',
+      '--exclude-paths',
+      'tests',
+      FLAG_CONFIG,
+      '{"apiToken":"fakeToken"}',
+    ],
+    'should succeed when --exclude-paths is used with --reach',
+    async cmd => {
+      const { code, stdout } = await spawnSocketCli(binCliPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(code, 'should exit with code 0 when all flags are valid').toBe(0)
     },
   )
 

--- a/src/commands/scan/cmd-scan-reach.mts
+++ b/src/commands/scan/cmd-scan-reach.mts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import { joinAnd } from '@socketsecurity/registry/lib/arrays'
 import { logger } from '@socketsecurity/registry/lib/logger'
 
+import { assertNoNegationPatterns } from './exclude-paths.mts'
 import { handleScanReach } from './handle-scan-reach.mts'
 import { reachabilityFlags } from './reachability-flags.mts'
 import { suggestTarget } from './suggest_target.mts'
@@ -167,8 +168,10 @@ async function run(
   const dryRun = !!cli.flags['dryRun']
 
   // Process comma-separated values for isMultiple flags.
+  const excludePaths = cmdFlagValueToArray(cli.flags['excludePaths'])
   const reachEcosystemsRaw = cmdFlagValueToArray(cli.flags['reachEcosystems'])
   const reachExcludePaths = cmdFlagValueToArray(cli.flags['reachExcludePaths'])
+  assertNoNegationPatterns(excludePaths)
 
   // Validate ecosystem values.
   const reachEcosystems: PURL_Type[] = []
@@ -272,6 +275,7 @@ async function run(
     outputKind,
     outputPath: outputPath || '',
     reachabilityOptions: {
+      excludePaths,
       reachAnalysisMemoryLimit: Number(reachAnalysisMemoryLimit),
       reachAnalysisTimeout: Number(reachAnalysisTimeout),
       reachConcurrency: Number(reachConcurrency),

--- a/src/commands/scan/cmd-scan-reach.test.mts
+++ b/src/commands/scan/cmd-scan-reach.test.mts
@@ -37,6 +37,7 @@ describe('socket scan reach', async () => {
             --output            Path to write the reachability report to (must end with .json). Defaults to .socket.facts.json in the current working directory.
 
           Reachability Options
+            --exclude-paths     List of glob patterns to exclude from the entire Tier 1 scan, including SCA/SBOM manifest discovery. Patterns are matched relative to the project root. Bare directory names are auto-extended to recursive globs (e.g. \`tests\` becomes \`tests/**\`). Trailing slashes are stripped. Negation patterns (\`!path\`) are not supported. Accepts a comma-separated value or multiple flags.
             --reach-analysis-memory-limit  The maximum memory in MB to use for the reachability analysis. The default is 8192MB.
             --reach-analysis-timeout  Set timeout for the reachability analysis. Split analysis runs may cause the total scan time to exceed this timeout significantly.
             --reach-concurrency  Set the maximum number of concurrent reachability analysis runs. It is recommended to choose a concurrency level that ensures each analysis run has at least the --reach-analysis-memory-limit amount of memory available. NPM reachability analysis does not support concurrent execution, so the concurrency level is ignored for NPM.
@@ -295,6 +296,50 @@ describe('socket scan reach', async () => {
       'scan',
       'reach',
       FLAG_DRY_RUN,
+      '--exclude-paths',
+      'node_modules,dist',
+      '--org',
+      'fakeOrg',
+      FLAG_CONFIG,
+      '{"apiToken":"fakeToken"}',
+    ],
+    'should accept --exclude-paths with comma-separated values',
+    async cmd => {
+      const { code, stdout } = await spawnSocketCli(binCliPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(code, 'should exit with code 0').toBe(0)
+    },
+  )
+
+  cmdit(
+    [
+      'scan',
+      'reach',
+      FLAG_DRY_RUN,
+      '--exclude-paths',
+      'node_modules',
+      '--exclude-paths',
+      'dist',
+      '--org',
+      'fakeOrg',
+      FLAG_CONFIG,
+      '{"apiToken":"fakeToken"}',
+    ],
+    'should accept multiple --exclude-paths flags',
+    async cmd => {
+      const { code, stdout } = await spawnSocketCli(binCliPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(code, 'should exit with code 0').toBe(0)
+    },
+  )
+
+  cmdit(
+    [
+      'scan',
+      'reach',
+      FLAG_DRY_RUN,
+      '--exclude-paths',
+      'build',
       '--reach-exclude-paths',
       'node_modules,dist',
       '--org',
@@ -307,6 +352,29 @@ describe('socket scan reach', async () => {
       const { code, stdout } = await spawnSocketCli(binCliPath, cmd)
       expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
       expect(code, 'should exit with code 0').toBe(0)
+    },
+  )
+
+  cmdit(
+    [
+      'scan',
+      'reach',
+      FLAG_DRY_RUN,
+      '--exclude-paths',
+      '!tests/keep',
+      '--org',
+      'fakeOrg',
+      FLAG_CONFIG,
+      '{"apiToken":"fakeToken"}',
+    ],
+    'should reject --exclude-paths negation patterns',
+    async cmd => {
+      const { code, stderr, stdout } = await spawnSocketCli(binCliPath, cmd)
+      const output = stdout + stderr
+      expect(output).toContain(
+        "--exclude-paths does not support negation patterns. Got: '!tests/keep'.",
+      )
+      expect(code, 'should exit with non-zero code').not.toBe(0)
     },
   )
 

--- a/src/commands/scan/create-scan-from-github.mts
+++ b/src/commands/scan/create-scan-from-github.mts
@@ -250,6 +250,7 @@ async function scanOneRepo(
     pendingHead: true,
     pullRequest: 0,
     reach: {
+      excludePaths: [],
       reachAnalysisMemoryLimit: 0,
       reachAnalysisTimeout: 0,
       reachConcurrency: 1,

--- a/src/commands/scan/exclude-paths.mts
+++ b/src/commands/scan/exclude-paths.mts
@@ -1,0 +1,25 @@
+import { InputError } from '../../utils/errors.mts'
+
+export function excludePathToProjectIgnorePath(path: string): string {
+  const stripped = stripTrailingSlash(path)
+  return stripped.endsWith('/**') ? stripped : `${stripped}/**`
+}
+
+export function assertNoNegationPatterns(paths: readonly string[]): void {
+  for (const path of paths) {
+    if (path.startsWith('!')) {
+      throw new InputError(
+        `--exclude-paths does not support negation patterns. Got: '${path}'.`,
+      )
+    }
+  }
+}
+
+export function normalizeExcludePath(path: string): string {
+  const stripped = stripTrailingSlash(path)
+  return stripped.endsWith('/*') ? stripped : `${stripped}/**`
+}
+
+function stripTrailingSlash(path: string): string {
+  return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path
+}

--- a/src/commands/scan/exclude-paths.test.mts
+++ b/src/commands/scan/exclude-paths.test.mts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  assertNoNegationPatterns,
+  excludePathToProjectIgnorePath,
+  normalizeExcludePath,
+} from './exclude-paths.mts'
+import { InputError } from '../../utils/errors.mts'
+
+describe('exclude-paths', () => {
+  describe('assertNoNegationPatterns', () => {
+    it('allows positive patterns', () => {
+      expect(() =>
+        assertNoNegationPatterns(['tests', 'packages/*']),
+      ).not.toThrow()
+    })
+
+    it('rejects negation patterns', () => {
+      expect(() => assertNoNegationPatterns(['!tests/keep'])).toThrow(
+        InputError,
+      )
+      expect(() => assertNoNegationPatterns(['!tests/keep'])).toThrow(
+        "--exclude-paths does not support negation patterns. Got: '!tests/keep'.",
+      )
+    })
+  })
+
+  describe('excludePathToProjectIgnorePath', () => {
+    it.each([
+      ['packages/*', 'packages/*/**'],
+      ['tests', 'tests/**'],
+      ['tests/', 'tests/**'],
+      ['tests/**', 'tests/**'],
+    ])('converts %s to %s', (input, expected) => {
+      expect(excludePathToProjectIgnorePath(input)).toBe(expected)
+    })
+  })
+
+  describe('normalizeExcludePath', () => {
+    it.each([
+      ['tests', 'tests/**'],
+      ['tests/', 'tests/**'],
+      ['tests/*', 'tests/*'],
+      ['tests/**', 'tests/**/**'],
+    ])('normalizes %s to %s', (input, expected) => {
+      expect(normalizeExcludePath(input)).toBe(expected)
+    })
+  })
+})

--- a/src/commands/scan/handle-create-new-scan.mts
+++ b/src/commands/scan/handle-create-new-scan.mts
@@ -6,6 +6,10 @@ import { debugDir, debugFn } from '@socketsecurity/registry/lib/debug'
 import { logger } from '@socketsecurity/registry/lib/logger'
 import { pluralize } from '@socketsecurity/registry/lib/words'
 
+import {
+  excludePathToProjectIgnorePath,
+  normalizeExcludePath,
+} from './exclude-paths.mts'
 import { fetchCreateOrgFullScan } from './fetch-create-org-full-scan.mts'
 import { fetchSupportedScanFileNames } from './fetch-supported-scan-file-names.mts'
 import { finalizeTier1Scan } from './finalize-tier1-scan.mts'
@@ -172,8 +176,27 @@ export async function handleCreateNewScan({
     ? socketYmlResult.data?.parsed
     : undefined
 
+  const excludePaths = reach.runReachabilityAnalysis ? reach.excludePaths : []
+  const scaExcludeGlobs = excludePaths.map(excludePathToProjectIgnorePath)
+  const coanaExcludeGlobs = excludePaths.map(normalizeExcludePath)
+  const effectiveSocketConfig = scaExcludeGlobs.length
+    ? {
+        ...socketConfig,
+        projectIgnorePaths: [
+          ...(socketConfig?.projectIgnorePaths ?? []),
+          ...scaExcludeGlobs,
+        ],
+      }
+    : socketConfig
+  const mergedReachabilityOptions = excludePaths.length
+    ? {
+        ...reach,
+        reachExcludePaths: [...reach.reachExcludePaths, ...coanaExcludeGlobs],
+      }
+    : reach
+
   const packagePaths = await getPackageFilesForScan(targets, supportedFiles, {
-    config: socketConfig,
+    config: effectiveSocketConfig,
     cwd,
   })
 
@@ -213,7 +236,7 @@ export async function handleCreateNewScan({
     logger.error('')
     logger.info('Starting reachability analysis...')
     debugFn('notice', 'Reachability analysis enabled')
-    debugDir('inspect', { reachabilityOptions: reach })
+    debugDir('inspect', { reachabilityOptions: mergedReachabilityOptions })
 
     spinner.start()
 
@@ -222,7 +245,7 @@ export async function handleCreateNewScan({
       cwd,
       orgSlug,
       packagePaths,
-      reachabilityOptions: reach,
+      reachabilityOptions: mergedReachabilityOptions,
       repoName,
       spinner,
       target: targets[0]!,

--- a/src/commands/scan/handle-create-new-scan.test.mts
+++ b/src/commands/scan/handle-create-new-scan.test.mts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { handleCreateNewScan } from './handle-create-new-scan.mts'
+
+const {
+  mockFetchCreateOrgFullScan,
+  mockFetchSupportedScanFileNames,
+  mockFindSocketYmlSync,
+  mockGetPackageFilesForScan,
+  mockPerformReachabilityAnalysis,
+  mockReadOrDefaultSocketJson,
+} = vi.hoisted(() => ({
+  mockFetchCreateOrgFullScan: vi.fn(),
+  mockFetchSupportedScanFileNames: vi.fn(),
+  mockFindSocketYmlSync: vi.fn(),
+  mockGetPackageFilesForScan: vi.fn(),
+  mockPerformReachabilityAnalysis: vi.fn(),
+  mockReadOrDefaultSocketJson: vi.fn(),
+}))
+
+vi.mock('./fetch-create-org-full-scan.mts', () => ({
+  fetchCreateOrgFullScan: mockFetchCreateOrgFullScan,
+}))
+
+vi.mock('./fetch-supported-scan-file-names.mts', () => ({
+  fetchSupportedScanFileNames: mockFetchSupportedScanFileNames,
+}))
+
+vi.mock('./finalize-tier1-scan.mts', () => ({
+  finalizeTier1Scan: vi.fn(),
+}))
+
+vi.mock('./handle-scan-report.mts', () => ({
+  handleScanReport: vi.fn(),
+}))
+
+vi.mock('./output-create-new-scan.mts', () => ({
+  outputCreateNewScan: vi.fn(),
+}))
+
+vi.mock('./perform-reachability-analysis.mts', () => ({
+  performReachabilityAnalysis: mockPerformReachabilityAnalysis,
+}))
+
+vi.mock('../../utils/config.mts', () => ({
+  findSocketYmlSync: mockFindSocketYmlSync,
+}))
+
+vi.mock('../../utils/path-resolve.mts', () => ({
+  getPackageFilesForScan: mockGetPackageFilesForScan,
+}))
+
+vi.mock('../../utils/socket-json.mts', () => ({
+  readOrDefaultSocketJson: mockReadOrDefaultSocketJson,
+}))
+
+vi.mock('../manifest/detect-manifest-actions.mts', () => ({
+  detectManifestActions: vi.fn(() => Promise.resolve({ count: 0 })),
+}))
+
+vi.mock('../manifest/generate_auto_manifest.mts', () => ({
+  generateAutoManifest: vi.fn(),
+}))
+
+describe('handleCreateNewScan excludePaths', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockFetchCreateOrgFullScan.mockResolvedValue({
+      data: { id: 'scan-id' },
+      ok: true,
+    })
+    mockFetchSupportedScanFileNames.mockResolvedValue({
+      data: { size: 1 },
+      ok: true,
+    })
+    mockFindSocketYmlSync.mockReturnValue({
+      data: { parsed: { projectIgnorePaths: ['fixtures/**'] } },
+      ok: true,
+    })
+    mockGetPackageFilesForScan.mockResolvedValue(['package.json'])
+    mockPerformReachabilityAnalysis.mockResolvedValue({
+      data: {
+        reachabilityReport: '.socket.facts.json',
+        tier1ReachabilityScanId: 'tier1-id',
+      },
+      ok: true,
+    })
+    mockReadOrDefaultSocketJson.mockReturnValue({})
+  })
+
+  it('adds excludePaths to manifest discovery and reachability excludes', async () => {
+    await handleCreateNewScan({
+      autoManifest: false,
+      branchName: 'main',
+      commitHash: '',
+      commitMessage: '',
+      committers: '',
+      cwd: '/repo',
+      defaultBranch: false,
+      interactive: false,
+      orgSlug: 'fakeOrg',
+      outputKind: 'text',
+      pendingHead: false,
+      pullRequest: 0,
+      reach: {
+        excludePaths: ['tests', 'packages/*'],
+        reachAnalysisMemoryLimit: 8192,
+        reachAnalysisTimeout: 0,
+        reachConcurrency: 1,
+        reachContinueOnAnalysisErrors: false,
+        reachContinueOnInstallErrors: false,
+        reachContinueOnMissingLockFiles: false,
+        reachContinueOnNoSourceFiles: false,
+        reachDebug: false,
+        reachDetailedAnalysisLogFile: false,
+        reachDisableAnalytics: false,
+        reachDisableExternalToolChecks: false,
+        reachEcosystems: [],
+        reachEnableAnalysisSplitting: false,
+        reachExcludePaths: ['dist'],
+        reachLazyMode: false,
+        reachSkipCache: false,
+        reachUseOnlyPregeneratedSboms: false,
+        reachVersion: undefined,
+        runReachabilityAnalysis: true,
+      },
+      readOnly: false,
+      repoName: 'repo',
+      report: false,
+      reportLevel: 'error',
+      targets: ['/repo'],
+      tmp: false,
+    })
+
+    expect(mockGetPackageFilesForScan).toHaveBeenCalledWith(
+      ['/repo'],
+      { size: 1 },
+      {
+        config: {
+          projectIgnorePaths: ['fixtures/**', 'tests/**', 'packages/*/**'],
+        },
+        cwd: '/repo',
+      },
+    )
+    expect(mockPerformReachabilityAnalysis).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reachabilityOptions: expect.objectContaining({
+          reachExcludePaths: ['dist', 'tests/**', 'packages/*'],
+        }),
+      }),
+    )
+  })
+
+  it('does not apply excludePaths when reachability is disabled', async () => {
+    await handleCreateNewScan({
+      autoManifest: false,
+      branchName: 'main',
+      commitHash: '',
+      commitMessage: '',
+      committers: '',
+      cwd: '/repo',
+      defaultBranch: false,
+      interactive: false,
+      orgSlug: 'fakeOrg',
+      outputKind: 'text',
+      pendingHead: false,
+      pullRequest: 0,
+      reach: {
+        excludePaths: ['tests'],
+        reachAnalysisMemoryLimit: 8192,
+        reachAnalysisTimeout: 0,
+        reachConcurrency: 1,
+        reachContinueOnAnalysisErrors: false,
+        reachContinueOnInstallErrors: false,
+        reachContinueOnMissingLockFiles: false,
+        reachContinueOnNoSourceFiles: false,
+        reachDebug: false,
+        reachDetailedAnalysisLogFile: false,
+        reachDisableAnalytics: false,
+        reachDisableExternalToolChecks: false,
+        reachEcosystems: [],
+        reachEnableAnalysisSplitting: false,
+        reachExcludePaths: [],
+        reachLazyMode: false,
+        reachSkipCache: false,
+        reachUseOnlyPregeneratedSboms: false,
+        reachVersion: undefined,
+        runReachabilityAnalysis: false,
+      },
+      readOnly: false,
+      repoName: 'repo',
+      report: false,
+      reportLevel: 'error',
+      targets: ['/repo'],
+      tmp: false,
+    })
+
+    expect(mockGetPackageFilesForScan).toHaveBeenCalledWith(
+      ['/repo'],
+      { size: 1 },
+      {
+        config: { projectIgnorePaths: ['fixtures/**'] },
+        cwd: '/repo',
+      },
+    )
+    expect(mockPerformReachabilityAnalysis).not.toHaveBeenCalled()
+  })
+})

--- a/src/commands/scan/handle-scan-reach.mts
+++ b/src/commands/scan/handle-scan-reach.mts
@@ -1,6 +1,10 @@
 import { logger } from '@socketsecurity/registry/lib/logger'
 import { pluralize } from '@socketsecurity/registry/lib/words'
 
+import {
+  excludePathToProjectIgnorePath,
+  normalizeExcludePath,
+} from './exclude-paths.mts'
 import { fetchSupportedScanFileNames } from './fetch-supported-scan-file-names.mts'
 import { outputScanReach } from './output-scan-reach.mts'
 import { performReachabilityAnalysis } from './perform-reachability-analysis.mts'
@@ -33,7 +37,7 @@ export async function handleScanReach({
 }: HandleScanReachConfig) {
   const { spinner } = constants
 
-  // Get supported file names
+  // Get supported file names.
   const supportedFilesCResult = await fetchSupportedScanFileNames({ spinner })
   if (!supportedFilesCResult.ok) {
     await outputScanReach(supportedFilesCResult, {
@@ -55,8 +59,32 @@ export async function handleScanReach({
     ? socketYmlResult.data?.parsed
     : undefined
 
+  const { excludePaths } = reachabilityOptions
+  const scaExcludeGlobs = excludePaths.map(excludePathToProjectIgnorePath)
+  const coanaExcludeGlobs = excludePaths.map(normalizeExcludePath)
+
+  const effectiveSocketConfig = scaExcludeGlobs.length
+    ? {
+        ...socketConfig,
+        projectIgnorePaths: [
+          ...(socketConfig?.projectIgnorePaths ?? []),
+          ...scaExcludeGlobs,
+        ],
+      }
+    : socketConfig
+
+  const mergedReachabilityOptions = excludePaths.length
+    ? {
+        ...reachabilityOptions,
+        reachExcludePaths: [
+          ...reachabilityOptions.reachExcludePaths,
+          ...coanaExcludeGlobs,
+        ],
+      }
+    : reachabilityOptions
+
   const packagePaths = await getPackageFilesForScan(targets, supportedFiles, {
-    config: socketConfig,
+    config: effectiveSocketConfig,
     cwd,
   })
 
@@ -86,7 +114,7 @@ export async function handleScanReach({
     orgSlug,
     outputPath,
     packagePaths,
-    reachabilityOptions,
+    reachabilityOptions: mergedReachabilityOptions,
     spinner,
     target: targets[0]!,
     uploadManifests: true,

--- a/src/commands/scan/handle-scan-reach.test.mts
+++ b/src/commands/scan/handle-scan-reach.test.mts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { handleScanReach } from './handle-scan-reach.mts'
+
+const {
+  mockCheckCommandInput,
+  mockFetchSupportedScanFileNames,
+  mockFindSocketYmlSync,
+  mockGetPackageFilesForScan,
+  mockOutputScanReach,
+  mockPerformReachabilityAnalysis,
+} = vi.hoisted(() => ({
+  mockCheckCommandInput: vi.fn(),
+  mockFetchSupportedScanFileNames: vi.fn(),
+  mockFindSocketYmlSync: vi.fn(),
+  mockGetPackageFilesForScan: vi.fn(),
+  mockOutputScanReach: vi.fn(),
+  mockPerformReachabilityAnalysis: vi.fn(),
+}))
+
+vi.mock('./fetch-supported-scan-file-names.mts', () => ({
+  fetchSupportedScanFileNames: mockFetchSupportedScanFileNames,
+}))
+
+vi.mock('./output-scan-reach.mts', () => ({
+  outputScanReach: mockOutputScanReach,
+}))
+
+vi.mock('./perform-reachability-analysis.mts', () => ({
+  performReachabilityAnalysis: mockPerformReachabilityAnalysis,
+}))
+
+vi.mock('../../constants.mts', () => ({
+  default: {
+    spinner: {
+      start: vi.fn(),
+      stop: vi.fn(),
+      successAndStop: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('../../utils/check-input.mts', () => ({
+  checkCommandInput: mockCheckCommandInput,
+}))
+
+vi.mock('../../utils/config.mts', () => ({
+  findSocketYmlSync: mockFindSocketYmlSync,
+}))
+
+vi.mock('../../utils/path-resolve.mts', () => ({
+  getPackageFilesForScan: mockGetPackageFilesForScan,
+}))
+
+vi.mock('@socketsecurity/registry/lib/logger', () => ({
+  logger: {
+    success: vi.fn(),
+  },
+}))
+
+describe('handleScanReach', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCheckCommandInput.mockReturnValue(true)
+    mockFetchSupportedScanFileNames.mockResolvedValue({
+      ok: true,
+      data: { npm: { packageJson: { pattern: 'package.json' } } },
+    })
+    mockFindSocketYmlSync.mockReturnValue({
+      ok: true,
+      data: { parsed: { projectIgnorePaths: ['vendor/**'] } },
+    })
+    mockGetPackageFilesForScan.mockResolvedValue(['package.json'])
+    mockPerformReachabilityAnalysis.mockResolvedValue({
+      ok: true,
+      data: {
+        reachabilityReport: '.socket.facts.json',
+        tier1ReachabilityScanId: undefined,
+      },
+    })
+  })
+
+  it('applies excludePaths to manifest discovery and reachability analysis', async () => {
+    const reachabilityOptions = {
+      excludePaths: ['tests', 'packages/*'],
+      reachAnalysisMemoryLimit: 8192,
+      reachAnalysisTimeout: 0,
+      reachConcurrency: 1,
+      reachContinueOnAnalysisErrors: false,
+      reachContinueOnInstallErrors: false,
+      reachContinueOnMissingLockFiles: false,
+      reachContinueOnNoSourceFiles: false,
+      reachDebug: false,
+      reachDetailedAnalysisLogFile: false,
+      reachDisableAnalytics: false,
+      reachDisableExternalToolChecks: false,
+      reachEcosystems: [],
+      reachEnableAnalysisSplitting: false,
+      reachExcludePaths: ['node_modules'],
+      reachLazyMode: false,
+      reachSkipCache: false,
+      reachUseOnlyPregeneratedSboms: false,
+      reachVersion: undefined,
+    }
+
+    await handleScanReach({
+      cwd: '/repo',
+      interactive: false,
+      orgSlug: 'fakeOrg',
+      outputKind: 'text',
+      outputPath: '',
+      reachabilityOptions,
+      targets: ['.'],
+    })
+
+    expect(mockGetPackageFilesForScan).toHaveBeenCalledWith(
+      ['.'],
+      { npm: { packageJson: { pattern: 'package.json' } } },
+      {
+        config: {
+          projectIgnorePaths: ['vendor/**', 'tests/**', 'packages/*/**'],
+        },
+        cwd: '/repo',
+      },
+    )
+    expect(mockPerformReachabilityAnalysis).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reachabilityOptions: expect.objectContaining({
+          reachExcludePaths: ['node_modules', 'tests/**', 'packages/*'],
+        }),
+      }),
+    )
+  })
+})

--- a/src/commands/scan/perform-reachability-analysis.mts
+++ b/src/commands/scan/perform-reachability-analysis.mts
@@ -16,6 +16,7 @@ import type { PURL_Type } from '../../utils/ecosystem.mts'
 import type { Spinner } from '@socketsecurity/registry/lib/spinner'
 
 export type ReachabilityOptions = {
+  excludePaths: string[]
   reachAnalysisMemoryLimit: number
   reachAnalysisTimeout: number
   reachConcurrency: number

--- a/src/commands/scan/reachability-flags.mts
+++ b/src/commands/scan/reachability-flags.mts
@@ -3,9 +3,11 @@ import constants from '../../constants.mts'
 import type { MeowFlags } from '../../flags.mts'
 
 export const reachabilityFlags: MeowFlags = {
-  reachVersion: {
+  excludePaths: {
     type: 'string',
-    description: `Override the version of @coana-tech/cli used for reachability analysis. Default: ${constants.ENV.INLINED_SOCKET_CLI_COANA_TECH_CLI_VERSION}.`,
+    isMultiple: true,
+    description:
+      'List of glob patterns to exclude from the entire Tier 1 scan, including SCA/SBOM manifest discovery. Patterns are matched relative to the project root. Bare directory names are auto-extended to recursive globs (e.g. `tests` becomes `tests/**`). Trailing slashes are stripped. Negation patterns (`!path`) are not supported. Accepts a comma-separated value or multiple flags.',
   },
   reachAnalysisMemoryLimit: {
     type: 'number',
@@ -49,11 +51,6 @@ export const reachabilityFlags: MeowFlags = {
     description:
       'Continue reachability analysis when a workspace contains no source files for its ecosystem. By default, the CLI halts.',
   },
-  reachDisableExternalToolChecks: {
-    type: 'boolean',
-    default: false,
-    description: 'Disable external tool checks during reachability analysis.',
-  },
   reachDebug: {
     type: 'boolean',
     default: false,
@@ -66,12 +63,6 @@ export const reachabilityFlags: MeowFlags = {
     description:
       'A log file with detailed analysis logs is written to root of each analyzed workspace.',
   },
-  reachDisableAnalytics: {
-    type: 'boolean',
-    default: false,
-    description:
-      'Disable reachability analytics sharing with Socket. Also disables caching-based optimizations.',
-  },
   reachDisableAnalysisSplitting: {
     type: 'boolean',
     default: false,
@@ -79,17 +70,28 @@ export const reachabilityFlags: MeowFlags = {
     description:
       'Deprecated: Analysis splitting is now disabled by default. This flag is a no-op.',
   },
-  reachEnableAnalysisSplitting: {
+  reachDisableAnalytics: {
     type: 'boolean',
     default: false,
     description:
-      'Allow the reachability analysis to partition CVEs into buckets that are processed in separate analysis runs. May improve accuracy, but not recommended by default.',
+      'Disable reachability analytics sharing with Socket. Also disables caching-based optimizations.',
+  },
+  reachDisableExternalToolChecks: {
+    type: 'boolean',
+    default: false,
+    description: 'Disable external tool checks during reachability analysis.',
   },
   reachEcosystems: {
     type: 'string',
     isMultiple: true,
     description:
       'List of ecosystems to conduct reachability analysis on, as either a comma separated value or as multiple flags. Defaults to all ecosystems.',
+  },
+  reachEnableAnalysisSplitting: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Allow the reachability analysis to partition CVEs into buckets that are processed in separate analysis runs. May improve accuracy, but not recommended by default.',
   },
   reachExcludePaths: {
     type: 'string',
@@ -114,5 +116,9 @@ export const reachabilityFlags: MeowFlags = {
     default: false,
     description:
       'When using this option, the scan is created based only on pre-generated CDX and SPDX files in your project.',
+  },
+  reachVersion: {
+    type: 'string',
+    description: `Override the version of @coana-tech/cli used for reachability analysis. Default: ${constants.ENV.INLINED_SOCKET_CLI_COANA_TECH_CLI_VERSION}.`,
   },
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `--exclude-paths` for Tier 1 scan flows and reject negation patterns.
- Apply exclude paths to manifest discovery via derived `projectIgnorePaths` and merge normalized patterns into Coana `--exclude-dirs` through existing reach exclude plumbing.
- Add helper, command, and handler coverage for normalization, validation, reach-only gating, and SCA/Coana merge behavior.

## Verification
- `git diff --check`
- Not run: `pnpm build:dist:src`, `pnpm check`, or unit tests because this cloud VM has no `node`, `npm`, `pnpm`, or `corepack` binaries installed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ac91250-8f2a-445b-8756-2251cf1587b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ac91250-8f2a-445b-8756-2251cf1587b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

