### PR TITLE
upgrading coana to version 15.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.92](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.92) - 2026-05-05
+
+### Changed
+- Updated the Coana CLI to v `15.2.2`.
+
 ## [1.1.91](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.91) - 2026-05-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.91",
+  "version": "1.1.92",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -97,7 +97,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "15.2.0",
+    "@coana-tech/cli": "15.2.2",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 15.2.0
-        version: 15.2.0
+        specifier: 15.2.2
+        version: 15.2.2
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@15.2.0':
-    resolution: {integrity: sha512-vSAJH1GlGiDDuJArNSHcJkmbyN0hdXMnIs6VmtWYB0HoZSYkMwjgZVEyeeUWHNbnwk7fBpNcZd1cpBiUgp7bjw==}
+  '@coana-tech/cli@15.2.2':
+    resolution: {integrity: sha512-Vyo30ac4XBFxPcRfyJVdzdDb4dCd4M9AXsKjKEG9R2nTUVzLeaj5hczm2vzRwvwd15c6hDAEN7oVeLAbJUMfgA==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5385,7 +5385,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@15.2.0': {}
+  '@coana-tech/cli@15.2.2': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 15.2.0 to 15.2.2

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).