### PR TITLE
chore(node, pnpm, skills): bump to Node v26.0.0 + pnpm 11.0.6 + sync updating-xport

### DIFF
--- a/.claude/skills/updating-xport/SKILL.md
+++ b/.claude/skills/updating-xport/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: updating-xport
+description: Acts on `xport.json` drift for repos that carry the xport lock-step manifest. Reads `pnpm run xport --json`, then for each row acts per-kind — auto-bump `version-pin` rows (low-risk mechanical updates), advisory-only for `file-fork` / `feature-parity` / `spec-conformance` / `lang-parity` (upstream semantics need human judgment). Invoked by the `updating` umbrella skill; can also be invoked standalone.
+user-invocable: true
+allowed-tools: Bash(pnpm:*), Bash(npm:*), Bash(git:*), Bash(node:*), Bash(rg:*), Bash(grep:*), Bash(find:*), Bash(ls:*), Bash(cat:*), Bash(head:*), Bash(tail:*), Bash(wc:*), Bash(diff:*), Read, Edit, Grep, Glob---
+
+# updating-xport
+
+<task>
+Act on drift findings in `xport.json`. Auto-apply mechanical version-pin bumps; surface everything else as advisory notes for human review. Commit each actioned row as its own atomic commit so the PR reviewer can accept/reject per-row.
+</task>
+
+<context>
+**xport** is a cross-project lock-step manifest. Not every repo has one; this skill exits cleanly when `xport.json` is absent. See `xport.schema.json` (deployed via `socket-repo-template/sync-scaffolding.mjs`) for the five row kinds.
+
+The harness at `scripts/xport.mts` emits JSON reports with `severity ∈ {ok, drift, error}` per row. This skill consumes that JSON.
+
+**Per-kind action policy:**
+
+| Kind | Drift signal | Action |
+|------|--------------|--------|
+| `version-pin` | Upstream commits on default ref since pinned SHA | **Auto-bump** per `upgrade_policy`: `track-latest` → advance to latest stable tag; `major-gate` → advance patch/minor only; `locked` → advisory only |
+| `file-fork` | Upstream file changed since `forked_at_sha` | **Advisory** — note in PR body; do NOT auto-merge (forks carry local deltas that need human review) |
+| `feature-parity` | Parity score below `criticality/10` floor | **Advisory** — note in PR body; human decides implement vs downgrade criticality |
+| `spec-conformance` | Spec submodule moved | **Advisory** — note in PR body; human decides whether to bump `spec_version` |
+| `lang-parity` | Port divergence / `rejected` anti-pattern reintroduced | **Advisory** — note in PR body; humans fix the port or update the manifest |
+
+The common rule: **version-pin is mechanical** (safe to auto-apply with `track-latest`/`major-gate` policies); everything else is **advisory** (upstream semantics and local deltas matter, humans decide).
+</context>
+
+<constraints>
+**Requirements:**
+- Start with clean working directory (check via `git status --porcelain`)
+- Run from repo root
+- Exit 0 cleanly if `xport.json` is absent (the repo doesn't use xport)
+- Conventional commit format: `chore(deps): bump <upstream> to <tag>`
+- Update `.gitmodules` version comments when submodule tags change (pattern: `# <name>-<version>` on the line above the submodule block)
+- Target stable releases only (filter `-rc`, `-alpha`, `-beta`, `-dev`, `-snapshot`, `-nightly`, `-preview`)
+
+**Forbidden:**
+- Never auto-edit `file-fork`, `feature-parity`, `spec-conformance`, or `lang-parity` rows' tracked state
+- Never bump a `locked` version-pin without human approval
+- Never skip the tag-stability filter
+- Never use `npx`, `pnpm dlx`, `yarn dlx` — use `pnpm exec` or `pnpm run`
+
+**CI mode** (`CI=true` or `GITHUB_ACTIONS`): skip per-row test validation (workflow validates at the end); emit advisory summary to `$GITHUB_OUTPUT` when present.
+
+**Interactive mode** (default): validate each auto-bump with `pnpm test` before committing the next.
+</constraints>
+
+<instructions>
+
+## Phase 1 — Pre-flight
+
+```bash
+test -f xport.json || { echo "no xport.json; skill n/a"; exit 0; }
+test -f xport.schema.json || { echo "xport.schema.json missing — malformed scaffolding"; exit 1; }
+test -f scripts/xport.mts || { echo "scripts/xport.mts missing — malformed scaffolding"; exit 1; }
+
+git status --porcelain | grep -v '^??' && { echo "dirty tree; aborting"; exit 1; } || true
+
+[ "$CI" = "true" ] || [ -n "$GITHUB_ACTIONS" ] && CI_MODE=true || CI_MODE=false
+```
+
+## Phase 2 — Collect drift
+
+```bash
+pnpm run xport --json > /tmp/xport-report.json
+```
+
+Parse `reports[]` from the JSON. Split into:
+
+- **auto** — rows where `severity == "drift"` AND `kind == "version-pin"` AND `upgrade_policy` ∈ `{ "track-latest", "major-gate" }`
+- **advisory** — everything else with `severity != "ok"`
+
+If both lists empty: exit 0 with "no xport drift".
+
+## Phase 3 — Auto-bump version-pin rows
+
+For each row in **auto** list, in manifest declaration order:
+
+**3a. Resolve the upstream submodule + fetch tags**
+
+```bash
+SUBMODULE=$(jq -r --arg a "$UPSTREAM_ALIAS" '.upstreams[$a].submodule' xport.json)
+cd "$SUBMODULE"
+git fetch origin --tags --quiet
+OLD_SHA=$(git rev-parse HEAD)
+```
+
+**3b. Find the target tag**
+
+Examine existing `pinned_tag` to identify the tag scheme, then match:
+
+- `v1.2.3` (v-prefixed semver)
+- `1.2.3` (bare semver)
+- `<prefix>-1.2.3` (project-prefixed)
+- `<prefix>_1_2_3` (underscore style; curl, liburing)
+
+For `major-gate` policy: parse major version from `LATEST` vs current `pinned_tag`. If majors differ, skip — add to advisory with note "major bump needs human review".
+
+**3c. Check out + capture new SHA**
+
+```bash
+NEW_SHA_FOR_CHECK=$(git rev-parse "$LATEST")
+[ "$OLD_SHA" = "$NEW_SHA_FOR_CHECK" ] && { cd -; continue; }
+git checkout "$LATEST" --quiet
+NEW_SHA=$(git rev-parse HEAD)
+cd -
+```
+
+**3d. Update `xport.json` + `.gitmodules`**
+
+Use `jq` for structured edit:
+
+```bash
+jq --arg id "$ROW_ID" --arg sha "$NEW_SHA" --arg tag "$LATEST" \
+  '(.rows[] | select(.id == $id) | .pinned_sha) = $sha
+   | (.rows[] | select(.id == $id) | .pinned_tag) = $tag' \
+  xport.json > xport.json.tmp && mv xport.json.tmp xport.json
+```
+
+Update `.gitmodules` version comment via Edit tool (NOT sed per CLAUDE.md) — replace `# <prefix>-<old>` with `# <prefix>-<new>` on the comment line above the submodule block.
+
+**3e. Validate + commit**
+
+```bash
+# Confirm xport harness accepts the new state
+pnpm run xport --json > /tmp/xport-post.json
+jq --arg id "$ROW_ID" '.reports[] | select(.id == $id) | .severity' /tmp/xport-post.json
+# expect "ok"
+
+if [ "$CI_MODE" = "false" ]; then
+  pnpm test || {
+    echo "tests failed; rolling back $ROW_ID"
+    git checkout xport.json .gitmodules "$SUBMODULE"
+    continue
+  }
+fi
+
+git add xport.json .gitmodules "$SUBMODULE"
+git commit -m "chore(deps): bump $UPSTREAM_ALIAS to $LATEST"
+```
+
+Record bumped row in summary accumulator.
+
+## Phase 4 — Compose advisory notes
+
+For each row in **advisory**, accumulate a markdown line:
+
+```
+- **file-fork** `<id>`: `<local>` — <N> upstream commit(s) since <forked_at_sha[0:12]>. Review diff, cherry-pick if applicable, bump forked_at_sha.
+- **feature-parity** `<id>`: parity score <score> below floor <floor>. Implement or downgrade criticality with reason.
+- **spec-conformance** `<id>`: upstream spec repo moved. Review for breaking changes before bumping spec_version.
+- **lang-parity** `<id>`: <details from messages[]>.
+- **version-pin** `<id>`: major bump to <LATEST> — policy=major-gate requires human review.
+- **version-pin** `<id>`: upgrade_policy=locked — skipped.
+```
+
+## Phase 5 — Report + emit
+
+Final human-readable report to stdout:
+
+```
+## updating-xport report
+
+**Auto-bumped:** <N> row(s)
+<list>
+
+**Advisory (human review):** <M> row(s)
+<list>
+```
+
+In CI mode, emit the advisory block to `$GITHUB_OUTPUT` (base64-encoded) under key `xport-advisory` so the weekly-update workflow can include it in the PR body:
+
+```bash
+if [ -n "$GITHUB_OUTPUT" ]; then
+  echo "xport-advisory=$(printf '%s' "$ADVISORY" | base64 | tr -d '\n')" >> "$GITHUB_OUTPUT"
+fi
+```
+
+Emit a HANDOFF block per `_shared/report-format.md`:
+
+```
+=== HANDOFF: updating-xport ===
+Status: {pass|fail}
+Findings: {auto_bumped: N, advisory: M}
+Summary: {one-line description}
+=== END HANDOFF ===
+```
+
+</instructions>
+
+## Success Criteria
+
+- All actionable `version-pin` rows bumped atomically (one commit per row)
+- Advisory rows collected for PR body / workflow output
+- No edits to non-version-pin row state
+- `pnpm run xport` exits 0 or 2 at end (never 1 — no schema errors introduced)
+- `.gitmodules` version comments synchronized with `pinned_tag`
+
+## Commands
+
+- `pnpm run xport --json` — drift report (consumed by this skill)
+- `jq` — parse + edit `xport.json` (structured JSON edits)
+- `git submodule status` — verify submodule state after bumps
+
+## When to use
+
+- Invoked by the `updating` umbrella skill (weekly-update workflow)
+- Standalone: `/updating-xport` when syncing just the xport manifest
+- After manual submodule bumps, to refresh `xport.json` metadata

--- a/.claude/skills/updating/SKILL.md
+++ b/.claude/skills/updating/SKILL.md
@@ -1,38 +1,240 @@
 ---
 name: updating
-description: >
-  Coordinates all dependency updates (npm packages and external tool checksums).
-  Triggers when user asks to "update everything", "update dependencies", or
-  prepare for a release.
+description: Umbrella update skill for a Socket fleet repo. Runs `pnpm run update` (npm), validates `xport.json` via `pnpm run xport` (if present), optionally bumps submodules, and checks workflow SHA pins. Use when asked to update dependencies, sync upstreams, or prepare for a release.
 user-invocable: true
-allowed-tools: Task, Skill, Bash, Read, Grep, Glob, Edit
+allowed-tools: Task, Skill, Read, Edit, Grep, Glob, Bash(pnpm run:*), Bash(pnpm test:*), Bash(pnpm install:*), Bash(git:*), Bash(claude --version)
 ---
 
 # updating
 
 <task>
-Your task is to update all dependencies in socket-cli: npm packages via `pnpm run update`, then sync external tool checksums, ensuring all builds and tests pass.
+Update all dependencies for this repo: npm packages first, then the
+xport-managed version pins (if `xport.json` exists), then any other
+submodules tracked via `.gitmodules`, and finally verify workflow
+SHA pins are current. Validate with the full check/test suite before
+committing. The sub-skill delegation mirrors the canonical
+socket-registry `updating` skill; uncomment the phases that apply to
+this repo and delete those that don't.
 </task>
 
+<context>
+**What is this?**
+The umbrella update skill. Runs `pnpm run update` for npm deps, then
+adapts to what the repo has:
+
+**Update Targets:**
+- **npm packages** — via `pnpm run update` (every Socket repo has this script)
+- **xport-managed upstreams** — via `pnpm run xport` when `xport.json` exists
+  (manifest-managed submodule pins + advisory drift on file-fork /
+  feature-parity / spec-conformance / lang-parity rows)
+- **Other submodules** — via repo-specific `updating-*` sub-skills
+  when `.gitmodules` has entries not claimed by xport version-pin rows
+- **Workflow SHA pins** — check `_local-not-for-reuse-*.yml` against
+  `origin/main`; run the `updating-workflows` skill when stale
+
+**Key files this skill consults:**
+- `xport.json` — if present, drives version-pin bumps and surfaces drift
+- `.gitmodules` — listed submodules; xport's `version-pin` rows take precedence
+- `.github/workflows/_local-not-for-reuse-*.yml` — SHA pin sources
+- `package.json` — `pnpm run update` script
+
+Sub-skills are invoked only when applicable — this umbrella reads repo
+state first to discover what to run.
+</context>
+
 <constraints>
-- Start with clean working directory (no uncommitted changes).
-- Target stable releases only (exclude -rc, -alpha, -beta tags).
-- **CI mode** (`CI=true` or `GITHUB_ACTIONS`): Create atomic commits, skip build validation.
-- **Interactive mode** (default): Validate each update with build/tests before proceeding.
+**Requirements:**
+- Start with clean working directory (no uncommitted changes)
+
+**CI Mode** (detected via `CI=true` or `GITHUB_ACTIONS`):
+- Create atomic commits, skip build validation (CI validates separately)
+- Workflow handles push and PR creation
+
+**Interactive Mode** (default):
+- Validate updates with build/tests before proceeding
+- Report validation results to user
+
+**Actions:**
+- Update npm packages
+- Apply xport-driven bumps (if `xport.json` present)
+- Bump remaining submodules (if any)
+- Create atomic commits per category
+- Report summary of changes
 </constraints>
 
-## Phases
+<instructions>
 
-1. **Validate Environment** - Verify clean working directory; detect CI vs interactive mode.
-2. **Update npm Packages** - Run `pnpm run update`; commit if changes detected.
-3. **Update External Tool Checksums** - Invoke the `updating-checksums` skill.
-3b. **Update Security Tools** - Run `node .claude/hooks/setup-security-tools/update.mts` to check for new zizmor/sfw releases. Respects pnpm `minimumReleaseAge` cooldown for third-party tools (zizmor) but updates Socket tools (sfw) immediately. Updates embedded checksums in the setup hook.
-3c. **Sync Claude Code version** - Run `claude --version` to get the installed version. If it's newer than the `@anthropic-ai/claude-code` entry in `pnpm-workspace.yaml` catalog, update both the catalog entry AND the `minimumReleaseAgeExclude` pinned version. This bypasses cooldown since we're the ones running it. Then run `pnpm install` to update the lockfile.
-4. **Final Validation** - In interactive mode: `pnpm run fix --all`, `pnpm run check --all`, `pnpm test`. Skipped in CI.
-5. **Report Summary** - List updates applied, commits created, validation results, and next steps.
+## Process
 
-## Coordinates
+### Phase 1: Validate Environment
 
-- `updating-checksums` skill for external tool checksums
-- `node .claude/hooks/setup-security-tools/update.mts` for security tool version updates
-- `pnpm run update` for npm packages
+Check clean working directory, detect CI mode (`CI=true` or
+`GITHUB_ACTIONS`), verify submodules initialized (if any).
+
+---
+
+### Phase 2: Update npm Packages
+
+```bash
+pnpm run update
+
+if [ -n "$(git status --porcelain)" ]; then
+  git add pnpm-lock.yaml package.json */package.json
+  git commit -m "chore: update npm dependencies
+
+Updated npm packages via pnpm run update."
+  echo "npm packages updated"
+else
+  echo "npm packages already up to date"
+fi
+```
+
+---
+
+### Phase 3: Validate xport manifest (if applicable)
+
+If `xport.json` exists at repo root, run the harness in read-only mode
+to classify drift before acting on it:
+
+```bash
+if [ -f xport.json ]; then
+  pnpm run xport
+  XPORT_EXIT=$?
+
+  case $XPORT_EXIT in
+    0) echo "✓ xport clean — manifest valid, no drift; skip Phase 4 xport step" ;;
+    1) echo "✗ xport schema/structural error — stopping"; exit 1 ;;
+    2) echo "⚠ xport drift — Phase 4 will invoke updating-xport to act" ;;
+  esac
+fi
+```
+
+Exit code semantics:
+- **0** — manifest valid, no drift; nothing for `updating-xport` to do.
+- **1** — schema violation, missing file, or unreachable baseline. Stop
+  and investigate via `scripts/xport-schema.mts` and the failing row's
+  `local_*`/`upstream` fields. Do not auto-retry.
+- **2** — drift detected. Phase 4 invokes the `updating-xport` skill,
+  which auto-bumps mechanical `version-pin` rows (per `upgrade_policy`)
+  and surfaces everything else (`file-fork` / `feature-parity` /
+  `spec-conformance` / `lang-parity` / `locked` version-pins) as
+  advisory notes for the PR body. Drift on `locked` rows never
+  auto-bumps — they need a coordinated upstream change first (e.g.,
+  `temporal-rs` is `locked` because Node vendors it and bumping is
+  gated on a Node bump landing first).
+
+If `xport.json` does NOT exist, skip this phase.
+
+---
+
+### Phase 4: Apply xport drift + update other submodules (if applicable)
+
+**4a. xport drift** — if Phase 3 reported exit 2 (drift), invoke the
+`updating-xport` skill. It auto-bumps `version-pin` rows whose
+`upgrade_policy` is `track-latest` or `major-gate` (patch/minor only,
+majors → advisory), and emits an advisory block for everything else.
+Each auto-bumped row becomes its own atomic commit.
+
+```bash
+if [ "$XPORT_EXIT" = "2" ]; then
+  # Invoke via the Skill tool / programmatic-claude flow used by the
+  # weekly-update workflow. Standalone runs can do `/updating-xport`.
+  echo "Invoking updating-xport for drift handling"
+fi
+```
+
+**4b. Non-xport submodules** — invoke each `updating-*` sub-skill this
+repo defines (e.g., `updating-node`, `updating-curl`) for submodules
+NOT claimed by an xport `version-pin` row. These sub-skills know about
+build inputs that aren't tracked in xport (cache-versions bumps,
+patch regeneration, etc.).
+
+If no `.gitmodules` exists, skip 4b.
+
+---
+
+### Phase 5: Check Workflow SHA Pins
+
+Inspect `_local-not-for-reuse-*.yml` files for their pinned SHA and
+compare against `origin/main`:
+
+```bash
+PINNED_SHA=$(grep -ohP '(?<=@)[0-9a-f]{40}' .github/workflows/_local-not-for-reuse-ci.yml 2>/dev/null | head -1)
+MAIN_SHA=$(git rev-parse origin/main 2>/dev/null || echo "")
+
+if [ -n "$PINNED_SHA" ] && [ -n "$MAIN_SHA" ] && [ "$PINNED_SHA" != "$MAIN_SHA" ]; then
+  echo "Workflow SHA pins are stale: $PINNED_SHA → $MAIN_SHA"
+  echo "Run the updating-workflows skill to cascade."
+else
+  echo "Workflow SHA pins are up to date (or no _local-not-for-reuse-*.yml pins in this repo)"
+fi
+```
+
+---
+
+### Phase 6: Final Validation (skip in CI)
+
+```bash
+if [ "$CI" = "true" ] || [ -n "$GITHUB_ACTIONS" ]; then
+  echo "CI mode: skipping validation"
+else
+  pnpm run check --all
+  pnpm test
+  pnpm run build  # if this repo has a build step
+fi
+```
+
+---
+
+### Phase 7: Report Summary
+
+```
+## Update Complete
+
+### Updates Applied:
+
+| Category           | Status                               |
+|--------------------|--------------------------------------|
+| npm packages       | Updated / Up to date                 |
+| xport manifest     | <ok>/<total> ok, <drift> drift, <error> error (exit <code>) — or n/a |
+| Other submodules   | K bumped — or n/a                    |
+| Workflow SHA pins  | Up to date / Stale                   |
+
+### Commits Created:
+- [list commits, if any]
+
+### Validation:
+- Build: SUCCESS / SKIPPED (CI mode)
+- Tests: PASS / SKIPPED (CI mode)
+
+### Next Steps:
+**Interactive mode:**
+1. Review changes: `git log --oneline -N`
+2. Push to remote: `git push origin main`
+
+**CI mode:**
+1. Workflow will push branch and create PR
+2. CI will run full build/test validation
+3. Review PR when CI passes
+```
+
+</instructions>
+
+## Success Criteria
+
+- All npm packages checked for updates
+- xport manifest validated (when present); schema/structural errors block
+- Full build and tests pass (interactive mode)
+- Summary report generated
+
+## Context
+
+This skill is useful for:
+
+- Weekly maintenance (automated via `weekly-update.yml`)
+- Security patch rollout
+- Pre-release preparation
+
+**Safety:** Updates are validated before committing. Schema errors
+(xport exit 1) stop the process; drift (xport exit 2) is advisory
+and does not block.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@51f34ffb69c5d38614a16078793af662b0cea38d # main
         with:
           checkout: 'false'
 
@@ -168,7 +168,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@51f34ffb69c5d38614a16078793af662b0cea38d # main
         with:
           checkout: 'false'
 
@@ -234,7 +234,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@51f34ffb69c5d38614a16078793af662b0cea38d # main
         with:
           checkout: 'false'
           node-version: ${{ matrix.node-version }}
@@ -317,7 +317,7 @@ jobs:
           export default { text, view, renderToString, renderToStringWithWidth, printComponent, eprintComponent, getTerminalSize, TuiRenderer, init }
           CODE
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@51f34ffb69c5d38614a16078793af662b0cea38d # main
         with:
           checkout: 'false'
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@51f34ffb69c5d38614a16078793af662b0cea38d # main
         with:
           checkout: 'false'
 
@@ -91,7 +91,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@51f34ffb69c5d38614a16078793af662b0cea38d # main
         with:
           checkout: 'false'
           registry-url: 'https://registry.npmjs.org'
@@ -141,7 +141,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@51f34ffb69c5d38614a16078793af662b0cea38d # main
         with:
           checkout: 'false'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@51f34ffb69c5d38614a16078793af662b0cea38d # main
         with:
           checkout: 'false'
 
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@51f34ffb69c5d38614a16078793af662b0cea38d # main
         with:
           checkout: 'false'
 
@@ -79,7 +79,7 @@ jobs:
           git checkout -b "$BRANCH_NAME" HEAD~1
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@51f34ffb69c5d38614a16078793af662b0cea38d # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -332,7 +332,7 @@ jobs:
             test.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@51f34ffb69c5d38614a16078793af662b0cea38d # main
         if: always()
 
   notify:

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "socket-cli-monorepo",
   "version": "0.0.0",
-  "packageManager": "pnpm@11.0.0-rc.5",
+  "packageManager": "pnpm@11.0.6+sha512.97f906e1da2bedac3df83cadae04b4753a130092dd49d55cd36825ad3e623e9df3f97754f8f259e699172a360fac569acf2f908e7732bdae3eddb2dcf7e121fd",
   "private": true,
   "engines": {
-    "node": ">=25.9.0",
-    "pnpm": ">=11.0.0-rc.3"
+    "node": ">=26.0.0",
+    "pnpm": ">=11.0.6"
   },
   "scripts": {
     "// Build": "",

--- a/packages/build-infra/package.json
+++ b/packages/build-infra/package.json
@@ -25,9 +25,5 @@
     "@sinclair/typebox": "catalog:",
     "@socketsecurity/lib": "catalog:",
     "magic-string": "catalog:"
-  },
-  "engines": {
-    "node": ">=25.5.0",
-    "pnpm": ">=10.22.0"
   }
 }

--- a/packages/package-builder/package.json
+++ b/packages/package-builder/package.json
@@ -18,8 +18,5 @@
     "@socketsecurity/lib": "catalog:",
     "build-infra": "workspace:*",
     "handlebars": "^4.7.9"
-  },
-  "engines": {
-    "node": ">=25.5.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,6 +571,16 @@ importers:
         specifier: 'catalog:'
         version: 4.1.8
 
+  .claude/hooks/auth-rotation-reminder:
+    dependencies:
+      '@socketsecurity/lib':
+        specifier: 5.24.0
+        version: 5.24.0(typescript@5.9.3)
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.9.2
+
   .claude/hooks/check-new-deps:
     dependencies:
       '@socketregistry/packageurl-js':
@@ -587,6 +597,14 @@ importers:
         specifier: 24.9.2
         version: 24.9.2
 
+  .claude/hooks/logger-guard:
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.9.2
+
+  .claude/hooks/path-guard: {}
+
   .claude/hooks/public-surface-reminder:
     devDependencies:
       '@types/node':
@@ -598,6 +616,10 @@ importers:
       '@socketsecurity/lib':
         specifier: 5.24.0
         version: 5.24.0(typescript@5.9.3)
+
+  .claude/hooks/stale-process-sweeper: {}
+
+  .claude/hooks/token-guard: {}
 
   .claude/hooks/token-hygiene:
     devDependencies:
@@ -2176,6 +2198,7 @@ packages:
 
   '@socketaddon/iocraft@file:packages/package-builder/build/dev/out/socketaddon-iocraft':
     resolution: {directory: packages/package-builder/build/dev/out/socketaddon-iocraft, type: directory}
+    engines: {node: '>=18'}
 
   '@socketregistry/es-set-tostringtag@1.0.10':
     resolution: {integrity: sha512-btXmvw1JpA8WtSoXx9mTapo9NAyIDKRRzK84i48d8zc0X09M6ORfobVnHbgwhXf7CFhkRzhYrHG9dqbI9vpELQ==}


### PR DESCRIPTION
## Summary

- Root `engines.node`: `>=25.9.0` → `>=26.0.0`
- Root `engines.pnpm`: `>=11.0.0-rc.3` → `>=11.0.6`
- Root `packageManager`: `pnpm@11.0.0-rc.5` → `pnpm@11.0.6+sha512.<hex>`
- Drop `engines` from internal-only `packages/build-infra` + `packages/package-builder`

## Why

Tracks the `SocketDev/socket-registry` external-tools.json bump (commit `9246c28b`) which moved pnpm to 11.0.6 in the canonical CI pin and migrated the schema from per-platform sha256 fields to SRI-format integrity strings.

The root packageManager now carries the corepack hex integrity hash (RFC 2018) so corepack verifies the downloaded pnpm tarball before trusting it. Different encoding from external-tools.json's SRI form because corepack's parser only accepts hex.

The two private subpackages were drift-prone (`>=25.5.0` vs root `>=25.9.0`) without serving any consumer — they're workspace-only and never published. Per the new socket-repo-template CLAUDE.md rule "monorepo-internal subpackages don't need engines", the field is removed.

## Test plan

- [ ] CI passes on Node 26.0.0 runners
- [ ] `pnpm install` succeeds with corepack hash verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates toolchain requirements/pins and removes redundant `engines` fields, but may break installs/CI for environments not yet on Node 26/pnpm 11.0.6.
> 
> **Overview**
> Bumps the monorepo toolchain requirements to **Node `>=26.0.0`** and **pnpm `>=11.0.6`**, and updates the root `packageManager` to `pnpm@11.0.6` with a pinned `sha512` integrity string for corepack verification.
> 
> Removes `engines` constraints from the internal workspace-only packages `build-infra` and `package-builder` to avoid per-package version drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5218f6e437f29c8f1f0cf17ce16ecdbeb1470cc0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->