### PR TITLE
chore(workspace): block exotic subdeps

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -165,6 +165,15 @@ minimumReleaseAgeExclude:
   - '@socketregistry/*'
   - '@socketsecurity/*'
 
+# Refuse transitive dependencies declared via git/tarball/local-tarball
+# specs — an npm package shouldn't be allowed to drag in a git URL we
+# don't control (bypasses npm registry validation, no provenance, no
+# soak window). Direct git deps are still allowed (the test suite at
+# pnpm/pkg-manager/core/test/install/blockExoticSubdeps.ts confirms
+# this). pnpm's current default is `false`; declared explicitly so a
+# future flip can't silently change install behavior.
+blockExoticSubdeps: true
+
 # Dependency overrides (migrated from package.json pnpm.overrides).
 overrides:
   '@octokit/graphql': 'catalog:'


### PR DESCRIPTION
Refuses transitive deps declared via git/tarball/local-tarball specs. An npm package shouldn't drag in a git URL we don't control (bypasses npm registry validation, no provenance, no soak window). Direct git deps are still allowed.

pnpm's current default is `false`; declared explicitly so a future flip can't silently change install behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pnpm install policy to reject transitive git/tarball/local-tarball dependencies, which could break installs for packages that rely on those specifiers. Impact is limited to dependency resolution/configuration (no runtime code changes).
> 
> **Overview**
> Enables pnpm’s `blockExoticSubdeps` in `pnpm-workspace.yaml` to **refuse transitive dependencies** declared via git/tarball/local-tarball specifiers, while still allowing direct git dependencies.
> 
> Adds explanatory comments and explicitly pins this behavior to avoid future pnpm default changes silently altering install policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 556936edb4bdb754b863660c6bf06610ab30683b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->