### PR TITLE
fix(fix): make --ecosystems case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.93](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.93) - 2026-05-08
+
+### Changed
+- `socket fix --ecosystems` now accepts values case-insensitively (e.g. `NPM`, `npm`, and `Npm` are all valid), matching the existing behavior of `--package-managers`.
+
 ## [1.1.92](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.92) - 2026-05-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - `socket fix --ecosystems` now accepts values case-insensitively (e.g. `NPM`, `npm`, and `Npm` are all valid), matching the existing behavior of `--package-managers`.
+- Updated the Coana CLI to v `15.2.4`.
 
 ## [1.1.92](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.92) - 2026-05-05
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "15.2.2",
+    "@coana-tech/cli": "15.2.4",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.92",
+  "version": "1.1.93",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 15.2.2
-        version: 15.2.2
+        specifier: 15.2.4
+        version: 15.2.4
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@15.2.2':
-    resolution: {integrity: sha512-Vyo30ac4XBFxPcRfyJVdzdDb4dCd4M9AXsKjKEG9R2nTUVzLeaj5hczm2vzRwvwd15c6hDAEN7oVeLAbJUMfgA==}
+  '@coana-tech/cli@15.2.4':
+    resolution: {integrity: sha512-vMdNmZlaxFgVJQ0bGi4H3ULjbP78A9OJGsmQu7Ec8clj2wIDVrCBVE/9Jf+7vAlg7t+haegPuCzzJiD4dQo66A==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5385,7 +5385,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@15.2.2': {}
+  '@coana-tech/cli@15.2.4': {}
 
   '@colors/colors@1.5.0':
     optional: true

--- a/src/commands/fix/cmd-fix.integration.test.mts
+++ b/src/commands/fix/cmd-fix.integration.test.mts
@@ -168,7 +168,7 @@ describe('socket fix', async () => {
                                 See GitHub documentation (https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository) for managing auto-merge for pull requests in your repository.
             --debug             Enable debug logging in the Coana-based Socket Fix CLI invocation.
             --disable-external-tool-checks  Disable external tool checks during fix analysis.
-            --ecosystems        Limit fix analysis to specific ecosystems. Can be provided as comma separated values or as multiple flags. Defaults to all ecosystems.
+            --ecosystems        Limit fix analysis to specific ecosystems. Accepts space- or comma-separated values and is case-insensitive. Defaults to all ecosystems.
             --exclude           Exclude workspaces matching these glob patterns. Can be provided as comma separated values or as multiple flags
             --fix-version       Override the version of @coana-tech/cli used for fix analysis. Default: <coana-version>.
             --id                Provide a list of vulnerability identifiers to compute fixes for:
@@ -1102,6 +1102,23 @@ describe('socket fix', async () => {
         '{"apiToken":"fakeToken"}',
       ],
       'should accept multiple --ecosystems flags',
+      async cmd => {
+        const { code, stdout } = await spawnSocketCli(binCliPath, cmd)
+        expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Not saving"`)
+        expect(code, 'should exit with code 0').toBe(0)
+      },
+    )
+
+    cmdit(
+      [
+        'fix',
+        FLAG_DRY_RUN,
+        '--ecosystems',
+        'NPM,PyPI',
+        FLAG_CONFIG,
+        '{"apiToken":"fakeToken"}',
+      ],
+      'should accept --ecosystems case-insensitively',
       async cmd => {
         const { code, stdout } = await spawnSocketCli(binCliPath, cmd)
         expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Not saving"`)

--- a/src/commands/fix/cmd-fix.mts
+++ b/src/commands/fix/cmd-fix.mts
@@ -168,7 +168,7 @@ Available styles:
     type: 'string',
     default: [],
     description:
-      'Limit fix analysis to specific ecosystems. Can be provided as comma separated values or as multiple flags. Defaults to all ecosystems.',
+      'Limit fix analysis to specific ecosystems. Accepts space- or comma-separated values and is case-insensitive. Defaults to all ecosystems.',
     isMultiple: true,
   },
   packageManagers: {
@@ -367,7 +367,11 @@ async function run(
   const outputKind = getOutputKind(json, markdown)
 
   // Process comma-separated values for ecosystems flag.
-  const ecosystemsRaw = cmdFlagValueToArray(ecosystems)
+  // ALL_ECOSYSTEMS is lowercase, so normalize input for a case-insensitive
+  // match (mirrors --package-managers behavior).
+  const ecosystemsRaw = cmdFlagValueToArray(ecosystems).map(s =>
+    s.toLowerCase(),
+  )
 
   // Validate ecosystem values early, before dry-run check.
   const validatedEcosystems: PURL_Type[] = []


### PR DESCRIPTION
## Summary
- Lowercase `--ecosystems` input before validation so `NPM`, `Npm`, and `npm` are all accepted, matching the behavior already in place for `--package-managers` (#1292).
- Update `--ecosystems` help text to mention case-insensitivity.
- Upgrade `@coana-tech/cli` from 15.2.2 to 15.2.4.
- Bump patch version to 1.1.93 and add a CHANGELOG entry.

## Why
`--package-managers` was added in #1292 as case-insensitive (input gets uppercased before validation against an ALL-CAPS list). `--ecosystems`, however, validates input verbatim against an all-lowercase list, so passing `NPM` would fail with "Invalid ecosystem". Asymmetric UX between two related filters; this commit makes `--ecosystems` mirror `--package-managers`.

## Coana Changelog
For details on what's included in the 15.2.4 Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

## Test plan
- [x] New integration test: `should accept --ecosystems case-insensitively` (passes `NPM,PyPI`)
- [x] Existing `--ecosystems` integration tests still pass
- [x] Help-text snapshot updated
- [x] `eslint` + `tsgo` pass on the changed files
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small input-normalization change for `socket fix` flag parsing plus a dependency bump; behavior change is limited to validation of `--ecosystems` values.
> 
> **Overview**
> `socket fix --ecosystems` now normalizes provided ecosystem values to lowercase before validation, making the flag case-insensitive (aligned with `--package-managers`), and updates the help text accordingly.
> 
> Adds an integration test covering mixed-case `--ecosystems` input, bumps `@coana-tech/cli` to `15.2.4`, and increments the CLI version to `1.1.93` with a matching `CHANGELOG.md` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 444d139aa2a0acb3684f618eec287668d1a381d8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->