### PR TITLE
Ignore local dev tool worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Thumbs.db
 /.env
 /.env.local
 /.nvm
+/.pnpm-store
 /.rollup.cache
 /.type-coverage
 /.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,12 @@ Thumbs.db
 test/fixtures/commands/fix/e2e-test-js-temp-*
 test/fixtures/commands/fix/e2e-test-py-temp-*
 
+/.claude/*
+!/.claude/agents/
+!/.claude/commands/
+!/.claude/hooks/
+!/.claude/ops/
+!/.claude/settings.json
+!/.claude/skills/
+
 !/.vscode/extensions.json

--- a/.oxlintignore
+++ b/.oxlintignore
@@ -1,1 +1,3 @@
 package-lock.json
+.claude/worktrees/
+.pnpm-store/

--- a/biome.json
+++ b/biome.json
@@ -10,9 +10,11 @@
       "!**/.github",
       "!**/.husky",
       "!**/.nvm",
+      "!.pnpm-store",
       "!**/.rollup.cache",
       "!**/.type-coverage",
       "!**/.vscode",
+      "!.claude/worktrees",
       "!**/coverage",
       "!**/package.json",
       "!**/package-lock.json"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,15 @@
 {
   "extends": "./.config/tsconfig.base.json",
   "include": ["src/**/*.mts"],
-  "exclude": ["src/**/*.test.mts"]
+  "exclude": [
+    "src/**/*.test.mts",
+    ".cache/**",
+    ".claude/**",
+    "binaries/**",
+    "build/**",
+    "dist/**",
+    "external/**",
+    "node_modules/**",
+    "pkg-binaries/**"
+  ]
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -8,6 +8,8 @@ export default defineConfig({
     exclude: [
       '**/node_modules/**',
       '**/dist/**',
+      '.claude/worktrees/**',
+      '.pnpm-store/**',
       '**/.{idea,git,cache,output,temp}/**',
       '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*',
       // Exclude E2E tests from regular test runs.

--- a/vitest.e2e.config.mts
+++ b/vitest.e2e.config.mts
@@ -9,6 +9,13 @@ export default defineConfig({
     // from racing on the npm _npx cache directory.
     fileParallelism: false,
     include: ['**/*.e2e.test.mts'],
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '.claude/worktrees/**',
+      '.pnpm-store/**',
+      '**/.{idea,git,cache,output,temp}/**',
+    ],
     coverage: {
       exclude: [
         '**/{eslint,vitest}.config.*',


### PR DESCRIPTION
## Summary

(chore) : Claude likes to store git worktrees in ./.claude/worktrees. This confuses the heck out of the linting tools, causing them to seemingly hang. Added worktres and pnpm store to various ignore lists,

- ignore repo-local .pnpm-store for Git/ESLint discovery
- ignore Claude worktrees and pnpm stores for Oxlint, Biome, and Vitest discovery
- keep patterns root-relative where broad excludes would make nested worktrees unusable

## Verification
- git diff --check
- git check-ignore -v .pnpm-store .pnpm-store/v10 .claude/worktrees .claude/worktrees/example
- oxlint --print-config with .oxlintignore
- vitest list --config vitest.config.mts --dir src/commands/scan --reporter dot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to ignore/exclude patterns for git, linters, TypeScript, and Vitest, with minimal chance of inadvertently skipping intended source files if patterns are too broad.
> 
> **Overview**
> Prevents tooling hangs/noise by **excluding local dev artifacts** from discovery: repo-local `.pnpm-store` and Claude-managed `.claude/worktrees` are now ignored by git and excluded from `oxlint`, `biome`, and both Vitest configs.
> 
> Expands `tsconfig.json` excludes to keep TypeScript from scanning build/cache/output directories (including `.claude/**` and common artifact folders).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2e6870e4766bfabefd00ea3436da5e4db615ad8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->