### PR TITLE
fix(manifest): copy sbt-generated poms out of `target/` (REA-437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [1.1.94](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.94) - 2026-05-12
 
 ### Fixed
-- `socket manifest scala` now copies sbt-generated `.pom` files out of each subproject's `target/` directory to the project root, so downstream SBOM and scan steps that respect `.gitignore` can see the generated manifest files.
+- `socket manifest scala` now copies sbt-generated `.pom` files out of each subproject's `target/` directory to the project root as `pom.xml`, so Socket scan (which discovers `**/pom.xml` and respects `.gitignore`) picks them up automatically. Use `--out` to override the destination filename.
 
 ## [1.1.93](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.93) - 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.94](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.94) - 2026-05-12
+
+### Fixed
+- `socket manifest scala` now copies sbt-generated `.pom` files out of each subproject's `target/` directory to the project root, so downstream SBOM and scan steps that respect `.gitignore` can see the generated manifests.
+
 ## [1.1.93](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.93) - 2026-05-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [1.1.94](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.94) - 2026-05-12
 
 ### Fixed
-- `socket manifest scala` now copies sbt-generated `.pom` files out of each subproject's `target/` directory to the project root, so downstream SBOM and scan steps that respect `.gitignore` can see the generated manifests.
+- `socket manifest scala` now copies sbt-generated `.pom` files out of each subproject's `target/` directory to the project root, so downstream SBOM and scan steps that respect `.gitignore` can see the generated manifest files.
 
 ## [1.1.93](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.93) - 2026-05-08
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.93",
+  "version": "1.1.94",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",

--- a/src/commands/manifest/cmd-manifest-scala.mts
+++ b/src/commands/manifest/cmd-manifest-scala.mts
@@ -59,8 +59,10 @@ const config: CliCommandConfig = {
 
     There are some caveats with \`build.sbt\` to \`pom.xml\` conversion:
 
-    - the xml is exported as socket.pom.xml as to not confuse existing build tools
-      but it will first hit your /target/sbt<version> folder (as a different name)
+    - the xml is exported as pom.xml at the project root so Socket scan picks
+      it up; sbt itself first writes it inside your /target/sbt<version> folder
+      (as a different name). Use --out to override if you already have a
+      hand-authored pom.xml at the project root.
 
     - the pom.xml format (standard by Scala) does not support certain sbt features
       - \`excludeAll()\`, \`dependencyOverrides\`, \`force()\`, \`relativePath\`
@@ -148,7 +150,7 @@ async function run(
       out = sockJson.defaults?.manifest?.sbt?.outfile
       logger.info(`Using default --out from ${SOCKET_JSON}:`, out)
     } else {
-      out = './socket.pom.xml'
+      out = './pom.xml'
     }
   }
   if (!sbtOpts) {

--- a/src/commands/manifest/cmd-manifest-scala.test.mts
+++ b/src/commands/manifest/cmd-manifest-scala.test.mts
@@ -35,8 +35,10 @@ describe('socket manifest scala', async () => {
 
           There are some caveats with \`build.sbt\` to \`pom.xml\` conversion:
 
-          - the xml is exported as socket.pom.xml as to not confuse existing build tools
-            but it will first hit your /target/sbt<version> folder (as a different name)
+          - the xml is exported as pom.xml at the project root so Socket scan picks
+            it up; sbt itself first writes it inside your /target/sbt<version> folder
+            (as a different name). Use --out to override if you already have a
+            hand-authored pom.xml at the project root.
 
           - the pom.xml format (standard by Scala) does not support certain sbt features
             - \`excludeAll()\`, \`dependencyOverrides\`, \`force()\`, \`relativePath\`

--- a/src/commands/manifest/convert_sbt_to_maven.mts
+++ b/src/commands/manifest/convert_sbt_to_maven.mts
@@ -116,7 +116,7 @@ export async function convertSbtToMaven({
       // typically gitignored. Copy them out to a sibling of `target/` so
       // downstream SBOM/scan steps see them.
       const copied: string[] = []
-      const outBasename = path.basename(out) || 'socket.pom.xml'
+      const outBasename = path.basename(out) || 'pom.xml'
       for (const pomPath of poms) {
         let destPath: string
         if (poms.length === 1 && out !== outBasename) {

--- a/src/commands/manifest/convert_sbt_to_maven.mts
+++ b/src/commands/manifest/convert_sbt_to_maven.mts
@@ -6,6 +6,7 @@ import { logger } from '@socketsecurity/registry/lib/logger'
 import { spawn } from '@socketsecurity/registry/lib/spawn'
 
 import constants from '../../constants.mts'
+import { getErrorCause } from '../../utils/errors.mts'
 
 // Walk up from a pom path to find a `target` directory ancestor and return
 // its parent (the project root). Returns undefined if no `target` ancestor
@@ -141,7 +142,7 @@ export async function convertSbtToMaven({
           copied.push(destPath)
         } catch (e) {
           logger.warn(
-            `Failed to copy \`${pomPath}\` to \`${destPath}\`: ${(e as Error).message}`,
+            `Failed to copy \`${pomPath}\` to \`${destPath}\`: ${getErrorCause(e)}`,
           )
         }
       }

--- a/src/commands/manifest/convert_sbt_to_maven.mts
+++ b/src/commands/manifest/convert_sbt_to_maven.mts
@@ -1,8 +1,27 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+
 import { safeReadFile } from '@socketsecurity/registry/lib/fs'
 import { logger } from '@socketsecurity/registry/lib/logger'
 import { spawn } from '@socketsecurity/registry/lib/spawn'
 
 import constants from '../../constants.mts'
+
+// Walk up from a pom path to find a `target` directory ancestor and return
+// its parent (the project root). Returns undefined if no `target` ancestor
+// is found, which means we cannot safely lift the file out of the ignored
+// build dir.
+function findProjectRootAboveTarget(pomPath: string): string | undefined {
+  let dir = path.dirname(pomPath)
+  const { root } = path.parse(dir)
+  while (dir !== root) {
+    if (path.basename(dir) === 'target') {
+      return path.dirname(dir)
+    }
+    dir = path.dirname(dir)
+  }
+  return undefined
+}
 
 export async function convertSbtToMaven({
   bin,
@@ -92,18 +111,47 @@ export async function convertSbtToMaven({
       logger.info('Exiting now...')
       return
     } else {
-      // if (verbose) {
-      //   logger.log(
-      //     `Moving manifest file from \`${loc.replace(/^\/home\/[^/]*?\//, '~/')}\` to \`${out}\``
-      //   )
-      // } else {
-      //   logger.log('Moving output pom file')
-      // }
-      // TODO: Do we prefer fs-extra? Renaming can be gnarly on windows and fs-extra's version is better.
-      // await renamep(loc, out)
-      logger.success(`Generated ${poms.length} pom files`)
-      poms.forEach(fn => logger.log('-', fn))
-      logger.success(`OK`)
+      // sbt writes poms inside each project's `target/` directory, which is
+      // typically gitignored. Copy them out to a sibling of `target/` so
+      // downstream SBOM/scan steps see them.
+      const copied: string[] = []
+      const outBasename = path.basename(out) || 'socket.pom.xml'
+      for (const pomPath of poms) {
+        let destPath: string
+        if (poms.length === 1 && out !== outBasename) {
+          // Honor the full `--out` path verbatim when exactly one pom was
+          // produced and the user (or default) supplied a path, not just a
+          // bare filename.
+          destPath = path.resolve(cwd, out)
+        } else {
+          const projectRoot = findProjectRootAboveTarget(pomPath)
+          if (!projectRoot) {
+            logger.warn(
+              `Could not locate \`target/\` ancestor for \`${pomPath}\`, leaving in place`,
+            )
+            continue
+          }
+          destPath = path.join(projectRoot, outBasename)
+        }
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          await fs.mkdir(path.dirname(destPath), { recursive: true })
+          // eslint-disable-next-line no-await-in-loop
+          await fs.copyFile(pomPath, destPath)
+          copied.push(destPath)
+        } catch (e) {
+          logger.warn(
+            `Failed to copy \`${pomPath}\` to \`${destPath}\`: ${(e as Error).message}`,
+          )
+        }
+      }
+      logger.success(
+        `Generated ${copied.length} pom file${copied.length === 1 ? '' : 's'}`,
+      )
+      logger.log('Reported exports:')
+      for (const fn of copied) {
+        logger.log('-', fn)
+      }
     }
   } catch (e) {
     process.exitCode = 1

--- a/src/commands/manifest/generate_auto_manifest.mts
+++ b/src/commands/manifest/generate_auto_manifest.mts
@@ -34,7 +34,7 @@ export async function generateAutoManifest({
       // Note: `sbt` is more likely to be resolved against PATH env
       bin: sockJson.defaults?.manifest?.sbt?.bin ?? 'sbt',
       cwd,
-      out: sockJson.defaults?.manifest?.sbt?.outfile ?? './socket.sbt.pom.xml',
+      out: sockJson.defaults?.manifest?.sbt?.outfile ?? './pom.xml',
       sbtOpts:
         sockJson.defaults?.manifest?.sbt?.sbtOpts
           ?.split(' ')


### PR DESCRIPTION
## Summary
- `socket manifest scala` ran `sbt makePom` but left every generated pom inside each subproject's `target/scala-X.Y/` dir, which is gitignored in standard SBT projects — so downstream SBOM/scan steps that respect `.gitignore` skipped all of them.
- After sbt finishes, copy each pom out to `<projectRoot>/socket.pom.xml` (or `<basename(--out)>`) by walking up to the nearest `target/` ancestor. Mirrors what `init.gradle` already does on the gradle path, just from Node.
- Tightens the success output to one list of destinations to match the gradle command's verbosity.

Linear: [REA-437](https://linear.app/socketdev/issue/REA-437/socket-manifest-scala-writes-poms-into-gitignored-target-dirs)

## Test plan
- [ ] Run `socket manifest scala .` on a multi-module sbt project (e.g. circe); confirm a `socket.pom.xml` lands next to each subproject's `target/` and that none of the destinations sit inside a `target/` dir.
- [ ] Single-module sbt project: confirm `--out=./custom.pom.xml` writes to that exact path.
- [ ] `--stdout` / `socket manifest scala --stdout .` behavior unchanged.
- [ ] `socket scan create` after the manifest step now picks up the generated scala manifests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes filesystem output locations for `socket manifest scala` by copying generated POMs out of `target/`, which could affect downstream tooling and user expectations around `--out` in multi-module projects.
> 
> **Overview**
> `socket manifest scala` now copies sbt-generated `.pom` files out of each module’s gitignored `target/` directory into the project root (using the `--out` basename, or honoring the full `--out` path when only one POM is produced), and reports the copied destinations.
> 
> Adds a `target/`-ancestor search helper and switches from “generated” logging to listing the exported copy locations; package version is bumped to `1.1.94`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acd6d30800b20bf80fc064498948b736dbd99fa5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->