### PR TITLE
upgrading coana to version 15.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.96](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.96) - 2026-05-15
+
+### Changed
+- Updated the Coana CLI to v `15.2.8`.
+
 ## [1.1.95](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.95) - 2026-05-15
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.95",
+  "version": "1.1.96",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -97,7 +97,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "15.2.7",
+    "@coana-tech/cli": "15.2.8",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 15.2.7
-        version: 15.2.7
+        specifier: 15.2.8
+        version: 15.2.8
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@15.2.7':
-    resolution: {integrity: sha512-JTkMRSIxfli5+wVx3LevjKPzXHPvwOWz978t60OqHcOs8ol0x43DR8nwwt9Ro3K8qPZ/iMEvQSW1jEVAxOyK6w==}
+  '@coana-tech/cli@15.2.8':
+    resolution: {integrity: sha512-aNlXwrdyvSJtH0Y6+F+ckyEb8+ZbxS/MmLL3+oem24FTTu9I901BL7NPuvIzd+eFpFnvnMJ+cTqagbD/JsxPJg==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5385,7 +5385,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@15.2.7': {}
+  '@coana-tech/cli@15.2.8': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 15.2.7 to 15.2.8

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump: only updates the bundled Coana CLI version and related lockfile metadata, with no code or behavioral changes in this repo beyond what the new Coana release introduces.
> 
> **Overview**
> Bumps the embedded Coana toolchain by upgrading `@coana-tech/cli` from `15.2.7` to `15.2.8`.
> 
> Updates release bookkeeping by incrementing the CLI version to `1.1.96`, updating `pnpm-lock.yaml`, and adding a `CHANGELOG.md` entry for the Coana upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfabf63fc464a24c5a63d9558e00b3f519626d59. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->