### PR TITLE
upgrading coana to version 15.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`socket manifest bazel [beta]`** — Generate Bazel JVM SBOM manifests by running `bazel query` against discovered Maven repos in a Bazel workspace. Closes the inline-Maven-declaration gap that lockfile-only parsing misses for repos like envoy, ray, tensorflow, tink-java, and or-tools. Auto-detects Bzlmod and legacy `WORKSPACE`.
 - **`socket scan create --auto-manifest`** now covers Bazel workspaces in addition to Gradle/Scala/Kotlin/Conda. Repos with `MODULE.bazel`, `WORKSPACE`, or `WORKSPACE.bazel` are detected automatically and their Maven dependencies extracted as part of the standard scan-create flow.
 
+## [1.1.97](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.97) - 2026-05-18
+
+### Changed
+- Updated the Coana CLI to v `15.3.0`.
+
 ## [1.1.96](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.96) - 2026-05-15
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.96",
+  "version": "1.1.97",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -97,7 +97,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "15.2.8",
+    "@coana-tech/cli": "15.3.0",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 15.2.8
-        version: 15.2.8
+        specifier: 15.3.0
+        version: 15.3.0
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@15.2.8':
-    resolution: {integrity: sha512-aNlXwrdyvSJtH0Y6+F+ckyEb8+ZbxS/MmLL3+oem24FTTu9I901BL7NPuvIzd+eFpFnvnMJ+cTqagbD/JsxPJg==}
+  '@coana-tech/cli@15.3.0':
+    resolution: {integrity: sha512-AgwIOsZ2TeLMGKhD1GXZqfmRPEX1Ups9l8kYPIfbJ7XvqUCT//NoyE2KUBs/jP20CFcbu1x8+at6CbqAix7rcw==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5385,7 +5385,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@15.2.8': {}
+  '@coana-tech/cli@15.3.0': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 15.2.8 to 15.3.0

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version/dependency bump: updates the bundled `@coana-tech/cli` used by analysis flows, which could change scan/fix behavior but does not modify this repo’s runtime logic.
> 
> **Overview**
> Bumps the CLI release to **v1.1.97** and updates the bundled `@coana-tech/cli` dependency from **15.2.8** to **15.3.0** (including lockfile updates).
> 
> Adds a `CHANGELOG.md` entry for `1.1.97` documenting the Coana upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bc8bb1a5453e59d31416265ea3eb599db3582b9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->