### PR TITLE
fix(api): always use node:https.request in apiFetch to avoid undici b…

### DIFF
--- a/src/utils/api.mts
+++ b/src/utils/api.mts
@@ -20,6 +20,7 @@
  */
 
 import { Agent as HttpsAgent, request as httpsRequest } from 'node:https'
+import { ReadableStream } from 'node:stream/web'
 
 import { messageWithCauses } from 'pony-cause'
 
@@ -151,29 +152,44 @@ function _httpsRequestFetch(
           )
           return
         }
-        const chunks: Buffer[] = []
-        res.on('data', (chunk: Buffer) => chunks.push(chunk))
-        res.on('end', () => {
-          const body = Buffer.concat(chunks)
-          const responseHeaders = new Headers()
-          for (const [key, value] of Object.entries(res.headers)) {
-            if (typeof value === 'string') {
-              responseHeaders.set(key, value)
-            } else if (Array.isArray(value)) {
-              for (const v of value) {
-                responseHeaders.append(key, v)
-              }
+        // Build response headers immediately on receipt.
+        const responseHeaders = new Headers()
+        for (const [key, value] of Object.entries(res.headers)) {
+          if (typeof value === 'string') {
+            responseHeaders.set(key, value)
+          } else if (Array.isArray(value)) {
+            for (const v of value) {
+              responseHeaders.append(key, v)
             }
           }
-          resolve(
-            new Response(body, {
-              status: statusCode ?? 0,
-              statusText: res.statusMessage ?? '',
-              headers: responseHeaders,
-            }),
-          )
+        }
+        // Resolve with a streaming body as soon as headers are available,
+        // matching fetch() semantics. Callers that pipe response.body (e.g.
+        // streamDownloadWithFetch) receive a live ReadableStream rather than
+        // a fully-buffered Buffer.
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            res.on('data', (chunk: Buffer) => {
+              controller.enqueue(chunk)
+            })
+            res.on('end', () => {
+              controller.close()
+            })
+            res.on('error', (err: Error) => {
+              controller.error(err)
+            })
+          },
+          cancel() {
+            res.destroy()
+          },
         })
-        res.on('error', reject)
+        resolve(
+          new Response(body, {
+            status: statusCode ?? 0,
+            statusText: res.statusMessage ?? '',
+            headers: responseHeaders,
+          }),
+        )
       },
     )
     if (init.body) {

--- a/src/utils/api.mts
+++ b/src/utils/api.mts
@@ -72,9 +72,12 @@ function getHttpsAgent(): HttpsAgent | undefined {
   return _httpsAgent
 }
 
-// Wrapper around fetch that supports extra CA certificates via SSL_CERT_FILE.
-// Uses node:https.request with a custom agent when extra CA certs are needed,
-// falling back to regular fetch() otherwise. Follows redirects like fetch().
+// Wrapper around fetch using node:https.request for all calls.
+// This avoids undici's default 300 s bodyTimeout, which would otherwise fire
+// on large streaming responses before the body has fully transferred. Behaviour
+// matches the SDK, which also uses node:https.request with no body timeout.
+// Passes the custom HTTPS agent when extra CA certificates are configured via
+// SSL_CERT_FILE, otherwise uses Node's default agent. Follows redirects like fetch().
 export type ApiFetchInit = {
   body?: string | undefined
   headers?: Record<string, string> | undefined
@@ -85,7 +88,7 @@ export type ApiFetchInit = {
 function _httpsRequestFetch(
   url: string,
   init: ApiFetchInit,
-  agent: HttpsAgent,
+  agent: HttpsAgent | undefined,
   redirectCount: number,
 ): Promise<Response> {
   return new Promise((resolve, reject) => {
@@ -186,11 +189,7 @@ export async function apiFetch(
   url: string,
   init: ApiFetchInit = {},
 ): Promise<Response> {
-  const agent = getHttpsAgent()
-  if (!agent) {
-    return await fetch(url, init as globalThis.RequestInit)
-  }
-  return await _httpsRequestFetch(url, init, agent, 0)
+  return await _httpsRequestFetch(url, init, getHttpsAgent(), 0)
 }
 
 export type CommandRequirements = {

--- a/src/utils/api.mts
+++ b/src/utils/api.mts
@@ -72,12 +72,11 @@ function getHttpsAgent(): HttpsAgent | undefined {
   return _httpsAgent
 }
 
-// Wrapper around fetch using node:https.request for all calls.
-// This avoids undici's default 300 s bodyTimeout, which would otherwise fire
-// on large streaming responses before the body has fully transferred. Behaviour
-// matches the SDK, which also uses node:https.request with no body timeout.
-// Passes the custom HTTPS agent when extra CA certificates are configured via
-// SSL_CERT_FILE, otherwise uses Node's default agent. Follows redirects like fetch().
+// All outbound API requests use node:https.request rather than global fetch.
+// This ensures no body timeout is applied — large streaming ND-JSON responses
+// (e.g. full scan results) can transfer without a hard deadline. When
+// SSL_CERT_FILE is configured, a custom HttpsAgent carrying the extra CA
+// certificates is passed; otherwise the default agent is used.
 export type ApiFetchInit = {
   body?: string | undefined
   headers?: Record<string, string> | undefined

--- a/src/utils/api.test.mts
+++ b/src/utils/api.test.mts
@@ -6,8 +6,9 @@
  * direct API calls when NODE_EXTRA_CA_CERTS is not set at process startup.
  *
  * Test Coverage:
- * - apiFetch falls back to regular fetch when no extra CA certs are needed.
- * - apiFetch uses node:https.request with custom agent when CA certs are set.
+ * - apiFetch always uses node:https.request (no undici body timeout).
+ * - apiFetch passes a custom HttpsAgent when CA certs are set via SSL_CERT_FILE.
+ * - apiFetch passes no agent (undefined) when no CA certs are configured.
  * - Response object construction from https.request output.
  * - POST requests with JSON body through https.request path.
  * - Error propagation from https.request failures.
@@ -113,18 +114,46 @@ describe('apiFetch with extra CA certificates', () => {
     globalThis.fetch = originalFetch
   })
 
-  it('should use regular fetch when no extra CA certs are needed', async () => {
-    const mockResponse = new Response(JSON.stringify({ ok: true }), {
-      status: 200,
-      statusText: 'OK',
-    })
-    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse)
+  it('should use https.request with no agent when no extra CA certs are needed', async () => {
+    const mockReq = {
+      end: vi.fn(),
+      on: vi.fn(),
+      write: vi.fn(),
+    }
+
+    mockHttpsRequest.mockImplementation(
+      (_url: string, _opts: unknown, callback: RequestCallback) => {
+        setTimeout(() => {
+          const mockRes = {
+            headers: { 'content-type': 'text/plain' },
+            on: vi.fn(),
+            statusCode: 200,
+            statusMessage: 'OK',
+          }
+          const handlers: Record<string, Function> = {}
+          mockRes.on.mockImplementation((event: string, handler: Function) => {
+            handlers[event] = handler
+            return mockRes
+          })
+          callback(mockRes)
+          handlers['data']?.(Buffer.from('response body'))
+          handlers['end']?.()
+        }, 0)
+        return mockReq
+      },
+    )
 
     const { queryApiSafeText } = await import('./api.mts')
     const result = await queryApiSafeText('test/path', 'test request')
 
-    expect(globalThis.fetch).toHaveBeenCalled()
-    expect(mockHttpsRequest).not.toHaveBeenCalled()
+    // Always uses https.request — no undici body timeout.
+    expect(mockHttpsRequest).toHaveBeenCalled()
+    // No custom HttpsAgent created when CA certs are not configured.
+    expect(MockHttpsAgent).not.toHaveBeenCalled()
+    // agent is undefined when no CA certs are configured.
+    const callArgs = mockHttpsRequest.mock.calls[0]
+    expect(callArgs[1]).toEqual(expect.objectContaining({ agent: undefined }))
+    expect(result.ok).toBe(true)
   })
 
   it('should use https.request when extra CA certs are available', async () => {


### PR DESCRIPTION
…ody timeout

Node's built-in fetch uses undici which has a default bodyTimeout of 300s. For large streaming ND-JSON responses (e.g. full scan results) this timeout fires before the body has fully transferred, producing a BodyTimeoutError.

[nodejs/undici` v6.21.3 — `lib/dispatcher/client.js`, line ~246](https://github.com/nodejs/undici/blob/v6.21.3/lib/dispatcher/client.js#L246)

```
this[kBodyTimeout] = bodyTimeout != null ? bodyTimeout : 300e3
```

Route all apiFetch calls through the existing _httpsRequestFetch path, which uses node:https.request and has no body timeout — consistent with the SDK and all other HTTP clients used across socket-cli, socket-sdk-js, and coana.

When SSL_CERT_FILE is not set, agent is passed as undefined and https.request uses its default agent. Behaviour is otherwise identical to before.

Update the apiFetch test to assert https.request is always used and that no custom HttpsAgent is created when CA certs are not configured.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> All CLI API traffic now routes through the custom `https.request` implementation, which could subtly change request/redirect behavior compared to `fetch` and affect all outbound calls. Mitigated by reusing the existing `_httpsRequestFetch` path and tightening tests around agent handling.
> 
> **Overview**
> **`apiFetch` no longer falls back to global `fetch`**; it now always uses the existing `_httpsRequestFetch` (`node:https.request`) path so large/streaming ND-JSON responses aren’t subject to undici’s default body timeout.
> 
> When no extra CA certs are configured, the request is made with `agent: undefined` (default agent); when `SSL_CERT_FILE` provides extra CAs, a custom `HttpsAgent` is still created and passed. Tests were updated to assert `https.request` is always used and that the agent behavior matches both scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee86ba4bd33265847c4801b3dda3cb6d32dd6e69. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->