### PR TITLE
test(optimize): clean up pnpm v8 and v9 fixture artifacts after tests

### DIFF
--- a/src/commands/optimize/cmd-optimize-pnpm-versions.test.mts
+++ b/src/commands/optimize/cmd-optimize-pnpm-versions.test.mts
@@ -21,6 +21,23 @@ const fixtureBaseDir = path.join(testPath, 'fixtures/commands/optimize')
 const pnpm8FixtureDir = path.join(fixtureBaseDir, 'pnpm8')
 const pnpm9FixtureDir = path.join(fixtureBaseDir, 'pnpm9')
 
+async function cleanupFixtureInstallArtifacts(
+  fixtureDir: string,
+): Promise<void> {
+  const staleDirs = [
+    path.join(fixtureDir, '.cache'),
+    path.join(fixtureDir, 'node_modules'),
+  ]
+
+  try {
+    await Promise.all(
+      staleDirs.filter(dir => existsSync(dir)).map(dir => trash(dir)),
+    )
+  } catch {
+    // Ignore cleanup errors.
+  }
+}
+
 describe('socket optimize - pnpm versions', { timeout: 60_000 }, async () => {
   const { binCliPath } = constants
 
@@ -36,13 +53,7 @@ describe('socket optimize - pnpm versions', { timeout: 60_000 }, async () => {
           stdio: 'ignore',
         })
       } catch {}
-      const staleDirs = [
-        path.join(pnpm8FixtureDir, 'node_modules'),
-        path.join(pnpm8FixtureDir, '.cache'),
-      ]
-      await Promise.all(
-        staleDirs.filter(dir => existsSync(dir)).map(dir => trash(dir)),
-      )
+      await cleanupFixtureInstallArtifacts(pnpm8FixtureDir)
       // Ensure pnpm v8 is installed in the fixture.
       // Skip if pnpm is not available globally (e.g., Windows CI).
       try {
@@ -70,13 +81,7 @@ describe('socket optimize - pnpm versions', { timeout: 60_000 }, async () => {
           stdio: 'ignore',
         })
       } catch {}
-      const staleDirs = [
-        path.join(pnpm8FixtureDir, 'node_modules'),
-        path.join(pnpm8FixtureDir, '.cache'),
-      ]
-      await Promise.all(
-        staleDirs.filter(dir => existsSync(dir)).map(dir => trash(dir)),
-      )
+      await cleanupFixtureInstallArtifacts(pnpm8FixtureDir)
     })
 
     it(
@@ -185,13 +190,7 @@ describe('socket optimize - pnpm versions', { timeout: 60_000 }, async () => {
           stdio: 'ignore',
         })
       } catch {}
-      const staleDirs = [
-        path.join(pnpm9FixtureDir, 'node_modules'),
-        path.join(pnpm9FixtureDir, '.cache'),
-      ]
-      await Promise.all(
-        staleDirs.filter(dir => existsSync(dir)).map(dir => trash(dir)),
-      )
+      await cleanupFixtureInstallArtifacts(pnpm9FixtureDir)
       // Ensure pnpm v9 is installed in the fixture.
       // Skip if pnpm is not available globally (e.g., Windows CI).
       try {
@@ -219,13 +218,7 @@ describe('socket optimize - pnpm versions', { timeout: 60_000 }, async () => {
           stdio: 'ignore',
         })
       } catch {}
-      const staleDirs = [
-        path.join(pnpm9FixtureDir, 'node_modules'),
-        path.join(pnpm9FixtureDir, '.cache'),
-      ]
-      await Promise.all(
-        staleDirs.filter(dir => existsSync(dir)).map(dir => trash(dir)),
-      )
+      await cleanupFixtureInstallArtifacts(pnpm9FixtureDir)
     })
 
     it(

--- a/src/commands/optimize/cmd-optimize-pnpm-versions.test.mts
+++ b/src/commands/optimize/cmd-optimize-pnpm-versions.test.mts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs'
 import path from 'node:path'
 
+import trash from 'trash'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { JsonContent } from '@socketsecurity/registry/lib/fs'
@@ -27,13 +28,21 @@ describe('socket optimize - pnpm versions', { timeout: 60_000 }, async () => {
     const pnpm8BinPath = path.join(pnpm8FixtureDir, 'node_modules', '.bin')
 
     beforeEach(async () => {
-      // Reset fixtures to their committed state (package.json and pnpm-lock.yaml).
+      // Reset fixtures to their committed state (package.json and pnpm-lock.yaml)
+      // and remove untracked install artifacts left by prior runs.
       try {
         await spawn('git', ['checkout', 'HEAD', '--', '.'], {
           cwd: pnpm8FixtureDir,
           stdio: 'ignore',
         })
       } catch {}
+      const staleDirs = [
+        path.join(pnpm8FixtureDir, 'node_modules'),
+        path.join(pnpm8FixtureDir, '.cache'),
+      ]
+      await Promise.all(
+        staleDirs.filter(dir => existsSync(dir)).map(dir => trash(dir)),
+      )
       // Ensure pnpm v8 is installed in the fixture.
       // Skip if pnpm is not available globally (e.g., Windows CI).
       try {
@@ -54,13 +63,20 @@ describe('socket optimize - pnpm versions', { timeout: 60_000 }, async () => {
     })
 
     afterEach(async () => {
-      // Reset fixtures to their committed state after each test.
+      // Reset tracked fixture files and remove install artifacts.
       try {
         await spawn('git', ['checkout', 'HEAD', '--', '.'], {
           cwd: pnpm8FixtureDir,
           stdio: 'ignore',
         })
       } catch {}
+      const staleDirs = [
+        path.join(pnpm8FixtureDir, 'node_modules'),
+        path.join(pnpm8FixtureDir, '.cache'),
+      ]
+      await Promise.all(
+        staleDirs.filter(dir => existsSync(dir)).map(dir => trash(dir)),
+      )
     })
 
     it(
@@ -161,13 +177,21 @@ describe('socket optimize - pnpm versions', { timeout: 60_000 }, async () => {
     const pnpm9BinPath = path.join(pnpm9FixtureDir, 'node_modules', '.bin')
 
     beforeEach(async () => {
-      // Reset fixtures to their committed state (package.json and pnpm-lock.yaml).
+      // Reset fixtures to their committed state (package.json and pnpm-lock.yaml)
+      // and remove untracked install artifacts left by prior runs.
       try {
         await spawn('git', ['checkout', 'HEAD', '--', '.'], {
           cwd: pnpm9FixtureDir,
           stdio: 'ignore',
         })
       } catch {}
+      const staleDirs = [
+        path.join(pnpm9FixtureDir, 'node_modules'),
+        path.join(pnpm9FixtureDir, '.cache'),
+      ]
+      await Promise.all(
+        staleDirs.filter(dir => existsSync(dir)).map(dir => trash(dir)),
+      )
       // Ensure pnpm v9 is installed in the fixture.
       // Skip if pnpm is not available globally (e.g., Windows CI).
       try {
@@ -188,13 +212,20 @@ describe('socket optimize - pnpm versions', { timeout: 60_000 }, async () => {
     })
 
     afterEach(async () => {
-      // Reset fixtures to their committed state after each test.
+      // Reset tracked fixture files and remove install artifacts.
       try {
         await spawn('git', ['checkout', 'HEAD', '--', '.'], {
           cwd: pnpm9FixtureDir,
           stdio: 'ignore',
         })
       } catch {}
+      const staleDirs = [
+        path.join(pnpm9FixtureDir, 'node_modules'),
+        path.join(pnpm9FixtureDir, '.cache'),
+      ]
+      await Promise.all(
+        staleDirs.filter(dir => existsSync(dir)).map(dir => trash(dir)),
+      )
     })
 
     it(


### PR DESCRIPTION
The pnpm v8/v9 optimize fixture tests run `pnpm install` inside the fixture directories during `beforeEach` to provision the specific pnpm binary version. The existing `afterEach` hooks only reset tracked files (`git checkout HEAD -- .`) but left untracked `node_modules/` and `.cache/` directories behind, polluting the working tree for **both pnpm v8 and pnpm v9 fixtures**.

This caused two problems for both fixtures:
1. Running `git add -A` (or relying on pre-commit hooks that do) would accidentally stage thousands of untracked fixture artifacts.
2. The pnpm9 fixture install was silently failing (swallowed by `try/catch` + `stdio: 'ignore'`), so pnpm9 tests fell back to the system pnpm rather than testing against pnpm v9.

## Changes
- Import `trash` and remove `node_modules/` + `.cache/` in both `beforeEach` (to clean up after prior aborted runs) and `afterEach` (to keep the fixture clean going forward) for **both pnpm8 and pnpm9 fixtures**.
- Use `Promise.all` for parallel cleanup to avoid `no-await-in-loop` lint warnings.

## Verification
- All 4 pnpm-version tests continue to pass.
- Fixture directories are now clean after each test run (only `package.json` and `pnpm-lock.yaml` remain).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that add cleanup of `node_modules`/`.cache` in fixtures; main impact is slightly longer test setup and potential environment-specific filesystem deletion behavior.
> 
> **Overview**
> Keeps the `pnpm8`/`pnpm9` optimize fixture tests from leaving behind untracked install artifacts by deleting `node_modules/` and `.cache/` in both `beforeEach` (cleanup from prior runs) and `afterEach` (post-test cleanup).
> 
> The tests now use `trash` and run cleanup in parallel via `Promise.all`, while still resetting tracked files via `git checkout`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f7d89d0a3acf7c99005e0e6f26397660f254ba0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->