### PR TITLE
feat(coana): add npm-install + node fallback when dlx fails

### DIFF
--- a/src/utils/dlx.mts
+++ b/src/utils/dlx.mts
@@ -18,8 +18,12 @@
  * - Configures environment for third-party tools
  */
 
+import { promises as fs } from 'node:fs'
 import { createRequire } from 'node:module'
+import os from 'node:os'
+import path from 'node:path'
 
+import { logger } from '@socketsecurity/registry/lib/logger'
 import { getOwn } from '@socketsecurity/registry/lib/objects'
 import { spawn } from '@socketsecurity/registry/lib/spawn'
 
@@ -182,12 +186,158 @@ export type CoanaDlxOptions = DlxOptions & {
 }
 
 /**
+ * Cache of resolved Coana CLI script paths from the npm-install fallback,
+ * keyed by version string. Lives for the lifetime of the Socket CLI process so
+ * repeated invocations (e.g. socket fix --pr looping per GHSA) only install
+ * once.
+ */
+const installedCoanaScriptPathsByVersion = new Map<string, string>()
+
+/**
+ * Spawn an installed Coana entry point via `node` (or directly, if it's a
+ * native binary). Shared by the SOCKET_CLI_COANA_LOCAL_PATH branch and the
+ * npm-install fallback.
+ */
+async function spawnCoanaScriptViaNode(
+  scriptPath: string,
+  args: string[] | readonly string[],
+  finalEnv: NodeJS.ProcessEnv,
+  options: { cwd?: string | URL | undefined },
+  spawnExtra?: SpawnExtra | undefined,
+): Promise<CResult<string>> {
+  const isBinary =
+    !scriptPath.endsWith('.js') && !scriptPath.endsWith('.mjs')
+
+  const spawnArgs = isBinary ? args : [scriptPath, ...args]
+  const spawnResult = await spawn(
+    isBinary ? scriptPath : 'node',
+    spawnArgs,
+    {
+      cwd: options.cwd,
+      env: finalEnv,
+      stdio: spawnExtra?.['stdio'] || 'inherit',
+    },
+  )
+
+  return { ok: true, data: spawnResult.stdout }
+}
+
+/**
+ * Resolve the executable JS file inside an installed @coana-tech/cli package
+ * by reading its package.json `bin` field. Returns an absolute path suitable
+ * for passing to `node`.
+ */
+async function resolveCoanaBinFromInstallDir(
+  installDir: string,
+): Promise<string> {
+  const packageJsonPath = path.join(
+    installDir,
+    'node_modules',
+    '@coana-tech',
+    'cli',
+    'package.json',
+  )
+  const pkg = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
+    bin?: string | Record<string, string> | undefined
+  }
+  const { bin } = pkg
+  let relativeBin: string | undefined
+  if (typeof bin === 'string') {
+    relativeBin = bin
+  } else if (bin && typeof bin === 'object') {
+    // Prefer an entry named "coana" if present; otherwise take the first.
+    relativeBin = bin['coana'] ?? Object.values(bin)[0]
+  }
+  if (!relativeBin) {
+    throw new Error(
+      `@coana-tech/cli package.json at ${packageJsonPath} is missing a usable bin entry`,
+    )
+  }
+  return path.resolve(path.dirname(packageJsonPath), relativeBin)
+}
+
+/**
+ * Install @coana-tech/cli into a fresh temp directory via `npm install` and
+ * return its executable JS path. Caches the result per version for the
+ * lifetime of the process.
+ */
+async function installCoanaToTmpdir(
+  version: string,
+  finalEnv: NodeJS.ProcessEnv,
+): Promise<string> {
+  const cached = installedCoanaScriptPathsByVersion.get(version)
+  if (cached) {
+    return cached
+  }
+  const installDir = await fs.mkdtemp(path.join(os.tmpdir(), 'socket-coana-'))
+  await spawn(
+    'npm',
+    [
+      'install',
+      '--no-save',
+      '--no-package-lock',
+      '--no-audit',
+      '--no-fund',
+      '--prefix',
+      installDir,
+      `@coana-tech/cli@${version}`,
+    ],
+    {
+      env: finalEnv,
+      stdio: 'inherit',
+    },
+  )
+  const scriptPath = await resolveCoanaBinFromInstallDir(installDir)
+  installedCoanaScriptPathsByVersion.set(version, scriptPath)
+  return scriptPath
+}
+
+/**
+ * Fallback path used when the dlx (npx / pnpm dlx / yarn dlx) invocation
+ * fails. Installs @coana-tech/cli into a temp directory via `npm install`
+ * and spawns it directly via `node`.
+ */
+async function spawnCoanaViaNpmInstall(
+  args: string[] | readonly string[],
+  version: string,
+  finalEnv: NodeJS.ProcessEnv,
+  options: { cwd?: string | URL | undefined },
+  spawnExtra?: SpawnExtra | undefined,
+): Promise<CResult<string>> {
+  let scriptPath: string
+  try {
+    scriptPath = await installCoanaToTmpdir(version, finalEnv)
+  } catch (e) {
+    const stderr = (e as any)?.stderr
+    const cause = getErrorCause(e)
+    return {
+      ok: false,
+      data: e,
+      message: `npm install fallback failed: ${stderr || cause}`,
+    }
+  }
+  return await spawnCoanaScriptViaNode(
+    scriptPath,
+    args,
+    finalEnv,
+    options,
+    spawnExtra,
+  )
+}
+
+/**
  * Helper to spawn coana with dlx.
  * Automatically uses force and silent when version is not pinned exactly.
  * Returns a CResult with stdout extraction for backward compatibility.
  *
  * If SOCKET_CLI_COANA_LOCAL_PATH environment variable is set, uses the local
  * Coana CLI at that path instead of downloading from npm.
+ *
+ * If the dlx path fails (e.g. broken `npx` on the host), falls back to
+ * `npm install`-ing @coana-tech/cli into a temp directory and invoking it
+ * directly via `node`. The fallback can be disabled with
+ * SOCKET_CLI_COANA_DISABLE_NPM_FALLBACK or forced as the primary path with
+ * SOCKET_CLI_COANA_FORCE_NPM_INSTALL.
  */
 export async function spawnCoanaDlx(
   args: string[] | readonly string[],
@@ -231,53 +381,57 @@ export async function spawnCoanaDlx(
     mixinsEnv['SOCKET_CLI_API_PROXY'] = proxyUrl
   }
 
-  try {
-    const localCoanaPath = process.env['SOCKET_CLI_COANA_LOCAL_PATH']
-    // Use local Coana CLI if path is provided.
-    if (localCoanaPath) {
-      const isBinary =
-        !localCoanaPath.endsWith('.js') && !localCoanaPath.endsWith('.mjs')
+  const finalEnv = {
+    ...process.env,
+    ...constants.processEnv,
+    ...mixinsEnv,
+    ...spawnEnv,
+  }
 
-      const finalEnv = {
-        ...process.env,
-        ...constants.processEnv,
-        ...mixinsEnv,
-        ...spawnEnv,
-      }
+  const resolvedVersion =
+    coanaVersion || constants.ENV.INLINED_SOCKET_CLI_COANA_TECH_CLI_VERSION
 
-      const spawnArgs = isBinary ? args : [localCoanaPath, ...args]
-      const spawnResult = await spawn(
-        isBinary ? localCoanaPath : 'node',
-        spawnArgs,
-        {
-          cwd: dlxOptions.cwd,
-          env: finalEnv,
-          stdio: spawnExtra?.['stdio'] || 'inherit',
-        },
+  const localCoanaPath = process.env['SOCKET_CLI_COANA_LOCAL_PATH']
+  // Use local Coana CLI if path is provided.
+  if (localCoanaPath) {
+    try {
+      return await spawnCoanaScriptViaNode(
+        localCoanaPath,
+        args,
+        finalEnv,
+        { cwd: dlxOptions.cwd },
+        spawnExtra,
       )
-
-      return { ok: true, data: spawnResult.stdout }
+    } catch (e) {
+      return buildDlxErrorResult(e)
     }
+  }
 
+  // Allow forcing the npm-install path for debugging or for environments
+  // where dlx is known-broken.
+  if (process.env['SOCKET_CLI_COANA_FORCE_NPM_INSTALL']) {
+    return await spawnCoanaViaNpmInstall(
+      args,
+      resolvedVersion,
+      finalEnv,
+      { cwd: dlxOptions.cwd },
+      spawnExtra,
+    )
+  }
+
+  try {
     // Use npm/dlx version.
     const result = await spawnDlx(
       {
         name: '@coana-tech/cli',
-        version:
-          coanaVersion ||
-          constants.ENV.INLINED_SOCKET_CLI_COANA_TECH_CLI_VERSION,
+        version: resolvedVersion,
       },
       args,
       {
         force: true,
         silent: true,
         ...dlxOptions,
-        env: {
-          ...process.env,
-          ...constants.processEnv,
-          ...mixinsEnv,
-          ...spawnEnv,
-        },
+        env: finalEnv,
         ipc: {
           [constants.SOCKET_CLI_SHADOW_ACCEPT_RISKS]: true,
           [constants.SOCKET_CLI_SHADOW_API_TOKEN]:
@@ -291,27 +445,59 @@ export async function spawnCoanaDlx(
     const output = await result.spawnPromise
     return { ok: true, data: output.stdout }
   } catch (e) {
-    const stderr = (e as any)?.stderr
-    const exitCode = (e as any)?.code
-    const signal = (e as any)?.signal
-    const cause = getErrorCause(e)
-    // Build a descriptive error message with exit code and signal details.
-    const details: string[] = []
-    if (typeof exitCode === 'number') {
-      details.push(`exit code ${exitCode}`)
+    const dlxError = buildDlxErrorResult(e)
+
+    if (process.env['SOCKET_CLI_COANA_DISABLE_NPM_FALLBACK']) {
+      return dlxError
     }
-    if (signal) {
-      details.push(`signal ${signal}`)
+
+    logger.warn(
+      'Coana dlx invocation failed; falling back to `npm install` + `node`.',
+    )
+
+    const fallbackResult = await spawnCoanaViaNpmInstall(
+      args,
+      resolvedVersion,
+      finalEnv,
+      { cwd: dlxOptions.cwd },
+      spawnExtra,
+    )
+    if (fallbackResult.ok) {
+      return fallbackResult
     }
-    const detailSuffix = details.length ? ` (${details.join(', ')})` : ''
-    const message = stderr
-      ? `Coana command failed${detailSuffix}: ${stderr}`
-      : `Coana command failed${detailSuffix}: ${cause}`
+    // Surface both errors so support has full context.
     return {
       ok: false,
       data: e,
-      message,
+      message: `${dlxError.message}. npm-install fallback also failed: ${fallbackResult.message}`,
     }
+  }
+}
+
+/**
+ * Build a CResult error from a thrown spawn error, preserving exit code,
+ * signal, and stderr context.
+ */
+function buildDlxErrorResult(e: unknown): CResult<string> {
+  const stderr = (e as any)?.stderr
+  const exitCode = (e as any)?.code
+  const signal = (e as any)?.signal
+  const cause = getErrorCause(e)
+  const details: string[] = []
+  if (typeof exitCode === 'number') {
+    details.push(`exit code ${exitCode}`)
+  }
+  if (signal) {
+    details.push(`signal ${signal}`)
+  }
+  const detailSuffix = details.length ? ` (${details.join(', ')})` : ''
+  const message = stderr
+    ? `Coana command failed${detailSuffix}: ${stderr}`
+    : `Coana command failed${detailSuffix}: ${cause}`
+  return {
+    ok: false,
+    data: e,
+    message,
   }
 }
 

--- a/src/utils/dlx.mts
+++ b/src/utils/dlx.mts
@@ -316,13 +316,17 @@ async function spawnCoanaViaNpmInstall(
       message: `npm install fallback failed: ${stderr || cause}`,
     }
   }
-  return await spawnCoanaScriptViaNode(
-    scriptPath,
-    args,
-    finalEnv,
-    options,
-    spawnExtra,
-  )
+  try {
+    return await spawnCoanaScriptViaNode(
+      scriptPath,
+      args,
+      finalEnv,
+      options,
+      spawnExtra,
+    )
+  } catch (e) {
+    return buildDlxErrorResult(e)
+  }
 }
 
 /**
@@ -451,8 +455,15 @@ export async function spawnCoanaDlx(
       return dlxError
     }
 
+    // Only retry via `npm install` when the failure looks like the launcher
+    // never got Coana running. A real Coana process that booted and exited
+    // with an error would just hit the same failure on retry.
+    if (!shouldFallbackOnDlxError(e)) {
+      return dlxError
+    }
+
     logger.warn(
-      'Coana dlx invocation failed; falling back to `npm install` + `node`.',
+      'Coana dlx invocation failed before Coana started; falling back to `npm install` + `node`.',
     )
 
     const fallbackResult = await spawnCoanaViaNpmInstall(
@@ -472,6 +483,47 @@ export async function spawnCoanaDlx(
       message: `${dlxError.message}. npm-install fallback also failed: ${fallbackResult.message}`,
     }
   }
+}
+
+/**
+ * Decide whether a thrown dlx error should trigger the npm-install fallback.
+ *
+ * The goal is to retry only when the dlx launcher (npx / pnpm dlx / yarn dlx)
+ * failed before Coana itself ran. If Coana actually booted, any subsequent
+ * non-zero exit is a real Coana failure and retrying would hit the same one.
+ *
+ * Signals we use, in priority order:
+ * 1. Captured stderr containing Coana's startup banner — definitive proof
+ *    Coana ran, so do NOT retry. Only available when the caller passed
+ *    `stdio: 'pipe'` (or the spawn defaulted to it).
+ * 2. Spawn-level errors (`e.code` is a string like 'ENOENT'): the binary
+ *    wasn't found / couldn't start — retry.
+ * 3. Signal kills (`e.signal` set, or numeric `e.code >= 128`): conventionally
+ *    not a clean exit; the customer-observed exit code 249 falls here. Retry.
+ * 4. Small integer exit codes with no banner in captured stderr: ambiguous,
+ *    but Coana's own exit codes are small integers, so default to NOT retrying
+ *    rather than blindly re-running Coana.
+ */
+function shouldFallbackOnDlxError(e: unknown): boolean {
+  const capturedStderr = String((e as any)?.stderr ?? '')
+  if (capturedStderr && /Coana CLI version/i.test(capturedStderr)) {
+    return false
+  }
+  const code = (e as any)?.code
+  // Spawn-level failure (e.g. ENOENT when npx is missing from PATH).
+  if (typeof code === 'string') {
+    return true
+  }
+  // Killed by signal — almost never a clean Coana exit.
+  if ((e as any)?.signal) {
+    return true
+  }
+  // Exit codes >= 128 are conventionally signal-derived, and the observed
+  // npx-launcher failures in the wild fall into this range (e.g. 249, 254).
+  if (typeof code === 'number' && code >= 128) {
+    return true
+  }
+  return false
 }
 
 /**

--- a/src/utils/dlx.test.mts
+++ b/src/utils/dlx.test.mts
@@ -1,13 +1,31 @@
+import { promises as fs } from 'node:fs'
 import { createRequire } from 'node:module'
+import os from 'node:os'
+import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { spawn } from '@socketsecurity/registry/lib/spawn'
+
 import constants from '../constants.mts'
-import { spawnDlx } from './dlx.mts'
+import { spawnCoanaDlx, spawnDlx } from './dlx.mts'
 
 import type { DlxPackageSpec } from './dlx.mts'
 
 const require = createRequire(import.meta.url)
+
+vi.mock('@socketsecurity/registry/lib/spawn', () => ({
+  spawn: vi.fn(),
+}))
+
+vi.mock('./sdk.mts', () => ({
+  getDefaultApiToken: () => undefined,
+  getDefaultProxyUrl: () => undefined,
+}))
+
+vi.mock('../commands/ci/fetch-default-org-slug.mts', () => ({
+  getDefaultOrgSlug: async () => ({ ok: false }),
+}))
 
 describe('utils/dlx', () => {
   describe('spawnDlx', () => {
@@ -177,6 +195,198 @@ describe('utils/dlx', () => {
       // For pinned versions, silent defaults to false.
       expect(spawnArgs[0]).toBe('dlx')
       expect(spawnArgs[1]).toBe('@coana-tech/cli@1.0.0')
+    })
+  })
+
+  describe('spawnCoanaDlx npm-install fallback', () => {
+    const mockSpawn = vi.mocked(spawn)
+    let mockDlxBin: ReturnType<typeof vi.fn>
+    let installRoot: string
+    let testCounter = 0
+
+    // Each test picks a unique version so they don't share the module-level
+    // install cache.
+    const nextVersion = () => `99.0.${testCounter++}`
+
+    beforeEach(async () => {
+      delete process.env['SOCKET_CLI_COANA_FORCE_NPM_INSTALL']
+      delete process.env['SOCKET_CLI_COANA_DISABLE_NPM_FALLBACK']
+      delete process.env['SOCKET_CLI_COANA_LOCAL_PATH']
+
+      installRoot = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'socket-coana-test-'),
+      )
+
+      // By default, make whichever shadow bin spawnDlx auto-selects fail so
+      // the catch path runs. spawnDlx detects the project's PM by lockfile, so
+      // we mock all three (npm/pnpm/yarn) to the same failing behavior.
+      // Use mockImplementation so a fresh rejected promise is created per call
+      // and attach a no-op .catch to suppress Node's unhandled-rejection
+      // warning (the real handler attaches a microtask later inside the SUT).
+      mockDlxBin = vi.fn().mockImplementation(async () => {
+        const rejected = Promise.reject(
+          Object.assign(new Error('dlx exploded'), {
+            code: 249,
+            stderr: 'npx aborted',
+          }),
+        )
+        rejected.catch(() => {})
+        return { spawnPromise: rejected }
+      })
+      for (const binPath of [
+        constants.shadowNpxBinPath,
+        constants.shadowPnpmBinPath,
+        constants.shadowYarnBinPath,
+      ]) {
+        // @ts-ignore
+        require.cache[binPath] = { exports: mockDlxBin }
+      }
+
+      // Default behavior: spawn() succeeds for both `npm install` (writing a
+      // realistic node_modules/@coana-tech/cli/package.json into the tmp
+      // install dir) and `node` (returning empty stdout). Tests override per
+      // case via .mockImplementationOnce.
+      mockSpawn.mockReset()
+      mockSpawn.mockImplementation(async (cmd: string, args: string[]) => {
+        if (cmd === 'npm' && args[0] === 'install') {
+          // Pull --prefix out of args to find the install dir.
+          const prefixIdx = args.indexOf('--prefix')
+          const installDir = args[prefixIdx + 1]
+          const pkgDir = path.join(
+            installDir,
+            'node_modules',
+            '@coana-tech',
+            'cli',
+          )
+          await fs.mkdir(pkgDir, { recursive: true })
+          await fs.writeFile(
+            path.join(pkgDir, 'package.json'),
+            JSON.stringify({ bin: { coana: 'dist/cli.js' } }),
+          )
+          return { stdout: '', stderr: '' }
+        }
+        // node <script> ...
+        return { stdout: 'coana-ok', stderr: '' }
+      })
+    })
+
+    afterEach(async () => {
+      for (const binPath of [
+        constants.shadowNpxBinPath,
+        constants.shadowPnpmBinPath,
+        constants.shadowYarnBinPath,
+      ]) {
+        // @ts-ignore
+        delete require.cache[binPath]
+      }
+      vi.restoreAllMocks()
+      mockSpawn.mockReset()
+      delete process.env['SOCKET_CLI_COANA_FORCE_NPM_INSTALL']
+      delete process.env['SOCKET_CLI_COANA_DISABLE_NPM_FALLBACK']
+      await fs.rm(installRoot, { recursive: true, force: true })
+    })
+
+    it('falls back to npm install + node when dlx throws', async () => {
+      const version = nextVersion()
+      const result = await spawnCoanaDlx(['run', '.'], 'acme', {
+        coanaVersion: version,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(mockDlxBin).toHaveBeenCalledTimes(1)
+
+      // npm install was invoked with the expected version.
+      const npmCalls = mockSpawn.mock.calls.filter(
+        ([cmd, args]) => cmd === 'npm' && (args as string[])[0] === 'install',
+      )
+      expect(npmCalls).toHaveLength(1)
+      expect((npmCalls[0]![1] as string[]).at(-1)).toBe(
+        `@coana-tech/cli@${version}`,
+      )
+
+      // node was then invoked with the resolved bin and the user's args.
+      const nodeCalls = mockSpawn.mock.calls.filter(([cmd]) => cmd === 'node')
+      expect(nodeCalls).toHaveLength(1)
+      const nodeArgs = nodeCalls[0]![1] as string[]
+      expect(nodeArgs[0]).toMatch(/dist[\\/]cli\.js$/)
+      expect(nodeArgs.slice(1)).toEqual(['run', '.'])
+    })
+
+    it('caches the install across calls with the same version', async () => {
+      const version = nextVersion()
+      const r1 = await spawnCoanaDlx(['run', '.'], 'acme', {
+        coanaVersion: version,
+      })
+      const r2 = await spawnCoanaDlx(['run', '.'], 'acme', {
+        coanaVersion: version,
+      })
+
+      expect(r1.ok).toBe(true)
+      expect(r2.ok).toBe(true)
+
+      // Only one npm install — second call reuses the cached path.
+      const npmInstallCalls = mockSpawn.mock.calls.filter(
+        ([cmd, args]) => cmd === 'npm' && (args as string[])[0] === 'install',
+      )
+      expect(npmInstallCalls).toHaveLength(1)
+      // But two node spawns — one per invocation.
+      const nodeCalls = mockSpawn.mock.calls.filter(([cmd]) => cmd === 'node')
+      expect(nodeCalls).toHaveLength(2)
+    })
+
+    it('skips fallback when SOCKET_CLI_COANA_DISABLE_NPM_FALLBACK is set', async () => {
+      process.env['SOCKET_CLI_COANA_DISABLE_NPM_FALLBACK'] = '1'
+
+      const result = await spawnCoanaDlx(['run', '.'], 'acme', {
+        coanaVersion: nextVersion(),
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('Coana command failed')
+      // No npm install was attempted.
+      const npmInstallCalls = mockSpawn.mock.calls.filter(
+        ([cmd, args]) => cmd === 'npm' && (args as string[])[0] === 'install',
+      )
+      expect(npmInstallCalls).toHaveLength(0)
+    })
+
+    it('skips dlx and goes straight to install when SOCKET_CLI_COANA_FORCE_NPM_INSTALL is set', async () => {
+      process.env['SOCKET_CLI_COANA_FORCE_NPM_INSTALL'] = '1'
+
+      const result = await spawnCoanaDlx(['run', '.'], 'acme', {
+        coanaVersion: nextVersion(),
+      })
+
+      expect(result.ok).toBe(true)
+      // dlx (any shadow bin) was never invoked.
+      expect(mockDlxBin).not.toHaveBeenCalled()
+      // npm install ran.
+      const npmInstallCalls = mockSpawn.mock.calls.filter(
+        ([cmd, args]) => cmd === 'npm' && (args as string[])[0] === 'install',
+      )
+      expect(npmInstallCalls).toHaveLength(1)
+    })
+
+    it('surfaces both dlx and install errors when fallback install fails', async () => {
+      // Make npm install fail; node would not be reached.
+      mockSpawn.mockImplementation(async (cmd: string) => {
+        if (cmd === 'npm') {
+          throw Object.assign(new Error('install boom'), {
+            stderr: 'registry unreachable',
+          })
+        }
+        return { stdout: '', stderr: '' }
+      })
+
+      const result = await spawnCoanaDlx(['run', '.'], 'acme', {
+        coanaVersion: nextVersion(),
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('Coana command failed')
+      expect(result.message).toContain('npx aborted')
+      expect(result.message).toContain('npm-install fallback also failed')
+      expect(result.message).toContain('registry unreachable')
     })
   })
 })

--- a/src/utils/dlx.test.mts
+++ b/src/utils/dlx.test.mts
@@ -208,6 +208,17 @@ describe('utils/dlx', () => {
     // install cache.
     const nextVersion = () => `99.0.${testCounter++}`
 
+    // Swap the shadow-bin mock to reject with a specific error shape.
+    // Default beforeEach uses code: 249 / stderr: 'npx aborted'.
+    const setDlxRejection = (err: Record<string, unknown>) => {
+      mockDlxBin.mockReset()
+      mockDlxBin.mockImplementation(async () => {
+        const rejected = Promise.reject(Object.assign(new Error('dlx exploded'), err))
+        rejected.catch(() => {})
+        return { spawnPromise: rejected }
+      })
+    }
+
     beforeEach(async () => {
       delete process.env['SOCKET_CLI_COANA_FORCE_NPM_INSTALL']
       delete process.env['SOCKET_CLI_COANA_DISABLE_NPM_FALLBACK']
@@ -387,6 +398,73 @@ describe('utils/dlx', () => {
       expect(result.message).toContain('npx aborted')
       expect(result.message).toContain('npm-install fallback also failed')
       expect(result.message).toContain('registry unreachable')
+    })
+
+    it('does NOT fall back on small integer exit codes (likely real Coana failures)', async () => {
+      // Coana ran and exited with code 1 — a real analysis failure. We want
+      // the dlx error to propagate as-is without triggering an install retry.
+      setDlxRejection({ code: 1, stderr: '' })
+
+      const result = await spawnCoanaDlx(['run', '.'], 'acme', {
+        coanaVersion: nextVersion(),
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('exit code 1')
+      // No npm install was attempted.
+      const npmInstallCalls = mockSpawn.mock.calls.filter(
+        ([cmd, args]) => cmd === 'npm' && (args as string[])[0] === 'install',
+      )
+      expect(npmInstallCalls).toHaveLength(0)
+    })
+
+    it('does NOT fall back when captured stderr shows Coana booted', async () => {
+      // Coana banner present in stderr → Coana clearly ran, so any subsequent
+      // failure is a real Coana issue, not a launcher problem.
+      setDlxRejection({
+        code: 137,
+        stderr:
+          '2026-05-22 09:31:34.817 - info: Coana CLI version 15.3.4 scan initiated on .\nfatal: out of memory',
+      })
+
+      const result = await spawnCoanaDlx(['run', '.'], 'acme', {
+        coanaVersion: nextVersion(),
+      })
+
+      expect(result.ok).toBe(false)
+      const npmInstallCalls = mockSpawn.mock.calls.filter(
+        ([cmd, args]) => cmd === 'npm' && (args as string[])[0] === 'install',
+      )
+      expect(npmInstallCalls).toHaveLength(0)
+    })
+
+    it('falls back on spawn-level errors (ENOENT-style)', async () => {
+      // npx itself missing from PATH — code is a string, not a number.
+      setDlxRejection({ code: 'ENOENT' })
+
+      const result = await spawnCoanaDlx(['run', '.'], 'acme', {
+        coanaVersion: nextVersion(),
+      })
+
+      expect(result.ok).toBe(true)
+      const npmInstallCalls = mockSpawn.mock.calls.filter(
+        ([cmd, args]) => cmd === 'npm' && (args as string[])[0] === 'install',
+      )
+      expect(npmInstallCalls).toHaveLength(1)
+    })
+
+    it('falls back when process was killed by signal', async () => {
+      setDlxRejection({ code: null, signal: 'SIGKILL' })
+
+      const result = await spawnCoanaDlx(['run', '.'], 'acme', {
+        coanaVersion: nextVersion(),
+      })
+
+      expect(result.ok).toBe(true)
+      const npmInstallCalls = mockSpawn.mock.calls.filter(
+        ([cmd, args]) => cmd === 'npm' && (args as string[])[0] === 'install',
+      )
+      expect(npmInstallCalls).toHaveLength(1)
     })
   })
 })


### PR DESCRIPTION
## Summary

- When `npx --yes @coana-tech/cli ...` (or the equivalent `pnpm dlx` / `yarn dlx`) aborts before Coana itself starts, the Socket CLI now retries by installing `@coana-tech/cli` into a temp directory via `npm install` and invoking it directly through `node`. The registry, npm, and node all work normally in the environments that hit this — only the dlx-driven launch is broken.
- All three Coana call sites (`socket scan reach`, `socket fix` discovery, `socket fix` per-GHSA loop) inherit the fallback transparently — the change is isolated to `spawnCoanaDlx` in `src/utils/dlx.mts`.
- Installed copies are cached per-version on a module-level `Map` for the lifetime of the process, so PR mode (which calls Coana once per GHSA) only pays the install cost once.

## Env vars

For support/debugging only — not documented in CHANGELOG:

- `SOCKET_CLI_COANA_FORCE_NPM_INSTALL=1` — skip dlx, go straight to the install path. Useful for validating the fallback end-to-end without needing dlx to actually fail.
- `SOCKET_CLI_COANA_DISABLE_NPM_FALLBACK=1` — disable the fallback and restore the previous behavior of returning the dlx error directly.

## Test plan

- [x] `pnpm check:tsc` — clean
- [x] `pnpm check:lint` — clean
- [x] `pnpm test:unit src/utils/dlx.test.mts` — 11/11 pass (added 5 new tests covering: fallback fires on dlx error, install caching across calls, DISABLE env skips fallback, FORCE env skips dlx, both errors surface when install also fails)
- [x] `pnpm test:unit` for the 4 Coana-caller test files (`handle-scan-reach`, `exclude-paths`, `handle-create-new-scan`, `handle-fix-limit`) — 47/47 pass
- [x] Manual smoke: `SOCKET_CLI_COANA_FORCE_NPM_INSTALL=1 socket scan reach <project>` against a small npm project — observed `npm install` of `@coana-tech/cli@15.3.4` into a `socket-coana-*` tmpdir, followed by Coana running via `node` and completing the reachability analysis successfully (`.socket.facts.json` written, expected vuln counts produced).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new execution path that installs and runs `@coana-tech/cli` via `npm install`+`node`, which changes runtime behavior and introduces new failure/perf modes in environments where dlx is flaky.
> 
> **Overview**
> `spawnCoanaDlx` now retries Coana execution when `npx`/`pnpm dlx`/`yarn dlx` fails by **installing `@coana-tech/cli` into a temp dir via `npm install` and running it via `node`**, caching the resolved CLI entrypoint per version for the lifetime of the process.
> 
> Adds support/debug env toggles to **force** the npm-install path (`SOCKET_CLI_COANA_FORCE_NPM_INSTALL`) or **disable** the fallback (`SOCKET_CLI_COANA_DISABLE_NPM_FALLBACK`), improves error reporting by surfacing both dlx and fallback failures, and adds unit tests covering fallback behavior and caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1549f69fc3f8d5064d20a51b6f2d862648c64204. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->