### PR TITLE
upgrading coana to version 15.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - **Bazel diagnostics** — `socket manifest bazel --verbose` now emits bounded subprocess traces with argv, cwd, duration, exit status, output sizes, and failure stderr tails to make customer log-only triage safer and faster.
 
+## [1.1.103](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.103) - 2026-05-26
+
+### Changed
+- Updated the Coana CLI to v `15.3.9`.
+
 ## [1.1.98](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.98) - 2026-05-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.102",
+  "version": "1.1.103",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -96,7 +96,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "15.3.6",
+    "@coana-tech/cli": "15.3.9",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 15.3.6
-        version: 15.3.6
+        specifier: 15.3.9
+        version: 15.3.9
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@15.3.6':
-    resolution: {integrity: sha512-C4XtKOM26NNgcwSWakKouGlRLQp9gl1kNG6FygmtBB0ZnFXSSgT32J2VXSV+2oStl70kjBAm4QYae0daa/ZtMQ==}
+  '@coana-tech/cli@15.3.9':
+    resolution: {integrity: sha512-ZhSop12HQLsT01TJaRvlHD/Jc90Wvt01vovhZf/gB9Gn2L0QSrL7II6yY5v0sJDa+r3N0vtQl9N9YO1UbQGu8A==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5385,7 +5385,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@15.3.6': {}
+  '@coana-tech/cli@15.3.9': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 15.3.6 to 15.3.9

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the Coana CLI used for reachability and fix flows; behavior may change per Coana 15.3.9 without any socket-cli code review in this diff.
> 
> **Overview**
> Releases **socket CLI v1.1.103** by bumping the bundled **`@coana-tech/cli`** dev dependency from **15.3.6** to **15.3.9** and refreshing **`pnpm-lock.yaml`**.
> 
> Documents the release under **`[1.1.103]`** in **`CHANGELOG.md`** (2026-05-26). No Socket application source changes—only version, changelog, and lockfile updates typical of a Coana upgrade PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f88e15d28a36264e048dfa924f99014c433de930. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->