### PR TITLE
upgrading coana to version 15.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - **Bazel diagnostics** — `socket manifest bazel --verbose` now emits bounded subprocess traces with argv, cwd, duration, exit status, output sizes, and failure stderr tails to make customer log-only triage safer and faster.
 
+## [1.1.105](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.105) - 2026-05-27
+
+### Changed
+- Updated the Coana CLI to v `15.3.11`.
+
 ## [1.1.104](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.104) - 2026-05-26
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.104",
+  "version": "1.1.105",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -96,7 +96,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "15.3.9",
+    "@coana-tech/cli": "15.3.11",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 15.3.9
-        version: 15.3.9
+        specifier: 15.3.11
+        version: 15.3.11
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@15.3.9':
-    resolution: {integrity: sha512-ZhSop12HQLsT01TJaRvlHD/Jc90Wvt01vovhZf/gB9Gn2L0QSrL7II6yY5v0sJDa+r3N0vtQl9N9YO1UbQGu8A==}
+  '@coana-tech/cli@15.3.11':
+    resolution: {integrity: sha512-c2f6d//BH43GhggP5aJwnmwlhUK1FE7IYkdXs2PLIF864lAnBDEa+WqNvOD1R+AG/uJmnKxe6OiVv1iOvyFD8w==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5385,7 +5385,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@15.3.9': {}
+  '@coana-tech/cli@15.3.11': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 15.3.9 to 15.3.11

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine dependency and version bump with lockfile and changelog only; no application logic changes in the diff.
> 
> **Overview**
> Releases **socket CLI v1.1.105** by bumping the bundled **`@coana-tech/cli`** dev dependency from **15.3.9** to **15.3.11** and refreshing **`pnpm-lock.yaml`**. A **CHANGELOG** section documents the Coana upgrade for the new tag.
> 
> That version is inlined at build time for reachability and fix flows, so this release ships the newer Coana behavior without other source changes in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65e410826c9e463ae09dc2a24d1e7256dc3f6db3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->