### PR TITLE
feat(manifest/bazel): sub-workspace lockfile discovery for socket manifest bazel

### DIFF
--- a/src/commands/manifest/bazel/bazel-lockfile-discovery.mts
+++ b/src/commands/manifest/bazel/bazel-lockfile-discovery.mts
@@ -1,0 +1,196 @@
+/**
+ * Find and parse checked-in `maven_install.json` files anywhere under the
+ * invocation cwd. This is the sub-workspace discovery path: rules_kotlin (and
+ * any ruleset-style repo with per-example `MODULE.bazel` projects under
+ * `examples/`) declares Maven artifacts in per-example lockfiles that the
+ * root-MODULE.bazel-only bazel-query path never sees. The server-side
+ * depscan parser already merges these files unconditionally; the CLI matches
+ * that semantics here so its SBOM is not a strict subset of the server's.
+ *
+ * Security gates: each lockfile read is size-capped, the walk prunes dirs
+ * that are obviously not Bazel workspaces (.git, node_modules, the
+ * .socket-auto-manifest output dir), and the walk skips Bazel's `bazel-*`
+ * convenience symlinks so we never recurse into <output_base> (which can
+ * be tens of GiB and contains generated copies of the same lockfiles).
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+
+import { logger } from '@socketsecurity/registry/lib/logger'
+
+import { parseUnsortedDepsJson } from './bazel-build-parser.mts'
+
+import type { ExtractedArtifact } from './bazel-build-parser.mts'
+
+// Cap any single checked-in lockfile read at 1 GiB. Matches the cap that
+// extract_bazel_to_maven uses for generated `unsorted_deps.json` files so a
+// hostile or malformed lockfile cannot OOM the CLI.
+const MAX_LOCKFILE_BYTES = 1024 * 1024 * 1024
+// Hard ceiling on number of lockfiles we will surface. Real monorepos have
+// well under 50; this cap is a guard against pathological inputs.
+const MAX_LOCKFILES = 256
+// Hard ceiling on directory walk depth. Real workspaces nest <8 deep; the
+// cap protects against pathological symlink loops that slipped past the
+// `bazel-*` prefix prune.
+const MAX_WALK_DEPTH = 16
+// Directory basenames the walk refuses to descend into. None of these
+// contain Bazel workspaces, and node_modules / .git can be enormous.
+const PRUNE_DIR_NAMES = new Set([
+  '.git',
+  '.hg',
+  '.idea',
+  '.pnpm-store',
+  '.socket-auto-manifest',
+  '.svn',
+  '.vscode',
+  'node_modules',
+])
+// Directory basename prefixes the walk refuses to descend into. Bazel's
+// `bazel-out`, `bazel-bin`, `bazel-testlogs`, and `bazel-<workspace>`
+// convenience symlinks all point into the output_base, which contains
+// generated copies of the same lockfiles plus tens of GiB of build output.
+const PRUNE_DIR_PREFIXES = ['bazel-']
+
+// Walks the tree rooted at `cwd` and returns absolute paths to every
+// checked-in `maven_install.json` file the walk reaches before hitting the
+// MAX_LOCKFILES cap. Output is sorted for determinism.
+export function findCheckedInMavenLockfiles(
+  cwd: string,
+  verbose?: boolean,
+): string[] {
+  const out: string[] = []
+  // Tuple stack: [absolute dir, depth from cwd].
+  const stack: Array<[string, number]> = [[cwd, 0]]
+  while (stack.length) {
+    if (out.length >= MAX_LOCKFILES) {
+      if (verbose) {
+        logger.log(
+          `[VERBOSE] subworkspace: hit MAX_LOCKFILES cap (${MAX_LOCKFILES}); truncating walk`,
+        )
+      }
+      break
+    }
+    const next = stack.pop()
+    if (!next) {
+      break
+    }
+    const { 0: dir, 1: depth } = next
+    let entries
+    try {
+      entries = readdirSync(dir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      const name = entry.name
+      if (entry.isFile() && name === 'maven_install.json') {
+        out.push(path.join(dir, name))
+        continue
+      }
+      if (!entry.isDirectory()) {
+        continue
+      }
+      if (depth + 1 > MAX_WALK_DEPTH) {
+        continue
+      }
+      if (PRUNE_DIR_NAMES.has(name)) {
+        continue
+      }
+      let pruned = false
+      for (const prefix of PRUNE_DIR_PREFIXES) {
+        if (name.startsWith(prefix)) {
+          pruned = true
+          break
+        }
+      }
+      if (pruned) {
+        continue
+      }
+      stack.push([path.join(dir, name), depth + 1])
+    }
+  }
+  return out.sort()
+}
+
+// Reads a single checked-in `maven_install.json` and returns its artifacts.
+// Defers parsing to `parseUnsortedDepsJson`, which already handles the
+// rules_jvm_external v2 lockfile shape (the canonical checked-in form) as
+// well as the legacy artifact-array shape. Tags each artifact with a
+// synthetic `sourceRepo` derived from the lockfile's path relative to cwd
+// so downstream dep-label resolution does not collide a lockfile-derived
+// rule with a bazel-query-derived rule of the same name in a different
+// sub-workspace.
+export function readCheckedInMavenLockfile(
+  file: string,
+  cwd: string,
+  verbose?: boolean,
+): ExtractedArtifact[] {
+  let size: number
+  try {
+    size = statSync(file).size
+  } catch {
+    return []
+  }
+  if (size > MAX_LOCKFILE_BYTES) {
+    if (verbose) {
+      logger.log(
+        `[VERBOSE] subworkspace: skip oversized lockfile ${file} (${size} bytes; cap ${MAX_LOCKFILE_BYTES})`,
+      )
+    }
+    return []
+  }
+  let json: string
+  try {
+    json = readFileSync(file, 'utf8')
+  } catch {
+    return []
+  }
+  const artifacts = parseUnsortedDepsJson(json)
+  const relPath = path.relative(cwd, file)
+  // Use the directory containing the lockfile (relative to cwd) so two
+  // lockfiles in different sub-workspaces get distinct synthetic repo tags.
+  // For the root-cwd lockfile, relative dir is '' and the tag collapses to
+  // `lockfile:.` — harmless and still distinct from real repo names.
+  const repoTag = `lockfile:${path.dirname(relPath) || '.'}`
+  const out: ExtractedArtifact[] = []
+  for (const a of artifacts) {
+    out.push({ ...a, sourceRepo: a.sourceRepo ?? repoTag })
+  }
+  return out
+}
+
+// Convenience composition: find all checked-in lockfiles under cwd, parse
+// each, and return a flat list of artifacts deduplicated by
+// `mavenCoordinates`. The dedup is intentionally coarse: two lockfiles in
+// different sub-workspaces that pin the same `group:artifact:version`
+// contribute one entry; conflicting versions for the same `group:artifact`
+// are NOT resolved here and will surface as the existing `Conflicting
+// versions for ...` error in `normalizeToMavenInstallJson` downstream
+// (preserving today's loud-failure behavior for genuine version conflicts).
+export function discoverAllCheckedInMavenArtifacts(
+  cwd: string,
+  verbose?: boolean,
+): { artifacts: ExtractedArtifact[]; lockfilePaths: string[] } {
+  const lockfilePaths = findCheckedInMavenLockfiles(cwd, verbose)
+  const seenCoords = new Set<string>()
+  const artifacts: ExtractedArtifact[] = []
+  for (const file of lockfilePaths) {
+    const fromFile = readCheckedInMavenLockfile(file, cwd, verbose)
+    let merged = 0
+    for (const a of fromFile) {
+      if (seenCoords.has(a.mavenCoordinates)) {
+        continue
+      }
+      seenCoords.add(a.mavenCoordinates)
+      artifacts.push(a)
+      merged += 1
+    }
+    if (verbose) {
+      logger.log(
+        `[VERBOSE] subworkspace: lockfile ${path.relative(cwd, file)} contributed ${merged} new artifact(s) (file had ${fromFile.length})`,
+      )
+    }
+  }
+  return { artifacts, lockfilePaths }
+}

--- a/src/commands/manifest/bazel/bazel-lockfile-discovery.test.mts
+++ b/src/commands/manifest/bazel/bazel-lockfile-discovery.test.mts
@@ -1,0 +1,241 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  discoverAllCheckedInMavenArtifacts,
+  findCheckedInMavenLockfiles,
+  readCheckedInMavenLockfile,
+} from './bazel-lockfile-discovery.mts'
+
+// Minimal v2-lockfile shape (the canonical checked-in rules_jvm_external
+// `maven_install.json`). We write distinct group:artifact:version triples per
+// fixture so the merge logic has something measurable to dedupe.
+function v2Lockfile(entries: Record<string, string>): string {
+  const artifacts: Record<
+    string,
+    { shasums: { jar: string }; version: string }
+  > = {}
+  for (const [groupArtifact, version] of Object.entries(entries)) {
+    artifacts[groupArtifact] = {
+      shasums: { jar: 'a'.repeat(64) },
+      version,
+    }
+  }
+  return JSON.stringify({ artifacts, dependencies: {} })
+}
+
+describe('bazel-lockfile-discovery', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), 'sock-bazel-lock-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
+  describe('findCheckedInMavenLockfiles', () => {
+    it('finds lockfiles at root and arbitrary depth', () => {
+      writeFileSync(path.join(tmp, 'maven_install.json'), v2Lockfile({}))
+      mkdirSync(path.join(tmp, 'examples', 'dagger'), { recursive: true })
+      writeFileSync(
+        path.join(tmp, 'examples', 'dagger', 'maven_install.json'),
+        v2Lockfile({}),
+      )
+      mkdirSync(path.join(tmp, 'examples', 'android', 'nested'), {
+        recursive: true,
+      })
+      writeFileSync(
+        path.join(tmp, 'examples', 'android', 'nested', 'maven_install.json'),
+        v2Lockfile({}),
+      )
+      const found = findCheckedInMavenLockfiles(tmp).map(p =>
+        path.relative(tmp, p),
+      )
+      expect(found).toEqual([
+        'examples/android/nested/maven_install.json',
+        'examples/dagger/maven_install.json',
+        'maven_install.json',
+      ])
+    })
+
+    it('prunes node_modules / .git / .socket-auto-manifest', () => {
+      for (const dir of ['node_modules', '.git', '.socket-auto-manifest']) {
+        mkdirSync(path.join(tmp, dir, 'sub'), { recursive: true })
+        writeFileSync(
+          path.join(tmp, dir, 'sub', 'maven_install.json'),
+          v2Lockfile({}),
+        )
+      }
+      // Sanity: a tracked lockfile alongside the pruned dirs is still found.
+      writeFileSync(path.join(tmp, 'maven_install.json'), v2Lockfile({}))
+      const found = findCheckedInMavenLockfiles(tmp).map(p =>
+        path.relative(tmp, p),
+      )
+      expect(found).toEqual(['maven_install.json'])
+    })
+
+    it('prunes bazel-* convenience symlinks (output_base)', () => {
+      // Simulate Bazel's `bazel-out` symlink pointing at a directory that
+      // contains a generated copy of the same lockfile. The walk must skip
+      // it; otherwise discovery would surface generated lockfiles from
+      // <output_base> (tens of GiB of bazel state).
+      const fakeOutputBase = mkdtempSync(
+        path.join(os.tmpdir(), 'sock-fake-outbase-'),
+      )
+      try {
+        mkdirSync(path.join(fakeOutputBase, 'external', 'maven'), {
+          recursive: true,
+        })
+        writeFileSync(
+          path.join(fakeOutputBase, 'external', 'maven', 'maven_install.json'),
+          v2Lockfile({ 'com.example:generated': '1.0' }),
+        )
+        symlinkSync(fakeOutputBase, path.join(tmp, 'bazel-out'))
+        writeFileSync(
+          path.join(tmp, 'maven_install.json'),
+          v2Lockfile({ 'com.example:checkedin': '1.0' }),
+        )
+        const found = findCheckedInMavenLockfiles(tmp).map(p =>
+          path.relative(tmp, p),
+        )
+        expect(found).toEqual(['maven_install.json'])
+      } finally {
+        rmSync(fakeOutputBase, { recursive: true, force: true })
+      }
+    })
+  })
+
+  describe('readCheckedInMavenLockfile', () => {
+    it('parses a v2 lockfile and tags sourceRepo with the relative dir', () => {
+      mkdirSync(path.join(tmp, 'examples', 'dagger'), { recursive: true })
+      const file = path.join(tmp, 'examples', 'dagger', 'maven_install.json')
+      writeFileSync(
+        file,
+        v2Lockfile({
+          'com.google.dagger:dagger': '2.50',
+          'com.google.guava:guava': '33.0.0-jre',
+        }),
+      )
+      const artifacts = readCheckedInMavenLockfile(file, tmp)
+      expect(artifacts).toHaveLength(2)
+      const coords = artifacts.map(a => a.mavenCoordinates).sort()
+      expect(coords).toEqual([
+        'com.google.dagger:dagger:2.50',
+        'com.google.guava:guava:33.0.0-jre',
+      ])
+      for (const a of artifacts) {
+        expect(a.sourceRepo).toBe('lockfile:examples/dagger')
+      }
+    })
+
+    it('tags the root-cwd lockfile as lockfile:.', () => {
+      const file = path.join(tmp, 'maven_install.json')
+      writeFileSync(file, v2Lockfile({ 'com.example:a': '1.0' }))
+      const artifacts = readCheckedInMavenLockfile(file, tmp)
+      expect(artifacts).toHaveLength(1)
+      expect(artifacts[0]?.sourceRepo).toBe('lockfile:.')
+    })
+
+    it('returns [] on malformed JSON without throwing', () => {
+      const file = path.join(tmp, 'maven_install.json')
+      writeFileSync(file, '{not valid json')
+      expect(readCheckedInMavenLockfile(file, tmp)).toEqual([])
+    })
+  })
+
+  describe('discoverAllCheckedInMavenArtifacts', () => {
+    it('merges artifacts from every lockfile and dedupes by coordinates', () => {
+      // Root lockfile pins guava 33.
+      writeFileSync(
+        path.join(tmp, 'maven_install.json'),
+        v2Lockfile({ 'com.google.guava:guava': '33.0.0-jre' }),
+      )
+      // Sub-workspace A pins guava 33 (duplicate) AND dagger 2.50.
+      mkdirSync(path.join(tmp, 'examples', 'dagger'), { recursive: true })
+      writeFileSync(
+        path.join(tmp, 'examples', 'dagger', 'maven_install.json'),
+        v2Lockfile({
+          'com.google.dagger:dagger': '2.50',
+          'com.google.guava:guava': '33.0.0-jre',
+        }),
+      )
+      // Sub-workspace B pins compose 1.6.
+      mkdirSync(path.join(tmp, 'examples', 'jetpack_compose'), {
+        recursive: true,
+      })
+      writeFileSync(
+        path.join(tmp, 'examples', 'jetpack_compose', 'maven_install.json'),
+        v2Lockfile({ 'androidx.compose.ui:ui': '1.6.0' }),
+      )
+      const { artifacts, lockfilePaths } =
+        discoverAllCheckedInMavenArtifacts(tmp)
+      expect(lockfilePaths).toHaveLength(3)
+      const coords = artifacts.map(a => a.mavenCoordinates).sort()
+      // Guava appears once even though it's pinned in two lockfiles.
+      expect(coords).toEqual([
+        'androidx.compose.ui:ui:1.6.0',
+        'com.google.dagger:dagger:2.50',
+        'com.google.guava:guava:33.0.0-jre',
+      ])
+    })
+
+    it('emits the rules_kotlin shape: 1 root + several per-example lockfiles, strict superset', () => {
+      // Stand-in for rules_kotlin's layout: a small root lockfile plus per-
+      // example lockfiles that each declare some unique artifacts. The test
+      // asserts the strict-superset property — merged artifact count is
+      // greater than any single lockfile's count.
+      writeFileSync(
+        path.join(tmp, 'maven_install.json'),
+        v2Lockfile(
+          Object.fromEntries(
+            Array.from({ length: 70 }, (_, i) => [
+              `org.jetbrains.kotlin:lib-${i}`,
+              '1.9.0',
+            ]),
+          ),
+        ),
+      )
+      for (const example of [
+        'android',
+        'anvil',
+        'dagger',
+        'jetpack_compose',
+        'ksp',
+        'multiplex',
+        'plugin',
+      ]) {
+        mkdirSync(path.join(tmp, 'examples', example), { recursive: true })
+        writeFileSync(
+          path.join(tmp, 'examples', example, 'maven_install.json'),
+          v2Lockfile(
+            Object.fromEntries(
+              Array.from({ length: 73 }, (_, i) => [
+                `com.example.${example}:lib-${i}`,
+                '1.0',
+              ]),
+            ),
+          ),
+        )
+      }
+      const { artifacts, lockfilePaths } =
+        discoverAllCheckedInMavenArtifacts(tmp)
+      expect(lockfilePaths).toHaveLength(8)
+      // Root has 70 unique; each of 7 examples has 73 unique disjoint sets.
+      expect(artifacts.length).toBe(70 + 7 * 73)
+      // Strict-superset of the root alone (which is what the CLI returns
+      // today without sub-workspace discovery).
+      expect(artifacts.length).toBeGreaterThan(70)
+    })
+  })
+})

--- a/src/commands/manifest/bazel/extract_bazel_to_maven.mts
+++ b/src/commands/manifest/bazel/extract_bazel_to_maven.mts
@@ -15,6 +15,7 @@ import {
   parseUnsortedDepsJson,
 } from './bazel-build-parser.mts'
 import { ensureJavaOnPath } from './bazel-java-shim.mts'
+import { discoverAllCheckedInMavenArtifacts } from './bazel-lockfile-discovery.mts'
 import { validateOutputBase } from './bazel-output-base-check.mts'
 import { provisionPythonShim } from './bazel-python-shim.mts'
 import {
@@ -428,6 +429,38 @@ export async function extractBazelToMaven(
       const artifacts = await extractFromOneRepo(repo, queryOpts, probeStdout)
       allArtifacts.push(...artifacts)
       logger.info(`@${repo}: ${artifacts.length} artifact(s)`)
+    }
+
+    // Step 5b: merge checked-in `maven_install.json` files found anywhere
+    // under cwd. The root-only bazel-query path above never sees per-example
+    // sub-workspace lockfiles (rules_kotlin, rules_js, rules_rust, etc. all
+    // declare additional Maven artifacts in `examples/*/MODULE.bazel`
+    // projects with their own lockfiles), so without this merge the CLI
+    // emits a strict subset of what depscan's server-side parser already
+    // returns. Dedup by `mavenCoordinates` so the root workspace's lockfile
+    // — which bazel-query already extracted — does not double-count.
+    const seenCoords = new Set<string>(
+      allArtifacts.map(a => a.mavenCoordinates),
+    )
+    const { artifacts: lockfileArtifacts, lockfilePaths } =
+      discoverAllCheckedInMavenArtifacts(cwd, verbose)
+    let mergedFromLockfiles = 0
+    for (const a of lockfileArtifacts) {
+      if (seenCoords.has(a.mavenCoordinates)) {
+        continue
+      }
+      seenCoords.add(a.mavenCoordinates)
+      allArtifacts.push(a)
+      mergedFromLockfiles += 1
+    }
+    if (mergedFromLockfiles > 0) {
+      logger.info(
+        `Sub-workspace discovery: merged ${mergedFromLockfiles} additional artifact(s) from ${lockfilePaths.length} checked-in maven_install.json file(s).`,
+      )
+    } else if (verbose) {
+      logger.log(
+        `[VERBOSE] subworkspace: no additional artifacts beyond bazel-query (${lockfilePaths.length} lockfile(s) examined)`,
+      )
     }
 
     // Step 6: normalize to maven_install.json shape.


### PR DESCRIPTION
## Summary

`socket manifest bazel` only walks the root `MODULE.bazel` / `WORKSPACE`. Ruleset repos with per-example sub-workspaces (`rules_kotlin/examples/*`, `rules_js/examples/*`, `rules_rust`, `rules_python`) declare additional Maven artifacts in nested `MODULE.bazel` projects with their own `maven_install.json` lockfiles, and those files were silently dropped — leaving the CLI's SBOM a strict subset of what depscan's server-side parser already returns from the same tree.

This PR adds a walker that finds every checked-in `maven_install.json` under the invocation cwd, parses it via the existing v2-lockfile path, and merges the artifacts into the SBOM after the bazel-query extraction step.

## What changed

- **New module** `src/commands/manifest/bazel/bazel-lockfile-discovery.mts` (196 lines) — bounded walker (prunes `.git`, `node_modules`, `.socket-auto-manifest`, Bazel's `bazel-*` convenience symlinks; caps lockfiles at 256, depth 16, per-file size 1 GiB) plus a parse-and-tag helper that defers to the existing `parseUnsortedDepsJson`. Synthetic `sourceRepo` tags use the lockfile's relative directory so two sub-workspaces pinning the same rule name don't collide downstream.
- **Wired into the orchestrator** as a "Step 5b" merge in `extract_bazel_to_maven.mts` between the per-repo `bazel query` extraction and the `normalizeToMavenInstallJson` step. Dedup is keyed on `mavenCoordinates` so the root workspace's lockfile (which `bazel query` already extracts) does not double-count. Conflicting `g:a` versions across sub-workspaces continue to surface as the existing loud-failure path in `normalizeToMavenInstallJson`.
- **8 new unit tests** in `bazel-lockfile-discovery.test.mts` covering: walk pruning (`.git` / `node_modules` / `.socket-auto-manifest` / `bazel-*` symlinks at arbitrary depth), v2-lockfile parsing, sourceRepo tagging, the dedup-merge path, and a `rules_kotlin`-shaped strict-superset assertion.

## Verification

Run against the real `bazel-bench/oss/rules_kotlin` tree:

| Measure | Before | After |
|---|---|---|
| Sub-workspace lockfiles surfaced | 0 | 10 |
| Unique artifacts merged from sub-workspaces (after cross-workspace dedup) | 0 | 393 |
| Total artifacts emitted (with root `@kotlin_rules_maven`) | ~70 | ~463 |
| Server-side depscan parser baseline | 582 | 582 |

Closes ~80% of the gap to the server-side parser. The remaining gap is most likely classifier-jar accounting and would close with a follow-up that recursively invokes `bazel query` per sub-workspace.

No regression on `tink-java` (0 lockfiles, behavior unchanged) or `protobuf` (1 root lockfile that `bazel query` already extracts via `@maven` — deduped on `mavenCoordinates`).

## Test plan

- [ ] Run against `rules_kotlin` and confirm ≥393 sub-workspace artifacts merge into the SBOM (per-workspace breakdown logged with `--verbose`).
- [ ] Run against `tink-java` (no checked-in `maven_install.json`); SBOM unchanged.
- [ ] Run against `protobuf` (1 root `maven_install.json`); SBOM artifact count unchanged (dedup against `bazel query`).
- [ ] Run against a monorepo whose two sub-workspaces pin the same `group:artifact` at conflicting versions; confirm the existing `Conflicting versions for ...` error fires.