### PR TITLE
fix(scan): suppress auto-manifest hint when .socket.facts.json exists

### DIFF
--- a/src/commands/scan/cmd-scan-create.mts
+++ b/src/commands/scan/cmd-scan-create.mts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import path from 'node:path'
 
 import { joinAnd } from '@socketsecurity/registry/lib/arrays'
@@ -443,7 +444,15 @@ async function run(
   }
 
   const detected = await detectManifestActions(sockJson, cwd)
-  if (detected.count > 0 && !autoManifest) {
+  // Suppress the --auto-manifest suggestion when a `.socket.facts.json` is
+  // already present at cwd. That file is the output of `socket manifest auto`
+  // (and `--facts` mode of the per-ecosystem manifest commands), so suggesting
+  // to regenerate it would be misleading — the manifest data is already there
+  // and will be picked up by the scan.
+  const hasFactsFile = existsSync(
+    path.join(cwd, constants.DOT_SOCKET_DOT_FACTS_JSON),
+  )
+  if (detected.count > 0 && !autoManifest && !hasFactsFile) {
     logger.info(
       `Detected ${detected.count} manifest targets we could try to generate. Please set the --auto-manifest flag if you want to include languages covered by \`socket manifest auto\` in the Scan.`,
     )

--- a/src/commands/scan/cmd-scan-create.mts
+++ b/src/commands/scan/cmd-scan-create.mts
@@ -447,7 +447,7 @@ async function run(
   // Suppress the --auto-manifest suggestion when a `.socket.facts.json` is
   // already present at cwd. That file is the output of `socket manifest auto`
   // (and `--facts` mode of the per-ecosystem manifest commands), so suggesting
-  // to regenerate it would be misleading — the manifest data is already there
+  // to regenerate it would be misleading; the manifest data is already there
   // and will be picked up by the scan.
   const hasFactsFile = existsSync(
     path.join(cwd, constants.DOT_SOCKET_DOT_FACTS_JSON),


### PR DESCRIPTION
## Summary
- `socket scan create` prints "Detected N manifest targets we could try to generate. Please set the --auto-manifest flag..." whenever `detectManifestActions` finds a `build.sbt`, `gradlew`, `MODULE.bazel`, or `environment.yml` in the cwd.
- That hint is misleading when a `.socket.facts.json` is already present — it's the output of `socket manifest auto` (or the `--facts` mode of the per-ecosystem manifest commands), and `handle-create-new-scan.mts` already includes it in `scanPaths`. So the manifest data is in the scan; the suggestion to regenerate it isn't useful.
- Gate the hint on `existsSync(cwd/.socket.facts.json)`; everything else (the auto-manifest pathway itself, the detector, other callers) is untouched.

## Notes / open questions
- Did not also gate on `pom.xml` presence (the non-`--facts` output for sbt/gradle), since `pom.xml` is commonly author-written for Maven projects and isn't a reliable "already generated" marker.

## Test plan
- [ ] `pnpm build:dist:src && pnpm test:unit src/commands/scan/`
- [ ] Manual: in a Gradle-ish repo, run `socket manifest gradle --facts`, then `socket scan create --dry-run` — confirm the "Detected N manifest targets..." line is gone.
- [ ] Manual: same repo without the facts file — confirm the hint still prints.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only change to a single log message in `cmd-scan-create.mts`; no scan upload or manifest generation behavior is modified.
> 
> **Overview**
> **`socket scan create`** no longer logs the “Detected N manifest targets… use `--auto-manifest`” hint when **`.socket.facts.json`** already exists in the scan working directory.
> 
> That file is produced by **`socket manifest auto`** (or ecosystem **`--facts`** flows) and is already included in scan paths, so the nudge to regenerate manifests was redundant. **`--auto-manifest`**, **`detectManifestActions`**, and other callers are unchanged—only the informational log is gated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a80415608b72bf8f0faec864426d138675a3a37. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->