### PR TITLE
fix(manifest): gradle --facts works with configuration cache + adds --configs/--ignore-unresolved (REA-484)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - **Bazel diagnostics** — `socket manifest bazel --verbose` now emits bounded subprocess traces with argv, cwd, duration, exit status, output sizes, and failure stderr tails to make customer log-only triage safer and faster.
 
+## [1.1.107](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.107) - 2026-05-28
+
+### Changed
+- **`socket manifest gradle --facts [beta]`** (and its `kotlin` alias) gained `--configs` and `--ignore-unresolved`, matching `socket manifest scala --facts`. `--configs=compileClasspath,runtimeClasspath` restricts resolution to matching Gradle configurations; unresolved dependencies are now a fatal error by default — pass `--ignore-unresolved` for the previous lenient behavior.
+
+### Fixed
+- **`socket manifest gradle --facts`** now works on Gradle builds with the configuration cache enabled (default on Gradle 9), which previously failed with `Task.project at execution time` errors.
+
 ## [1.1.106](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.106) - 2026-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - **`socket manifest gradle --facts [beta]`** (and its `kotlin` alias) gained `--configs` and `--ignore-unresolved`, matching `socket manifest scala --facts`. `--configs` takes comma-separated glob patterns (e.g. `*CompileClasspath,*RuntimeClasspath`) to restrict resolution to matching Gradle configurations; unresolved dependencies are now a fatal error by default — pass `--ignore-unresolved` for the previous lenient behavior.
+- **`socket manifest scala --facts --configs`** now accepts glob patterns too (e.g. `*Test*`) for consistency with the gradle command. Bare names (no `*`/`?`) keep working as exact-name filters, so existing usages are unchanged.
 
 ### Fixed
 - **`socket manifest gradle --facts`** now works on Gradle builds with the configuration cache enabled (default on Gradle 9), which previously failed with `Task.project at execution time` errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [1.1.107](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.107) - 2026-05-28
 
 ### Changed
-- **`socket manifest gradle --facts [beta]`** (and its `kotlin` alias) gained `--configs` and `--ignore-unresolved`, matching `socket manifest scala --facts`. `--configs=compileClasspath,runtimeClasspath` restricts resolution to matching Gradle configurations; unresolved dependencies are now a fatal error by default — pass `--ignore-unresolved` for the previous lenient behavior.
+- **`socket manifest gradle --facts [beta]`** (and its `kotlin` alias) gained `--configs` and `--ignore-unresolved`, matching `socket manifest scala --facts`. `--configs` takes comma-separated glob patterns (e.g. `*CompileClasspath,*RuntimeClasspath`) to restrict resolution to matching Gradle configurations; unresolved dependencies are now a fatal error by default — pass `--ignore-unresolved` for the previous lenient behavior.
 
 ### Fixed
 - **`socket manifest gradle --facts`** now works on Gradle builds with the configuration cache enabled (default on Gradle 9), which previously failed with `Task.project at execution time` errors.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.106",
+  "version": "1.1.107",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",

--- a/src/commands/manifest/cmd-manifest-gradle.mts
+++ b/src/commands/manifest/cmd-manifest-gradle.mts
@@ -37,7 +37,7 @@ const config: CliCommandConfig = {
     configs: {
       type: 'string',
       description:
-        'With --facts: comma-separated glob patterns matched against Gradle configuration names (case-insensitive, `*` and `?` wildcards). e.g. `*CompileClasspath,*RuntimeClasspath` to skip tooling configs. Default: every resolvable configuration except AGP instrumented-test classpaths',
+        'With --facts: comma-separated glob patterns matched against Gradle configuration names (case-sensitive, `*` and `?` wildcards). e.g. `*CompileClasspath,*RuntimeClasspath` to skip tooling configs. Default: every resolvable configuration except AGP instrumented-test classpaths',
     },
     ignoreUnresolved: {
       type: 'boolean',

--- a/src/commands/manifest/cmd-manifest-gradle.mts
+++ b/src/commands/manifest/cmd-manifest-gradle.mts
@@ -34,6 +34,16 @@ const config: CliCommandConfig = {
       description:
         'Emit a Socket facts JSON file (`.socket.facts.json`) describing the resolved dependency graph instead of generating `pom.xml` files',
     },
+    configs: {
+      type: 'string',
+      description:
+        'With --facts: comma-separated Gradle configuration name suffixes to resolve (case-insensitive, e.g. `compileClasspath,runtimeClasspath`). Default: every resolvable configuration except AGP instrumented-test classpaths',
+    },
+    ignoreUnresolved: {
+      type: 'boolean',
+      description:
+        'With --facts: skip dependencies that fail to resolve instead of failing the run',
+    },
     gradleOpts: {
       type: 'string',
       description:
@@ -69,11 +79,19 @@ const config: CliCommandConfig = {
 
     - it works with your \`gradlew\` from your repo and local settings and config
 
+    Pass --facts to instead emit a single \`.socket.facts.json\` describing the
+    resolved dependency graph of the whole build (no \`pom.xml\` files). An
+    unresolved dependency is a fatal error. With --facts you can pass
+    --configs=compileClasspath,runtimeClasspath to restrict resolution to
+    matching configurations (case-insensitive suffix match), and
+    --ignore-unresolved to skip dependencies that fail to resolve.
+
     Support is beta. Please report issues or give us feedback on what's missing.
 
     Examples
 
       $ ${command} .
+      $ ${command} --facts .
       $ ${command} --bin=../gradlew .
   `,
 }
@@ -116,7 +134,7 @@ async function run(
     sockJson?.defaults?.manifest?.gradle,
   )
 
-  let { bin, facts, gradleOpts, verbose } = cli.flags
+  let { bin, configs, facts, gradleOpts, ignoreUnresolved, verbose } = cli.flags
 
   // Set defaults for any flag/arg that is not given. Check socket.json first.
   if (!bin) {
@@ -153,6 +171,40 @@ async function run(
     } else {
       facts = false
     }
+  }
+  if (configs === undefined) {
+    if (sockJson.defaults?.manifest?.gradle?.configs !== undefined) {
+      configs = sockJson.defaults?.manifest?.gradle?.configs
+      logger.info(`Using default --configs from ${SOCKET_JSON}:`, configs)
+    } else {
+      configs = ''
+    }
+  }
+  if (ignoreUnresolved === undefined) {
+    if (sockJson.defaults?.manifest?.gradle?.ignoreUnresolved !== undefined) {
+      ignoreUnresolved = sockJson.defaults?.manifest?.gradle?.ignoreUnresolved
+      logger.info(
+        `Using default --ignore-unresolved from ${SOCKET_JSON}:`,
+        ignoreUnresolved,
+      )
+    } else {
+      ignoreUnresolved = false
+    }
+  }
+
+  // `--configs` and `--ignore-unresolved` only affect --facts; the pom path
+  // (the legacy `socketGenerateMaven` task) has no equivalent knobs. Warn
+  // rather than silently ignore an explicitly-passed flag. (socket.json
+  // defaults don't trip this — only a flag actually present on the command
+  // line does.)
+  if (
+    !facts &&
+    (cli.flags['configs'] !== undefined ||
+      cli.flags['ignoreUnresolved'] !== undefined)
+  ) {
+    logger.warn(
+      'The `--configs` and `--ignore-unresolved` options only apply with `--facts`; ignoring them.',
+    )
   }
 
   if (verbose) {
@@ -197,8 +249,10 @@ async function run(
   if (facts) {
     await convertGradleToFacts({
       bin: String(bin),
+      configs: String(configs || ''),
       cwd,
       gradleOpts: parsedGradleOpts,
+      ignoreUnresolved: Boolean(ignoreUnresolved),
       verbose: Boolean(verbose),
     })
     return

--- a/src/commands/manifest/cmd-manifest-gradle.mts
+++ b/src/commands/manifest/cmd-manifest-gradle.mts
@@ -42,7 +42,7 @@ const config: CliCommandConfig = {
     ignoreUnresolved: {
       type: 'boolean',
       description:
-        "With --facts: warn on unresolved dependencies instead of failing the run (they're still emitted as direct entries with their declared coordinates)",
+        'With --facts: warn on unresolved dependencies instead of failing the run (unresolved deps are not emitted to the facts file)',
     },
     gradleOpts: {
       type: 'string',
@@ -85,8 +85,7 @@ const config: CliCommandConfig = {
     --configs=<comma-separated glob patterns> to restrict resolution to
     matching configurations (e.g. \`*CompileClasspath,*RuntimeClasspath\`),
     and --ignore-unresolved to warn on unresolved dependencies instead of
-    failing the run (they're still emitted as direct entries with their
-    declared coordinates).
+    failing the run.
 
     Support is beta. Please report issues or give us feedback on what's missing.
 

--- a/src/commands/manifest/cmd-manifest-gradle.mts
+++ b/src/commands/manifest/cmd-manifest-gradle.mts
@@ -42,7 +42,7 @@ const config: CliCommandConfig = {
     ignoreUnresolved: {
       type: 'boolean',
       description:
-        'With --facts: skip dependencies that fail to resolve instead of failing the run',
+        "With --facts: warn on unresolved dependencies instead of failing the run (they're still emitted as direct entries with their declared coordinates)",
     },
     gradleOpts: {
       type: 'string',
@@ -84,7 +84,9 @@ const config: CliCommandConfig = {
     unresolved dependency is a fatal error. With --facts you can pass
     --configs=<comma-separated glob patterns> to restrict resolution to
     matching configurations (e.g. \`*CompileClasspath,*RuntimeClasspath\`),
-    and --ignore-unresolved to skip dependencies that fail to resolve.
+    and --ignore-unresolved to warn on unresolved dependencies instead of
+    failing the run (they're still emitted as direct entries with their
+    declared coordinates).
 
     Support is beta. Please report issues or give us feedback on what's missing.
 

--- a/src/commands/manifest/cmd-manifest-gradle.mts
+++ b/src/commands/manifest/cmd-manifest-gradle.mts
@@ -37,7 +37,7 @@ const config: CliCommandConfig = {
     configs: {
       type: 'string',
       description:
-        'With --facts: comma-separated Gradle configuration name suffixes to resolve (case-insensitive, e.g. `compileClasspath,runtimeClasspath`). Default: every resolvable configuration except AGP instrumented-test classpaths',
+        'With --facts: comma-separated glob patterns matched against Gradle configuration names (case-insensitive, `*` and `?` wildcards). e.g. `*CompileClasspath,*RuntimeClasspath` to skip tooling configs. Default: every resolvable configuration except AGP instrumented-test classpaths',
     },
     ignoreUnresolved: {
       type: 'boolean',
@@ -82,9 +82,9 @@ const config: CliCommandConfig = {
     Pass --facts to instead emit a single \`.socket.facts.json\` describing the
     resolved dependency graph of the whole build (no \`pom.xml\` files). An
     unresolved dependency is a fatal error. With --facts you can pass
-    --configs=compileClasspath,runtimeClasspath to restrict resolution to
-    matching configurations (case-insensitive suffix match), and
-    --ignore-unresolved to skip dependencies that fail to resolve.
+    --configs=<comma-separated glob patterns> to restrict resolution to
+    matching configurations (e.g. \`*CompileClasspath,*RuntimeClasspath\`),
+    and --ignore-unresolved to skip dependencies that fail to resolve.
 
     Support is beta. Please report issues or give us feedback on what's missing.
 

--- a/src/commands/manifest/cmd-manifest-gradle.test.mts
+++ b/src/commands/manifest/cmd-manifest-gradle.test.mts
@@ -27,7 +27,7 @@ describe('socket manifest gradle', async () => {
             --configs           With --facts: comma-separated glob patterns matched against Gradle configuration names (case-sensitive, \`*\` and \`?\` wildcards). e.g. \`*CompileClasspath,*RuntimeClasspath\` to skip tooling configs. Default: every resolvable configuration except AGP instrumented-test classpaths
             --facts             Emit a Socket facts JSON file (\`.socket.facts.json\`) describing the resolved dependency graph instead of generating \`pom.xml\` files
             --gradle-opts       Additional options to pass on to ./gradlew, see \`./gradlew --help\`
-            --ignore-unresolved  With --facts: skip dependencies that fail to resolve instead of failing the run
+            --ignore-unresolved  With --facts: warn on unresolved dependencies instead of failing the run (they're still emitted as direct entries with their declared coordinates)
             --verbose           Print debug messages
 
           Uses gradle, preferably through your local project \`gradlew\`, to generate a
@@ -53,7 +53,9 @@ describe('socket manifest gradle', async () => {
           unresolved dependency is a fatal error. With --facts you can pass
           --configs=<comma-separated glob patterns> to restrict resolution to
           matching configurations (e.g. \`*CompileClasspath,*RuntimeClasspath\`),
-          and --ignore-unresolved to skip dependencies that fail to resolve.
+          and --ignore-unresolved to warn on unresolved dependencies instead of
+          failing the run (they're still emitted as direct entries with their
+          declared coordinates).
 
           Support is beta. Please report issues or give us feedback on what's missing.
 

--- a/src/commands/manifest/cmd-manifest-gradle.test.mts
+++ b/src/commands/manifest/cmd-manifest-gradle.test.mts
@@ -27,7 +27,7 @@ describe('socket manifest gradle', async () => {
             --configs           With --facts: comma-separated glob patterns matched against Gradle configuration names (case-sensitive, \`*\` and \`?\` wildcards). e.g. \`*CompileClasspath,*RuntimeClasspath\` to skip tooling configs. Default: every resolvable configuration except AGP instrumented-test classpaths
             --facts             Emit a Socket facts JSON file (\`.socket.facts.json\`) describing the resolved dependency graph instead of generating \`pom.xml\` files
             --gradle-opts       Additional options to pass on to ./gradlew, see \`./gradlew --help\`
-            --ignore-unresolved  With --facts: warn on unresolved dependencies instead of failing the run (they're still emitted as direct entries with their declared coordinates)
+            --ignore-unresolved  With --facts: warn on unresolved dependencies instead of failing the run (unresolved deps are not emitted to the facts file)
             --verbose           Print debug messages
 
           Uses gradle, preferably through your local project \`gradlew\`, to generate a
@@ -54,8 +54,7 @@ describe('socket manifest gradle', async () => {
           --configs=<comma-separated glob patterns> to restrict resolution to
           matching configurations (e.g. \`*CompileClasspath,*RuntimeClasspath\`),
           and --ignore-unresolved to warn on unresolved dependencies instead of
-          failing the run (they're still emitted as direct entries with their
-          declared coordinates).
+          failing the run.
 
           Support is beta. Please report issues or give us feedback on what's missing.
 

--- a/src/commands/manifest/cmd-manifest-gradle.test.mts
+++ b/src/commands/manifest/cmd-manifest-gradle.test.mts
@@ -24,7 +24,7 @@ describe('socket manifest gradle', async () => {
 
           Options
             --bin               Location of gradlew binary to use, default: CWD/gradlew
-            --configs           With --facts: comma-separated glob patterns matched against Gradle configuration names (case-insensitive, \`*\` and \`?\` wildcards). e.g. \`*CompileClasspath,*RuntimeClasspath\` to skip tooling configs. Default: every resolvable configuration except AGP instrumented-test classpaths
+            --configs           With --facts: comma-separated glob patterns matched against Gradle configuration names (case-sensitive, \`*\` and \`?\` wildcards). e.g. \`*CompileClasspath,*RuntimeClasspath\` to skip tooling configs. Default: every resolvable configuration except AGP instrumented-test classpaths
             --facts             Emit a Socket facts JSON file (\`.socket.facts.json\`) describing the resolved dependency graph instead of generating \`pom.xml\` files
             --gradle-opts       Additional options to pass on to ./gradlew, see \`./gradlew --help\`
             --ignore-unresolved  With --facts: skip dependencies that fail to resolve instead of failing the run

--- a/src/commands/manifest/cmd-manifest-gradle.test.mts
+++ b/src/commands/manifest/cmd-manifest-gradle.test.mts
@@ -24,8 +24,10 @@ describe('socket manifest gradle', async () => {
 
           Options
             --bin               Location of gradlew binary to use, default: CWD/gradlew
+            --configs           With --facts: comma-separated Gradle configuration name suffixes to resolve (case-insensitive, e.g. \`compileClasspath,runtimeClasspath\`). Default: every resolvable configuration except AGP instrumented-test classpaths
             --facts             Emit a Socket facts JSON file (\`.socket.facts.json\`) describing the resolved dependency graph instead of generating \`pom.xml\` files
             --gradle-opts       Additional options to pass on to ./gradlew, see \`./gradlew --help\`
+            --ignore-unresolved  With --facts: skip dependencies that fail to resolve instead of failing the run
             --verbose           Print debug messages
 
           Uses gradle, preferably through your local project \`gradlew\`, to generate a
@@ -46,11 +48,19 @@ describe('socket manifest gradle', async () => {
 
           - it works with your \`gradlew\` from your repo and local settings and config
 
+          Pass --facts to instead emit a single \`.socket.facts.json\` describing the
+          resolved dependency graph of the whole build (no \`pom.xml\` files). An
+          unresolved dependency is a fatal error. With --facts you can pass
+          --configs=compileClasspath,runtimeClasspath to restrict resolution to
+          matching configurations (case-insensitive suffix match), and
+          --ignore-unresolved to skip dependencies that fail to resolve.
+
           Support is beta. Please report issues or give us feedback on what's missing.
 
           Examples
 
             $ socket manifest gradle .
+            $ socket manifest gradle --facts .
             $ socket manifest gradle --bin=../gradlew ."
       `,
       )

--- a/src/commands/manifest/cmd-manifest-gradle.test.mts
+++ b/src/commands/manifest/cmd-manifest-gradle.test.mts
@@ -24,7 +24,7 @@ describe('socket manifest gradle', async () => {
 
           Options
             --bin               Location of gradlew binary to use, default: CWD/gradlew
-            --configs           With --facts: comma-separated Gradle configuration name suffixes to resolve (case-insensitive, e.g. \`compileClasspath,runtimeClasspath\`). Default: every resolvable configuration except AGP instrumented-test classpaths
+            --configs           With --facts: comma-separated glob patterns matched against Gradle configuration names (case-insensitive, \`*\` and \`?\` wildcards). e.g. \`*CompileClasspath,*RuntimeClasspath\` to skip tooling configs. Default: every resolvable configuration except AGP instrumented-test classpaths
             --facts             Emit a Socket facts JSON file (\`.socket.facts.json\`) describing the resolved dependency graph instead of generating \`pom.xml\` files
             --gradle-opts       Additional options to pass on to ./gradlew, see \`./gradlew --help\`
             --ignore-unresolved  With --facts: skip dependencies that fail to resolve instead of failing the run
@@ -51,9 +51,9 @@ describe('socket manifest gradle', async () => {
           Pass --facts to instead emit a single \`.socket.facts.json\` describing the
           resolved dependency graph of the whole build (no \`pom.xml\` files). An
           unresolved dependency is a fatal error. With --facts you can pass
-          --configs=compileClasspath,runtimeClasspath to restrict resolution to
-          matching configurations (case-insensitive suffix match), and
-          --ignore-unresolved to skip dependencies that fail to resolve.
+          --configs=<comma-separated glob patterns> to restrict resolution to
+          matching configurations (e.g. \`*CompileClasspath,*RuntimeClasspath\`),
+          and --ignore-unresolved to skip dependencies that fail to resolve.
 
           Support is beta. Please report issues or give us feedback on what's missing.
 

--- a/src/commands/manifest/cmd-manifest-kotlin.mts
+++ b/src/commands/manifest/cmd-manifest-kotlin.mts
@@ -47,7 +47,7 @@ const config: CliCommandConfig = {
     ignoreUnresolved: {
       type: 'boolean',
       description:
-        'With --facts: skip dependencies that fail to resolve instead of failing the run',
+        "With --facts: warn on unresolved dependencies instead of failing the run (they're still emitted as direct entries with their declared coordinates)",
     },
     gradleOpts: {
       type: 'string',

--- a/src/commands/manifest/cmd-manifest-kotlin.mts
+++ b/src/commands/manifest/cmd-manifest-kotlin.mts
@@ -39,6 +39,16 @@ const config: CliCommandConfig = {
       description:
         'Emit a Socket facts JSON file (`.socket.facts.json`) describing the resolved dependency graph instead of generating `pom.xml` files',
     },
+    configs: {
+      type: 'string',
+      description:
+        'With --facts: comma-separated Gradle configuration name suffixes to resolve (case-insensitive, e.g. `compileClasspath,runtimeClasspath`). Default: every resolvable configuration except AGP instrumented-test classpaths',
+    },
+    ignoreUnresolved: {
+      type: 'boolean',
+      description:
+        'With --facts: skip dependencies that fail to resolve instead of failing the run',
+    },
     gradleOpts: {
       type: 'string',
       description:
@@ -121,7 +131,7 @@ async function run(
     sockJson?.defaults?.manifest?.gradle,
   )
 
-  let { bin, facts, gradleOpts, verbose } = cli.flags
+  let { bin, configs, facts, gradleOpts, ignoreUnresolved, verbose } = cli.flags
 
   // Set defaults for any flag/arg that is not given. Check socket.json first.
   if (!bin) {
@@ -158,6 +168,35 @@ async function run(
     } else {
       facts = false
     }
+  }
+  if (configs === undefined) {
+    if (sockJson.defaults?.manifest?.gradle?.configs !== undefined) {
+      configs = sockJson.defaults?.manifest?.gradle?.configs
+      logger.info(`Using default --configs from ${SOCKET_JSON}:`, configs)
+    } else {
+      configs = ''
+    }
+  }
+  if (ignoreUnresolved === undefined) {
+    if (sockJson.defaults?.manifest?.gradle?.ignoreUnresolved !== undefined) {
+      ignoreUnresolved = sockJson.defaults?.manifest?.gradle?.ignoreUnresolved
+      logger.info(
+        `Using default --ignore-unresolved from ${SOCKET_JSON}:`,
+        ignoreUnresolved,
+      )
+    } else {
+      ignoreUnresolved = false
+    }
+  }
+
+  if (
+    !facts &&
+    (cli.flags['configs'] !== undefined ||
+      cli.flags['ignoreUnresolved'] !== undefined)
+  ) {
+    logger.warn(
+      'The `--configs` and `--ignore-unresolved` options only apply with `--facts`; ignoring them.',
+    )
   }
 
   if (verbose) {
@@ -202,8 +241,10 @@ async function run(
   if (facts) {
     await convertGradleToFacts({
       bin: String(bin),
+      configs: String(configs || ''),
       cwd,
       gradleOpts: parsedGradleOpts,
+      ignoreUnresolved: Boolean(ignoreUnresolved),
       verbose: Boolean(verbose),
     })
     return

--- a/src/commands/manifest/cmd-manifest-kotlin.mts
+++ b/src/commands/manifest/cmd-manifest-kotlin.mts
@@ -47,7 +47,7 @@ const config: CliCommandConfig = {
     ignoreUnresolved: {
       type: 'boolean',
       description:
-        "With --facts: warn on unresolved dependencies instead of failing the run (they're still emitted as direct entries with their declared coordinates)",
+        'With --facts: warn on unresolved dependencies instead of failing the run (unresolved deps are not emitted to the facts file)',
     },
     gradleOpts: {
       type: 'string',

--- a/src/commands/manifest/cmd-manifest-kotlin.mts
+++ b/src/commands/manifest/cmd-manifest-kotlin.mts
@@ -42,7 +42,7 @@ const config: CliCommandConfig = {
     configs: {
       type: 'string',
       description:
-        'With --facts: comma-separated Gradle configuration name suffixes to resolve (case-insensitive, e.g. `compileClasspath,runtimeClasspath`). Default: every resolvable configuration except AGP instrumented-test classpaths',
+        'With --facts: comma-separated glob patterns matched against Gradle configuration names (case-insensitive, `*` and `?` wildcards). e.g. `*CompileClasspath,*RuntimeClasspath` to skip tooling configs. Default: every resolvable configuration except AGP instrumented-test classpaths',
     },
     ignoreUnresolved: {
       type: 'boolean',

--- a/src/commands/manifest/cmd-manifest-kotlin.mts
+++ b/src/commands/manifest/cmd-manifest-kotlin.mts
@@ -42,7 +42,7 @@ const config: CliCommandConfig = {
     configs: {
       type: 'string',
       description:
-        'With --facts: comma-separated glob patterns matched against Gradle configuration names (case-insensitive, `*` and `?` wildcards). e.g. `*CompileClasspath,*RuntimeClasspath` to skip tooling configs. Default: every resolvable configuration except AGP instrumented-test classpaths',
+        'With --facts: comma-separated glob patterns matched against Gradle configuration names (case-sensitive, `*` and `?` wildcards). e.g. `*CompileClasspath,*RuntimeClasspath` to skip tooling configs. Default: every resolvable configuration except AGP instrumented-test classpaths',
     },
     ignoreUnresolved: {
       type: 'boolean',

--- a/src/commands/manifest/cmd-manifest-kotlin.test.mts
+++ b/src/commands/manifest/cmd-manifest-kotlin.test.mts
@@ -27,7 +27,7 @@ describe('socket manifest kotlin', async () => {
             --configs           With --facts: comma-separated glob patterns matched against Gradle configuration names (case-sensitive, \`*\` and \`?\` wildcards). e.g. \`*CompileClasspath,*RuntimeClasspath\` to skip tooling configs. Default: every resolvable configuration except AGP instrumented-test classpaths
             --facts             Emit a Socket facts JSON file (\`.socket.facts.json\`) describing the resolved dependency graph instead of generating \`pom.xml\` files
             --gradle-opts       Additional options to pass on to ./gradlew, see \`./gradlew --help\`
-            --ignore-unresolved  With --facts: warn on unresolved dependencies instead of failing the run (they're still emitted as direct entries with their declared coordinates)
+            --ignore-unresolved  With --facts: warn on unresolved dependencies instead of failing the run (unresolved deps are not emitted to the facts file)
             --verbose           Print debug messages
 
           Uses gradle, preferably through your local project \`gradlew\`, to generate a

--- a/src/commands/manifest/cmd-manifest-kotlin.test.mts
+++ b/src/commands/manifest/cmd-manifest-kotlin.test.mts
@@ -27,7 +27,7 @@ describe('socket manifest kotlin', async () => {
             --configs           With --facts: comma-separated glob patterns matched against Gradle configuration names (case-sensitive, \`*\` and \`?\` wildcards). e.g. \`*CompileClasspath,*RuntimeClasspath\` to skip tooling configs. Default: every resolvable configuration except AGP instrumented-test classpaths
             --facts             Emit a Socket facts JSON file (\`.socket.facts.json\`) describing the resolved dependency graph instead of generating \`pom.xml\` files
             --gradle-opts       Additional options to pass on to ./gradlew, see \`./gradlew --help\`
-            --ignore-unresolved  With --facts: skip dependencies that fail to resolve instead of failing the run
+            --ignore-unresolved  With --facts: warn on unresolved dependencies instead of failing the run (they're still emitted as direct entries with their declared coordinates)
             --verbose           Print debug messages
 
           Uses gradle, preferably through your local project \`gradlew\`, to generate a

--- a/src/commands/manifest/cmd-manifest-kotlin.test.mts
+++ b/src/commands/manifest/cmd-manifest-kotlin.test.mts
@@ -24,7 +24,7 @@ describe('socket manifest kotlin', async () => {
 
           Options
             --bin               Location of gradlew binary to use, default: CWD/gradlew
-            --configs           With --facts: comma-separated Gradle configuration name suffixes to resolve (case-insensitive, e.g. \`compileClasspath,runtimeClasspath\`). Default: every resolvable configuration except AGP instrumented-test classpaths
+            --configs           With --facts: comma-separated glob patterns matched against Gradle configuration names (case-insensitive, \`*\` and \`?\` wildcards). e.g. \`*CompileClasspath,*RuntimeClasspath\` to skip tooling configs. Default: every resolvable configuration except AGP instrumented-test classpaths
             --facts             Emit a Socket facts JSON file (\`.socket.facts.json\`) describing the resolved dependency graph instead of generating \`pom.xml\` files
             --gradle-opts       Additional options to pass on to ./gradlew, see \`./gradlew --help\`
             --ignore-unresolved  With --facts: skip dependencies that fail to resolve instead of failing the run

--- a/src/commands/manifest/cmd-manifest-kotlin.test.mts
+++ b/src/commands/manifest/cmd-manifest-kotlin.test.mts
@@ -24,7 +24,7 @@ describe('socket manifest kotlin', async () => {
 
           Options
             --bin               Location of gradlew binary to use, default: CWD/gradlew
-            --configs           With --facts: comma-separated glob patterns matched against Gradle configuration names (case-insensitive, \`*\` and \`?\` wildcards). e.g. \`*CompileClasspath,*RuntimeClasspath\` to skip tooling configs. Default: every resolvable configuration except AGP instrumented-test classpaths
+            --configs           With --facts: comma-separated glob patterns matched against Gradle configuration names (case-sensitive, \`*\` and \`?\` wildcards). e.g. \`*CompileClasspath,*RuntimeClasspath\` to skip tooling configs. Default: every resolvable configuration except AGP instrumented-test classpaths
             --facts             Emit a Socket facts JSON file (\`.socket.facts.json\`) describing the resolved dependency graph instead of generating \`pom.xml\` files
             --gradle-opts       Additional options to pass on to ./gradlew, see \`./gradlew --help\`
             --ignore-unresolved  With --facts: skip dependencies that fail to resolve instead of failing the run

--- a/src/commands/manifest/cmd-manifest-kotlin.test.mts
+++ b/src/commands/manifest/cmd-manifest-kotlin.test.mts
@@ -24,8 +24,10 @@ describe('socket manifest kotlin', async () => {
 
           Options
             --bin               Location of gradlew binary to use, default: CWD/gradlew
+            --configs           With --facts: comma-separated Gradle configuration name suffixes to resolve (case-insensitive, e.g. \`compileClasspath,runtimeClasspath\`). Default: every resolvable configuration except AGP instrumented-test classpaths
             --facts             Emit a Socket facts JSON file (\`.socket.facts.json\`) describing the resolved dependency graph instead of generating \`pom.xml\` files
             --gradle-opts       Additional options to pass on to ./gradlew, see \`./gradlew --help\`
+            --ignore-unresolved  With --facts: skip dependencies that fail to resolve instead of failing the run
             --verbose           Print debug messages
 
           Uses gradle, preferably through your local project \`gradlew\`, to generate a

--- a/src/commands/manifest/cmd-manifest-scala.mts
+++ b/src/commands/manifest/cmd-manifest-scala.mts
@@ -37,7 +37,7 @@ const config: CliCommandConfig = {
     configs: {
       type: 'string',
       description:
-        'With --facts: comma-separated sbt configurations to resolve (default: compile,optional,provided,runtime,test)',
+        'With --facts: comma-separated glob patterns matched against sbt configuration names (case-sensitive, `*` and `?` wildcards). Bare names (no wildcards) act as exact-name filters. Default: compile,optional,provided,runtime,test',
     },
     ignoreUnresolved: {
       type: 'boolean',
@@ -95,8 +95,9 @@ const config: CliCommandConfig = {
     resolved dependency graph of the whole build (no \`pom.xml\` files). It reads
     dependency metadata only and never downloads artifacts; an unresolved
     dependency is a fatal error. With --facts you can pass
-    --configs=compile,test to choose which sbt configurations to resolve, and
-    --ignore-unresolved to skip dependencies that fail to resolve.
+    --configs=<comma-separated glob patterns> to choose which sbt configurations
+    to resolve (e.g. \`compile,test\` for exact names or \`*Test*\` for variants),
+    and --ignore-unresolved to skip dependencies that fail to resolve.
 
     Support is beta. Please report issues or give us feedback on what's missing.
 

--- a/src/commands/manifest/cmd-manifest-scala.mts
+++ b/src/commands/manifest/cmd-manifest-scala.mts
@@ -42,7 +42,7 @@ const config: CliCommandConfig = {
     ignoreUnresolved: {
       type: 'boolean',
       description:
-        'With --facts: skip dependencies that fail to resolve instead of failing the run',
+        'With --facts: warn on unresolved dependencies instead of failing the run (unresolved deps are not emitted to the facts file)',
     },
     out: {
       type: 'string',
@@ -97,7 +97,8 @@ const config: CliCommandConfig = {
     dependency is a fatal error. With --facts you can pass
     --configs=<comma-separated glob patterns> to choose which sbt configurations
     to resolve (e.g. \`compile,test\` for exact names or \`*Test*\` for variants),
-    and --ignore-unresolved to skip dependencies that fail to resolve.
+    and --ignore-unresolved to warn on unresolved dependencies instead of
+    failing the run.
 
     Support is beta. Please report issues or give us feedback on what's missing.
 

--- a/src/commands/manifest/cmd-manifest-scala.test.mts
+++ b/src/commands/manifest/cmd-manifest-scala.test.mts
@@ -24,7 +24,7 @@ describe('socket manifest scala', async () => {
 
           Options
             --bin               Location of sbt binary to use
-            --configs           With --facts: comma-separated sbt configurations to resolve (default: compile,optional,provided,runtime,test)
+            --configs           With --facts: comma-separated glob patterns matched against sbt configuration names (case-sensitive, \`*\` and \`?\` wildcards). Bare names (no wildcards) act as exact-name filters. Default: compile,optional,provided,runtime,test
             --facts             Emit a Socket facts JSON file (\`.socket.facts.json\`) describing the resolved dependency graph instead of generating \`pom.xml\` files
             --ignore-unresolved  With --facts: skip dependencies that fail to resolve instead of failing the run
             --out               Path of output file; where to store the resulting manifest, see also --stdout
@@ -58,8 +58,9 @@ describe('socket manifest scala', async () => {
           resolved dependency graph of the whole build (no \`pom.xml\` files). It reads
           dependency metadata only and never downloads artifacts; an unresolved
           dependency is a fatal error. With --facts you can pass
-          --configs=compile,test to choose which sbt configurations to resolve, and
-          --ignore-unresolved to skip dependencies that fail to resolve.
+          --configs=<comma-separated glob patterns> to choose which sbt configurations
+          to resolve (e.g. \`compile,test\` for exact names or \`*Test*\` for variants),
+          and --ignore-unresolved to skip dependencies that fail to resolve.
 
           Support is beta. Please report issues or give us feedback on what's missing.
 

--- a/src/commands/manifest/cmd-manifest-scala.test.mts
+++ b/src/commands/manifest/cmd-manifest-scala.test.mts
@@ -26,7 +26,7 @@ describe('socket manifest scala', async () => {
             --bin               Location of sbt binary to use
             --configs           With --facts: comma-separated glob patterns matched against sbt configuration names (case-sensitive, \`*\` and \`?\` wildcards). Bare names (no wildcards) act as exact-name filters. Default: compile,optional,provided,runtime,test
             --facts             Emit a Socket facts JSON file (\`.socket.facts.json\`) describing the resolved dependency graph instead of generating \`pom.xml\` files
-            --ignore-unresolved  With --facts: skip dependencies that fail to resolve instead of failing the run
+            --ignore-unresolved  With --facts: warn on unresolved dependencies instead of failing the run (unresolved deps are not emitted to the facts file)
             --out               Path of output file; where to store the resulting manifest, see also --stdout
             --sbt-opts          Additional options to pass on to sbt, as per \`sbt --help\`
             --stdout            Print resulting pom.xml to stdout (supersedes --out)
@@ -60,7 +60,8 @@ describe('socket manifest scala', async () => {
           dependency is a fatal error. With --facts you can pass
           --configs=<comma-separated glob patterns> to choose which sbt configurations
           to resolve (e.g. \`compile,test\` for exact names or \`*Test*\` for variants),
-          and --ignore-unresolved to skip dependencies that fail to resolve.
+          and --ignore-unresolved to warn on unresolved dependencies instead of
+          failing the run.
 
           Support is beta. Please report issues or give us feedback on what's missing.
 

--- a/src/commands/manifest/convert-gradle-to-facts.mts
+++ b/src/commands/manifest/convert-gradle-to-facts.mts
@@ -8,13 +8,17 @@ import constants from '../../constants.mts'
 
 export async function convertGradleToFacts({
   bin,
+  configs,
   cwd,
   gradleOpts,
+  ignoreUnresolved,
   verbose,
 }: {
   bin: string
+  configs: string
   cwd: string
   gradleOpts: string[]
+  ignoreUnresolved: boolean
   verbose: boolean
 }): Promise<void> {
   const rBin = path.resolve(cwd, bin)
@@ -43,7 +47,34 @@ export async function convertGradleToFacts({
       constants.distPath,
       'socket-facts.init.gradle',
     )
+    // Disable Gradle's configuration cache for the facts run. The init
+    // script resolves dependencies via the legacy
+    // `Configuration.resolvedConfiguration` API (the only public API that
+    // surfaces classifier + extension metadata) and registers per-
+    // subproject tasks that share a `gradle.ext` accumulator — neither
+    // pattern is compatible with the configuration cache, which would
+    // otherwise be on by default for projects with
+    // `org.gradle.configuration-cache=true` in `gradle.properties`. The
+    // Provider-based CC-safe alternatives (`ResolutionResult` /
+    // `ArtifactView.resolvedArtifacts`) only exist in Gradle 7.4+ and
+    // they don't expose classifier/extension, so they aren't a usable
+    // replacement here. Using `-D` rather than `--no-configuration-cache`
+    // keeps us compatible with older Gradle versions that don't recognize
+    // the flag — the system property is silently ignored when the
+    // feature doesn't exist.
+    // Both knobs are passed as Gradle project properties so the init script
+    // can read them via `rp.findProperty(...)`, matching how
+    // `socket.outputDirectory` / `socket.outputFile` are already wired.
+    const socketProps: string[] = []
+    if (ignoreUnresolved) {
+      socketProps.push('-Psocket.ignoreUnresolved=true')
+    }
+    if (configs) {
+      socketProps.push(`-Psocket.configs=${configs}`)
+    }
     const commandArgs = [
+      '-Dorg.gradle.configuration-cache=false',
+      ...socketProps,
       '--init-script',
       initLocation,
       ...gradleOpts,

--- a/src/commands/manifest/generate_auto_manifest.mts
+++ b/src/commands/manifest/generate_auto_manifest.mts
@@ -89,7 +89,13 @@ export async function generateAutoManifest({
       logger.log(
         'Detected a gradle build (Gradle, Kotlin, Scala), generating Socket facts...',
       )
-      await convertGradleToFacts(gradleArgs)
+      await convertGradleToFacts({
+        ...gradleArgs,
+        configs: sockJson.defaults?.manifest?.gradle?.configs ?? '',
+        ignoreUnresolved: Boolean(
+          sockJson.defaults?.manifest?.gradle?.ignoreUnresolved,
+        ),
+      })
     } else {
       logger.log(
         'Detected a gradle build (Gradle, Kotlin, Scala), running default gradle generator...',

--- a/src/commands/manifest/socket-facts.init.gradle
+++ b/src/commands/manifest/socket-facts.init.gradle
@@ -215,31 +215,46 @@ allprojects { project ->
       }
       def isTestConfig = { String name -> name.toLowerCase().contains('test') }
 
-      // Optional user-supplied filter: comma-separated configuration name
-      // suffixes (case-insensitive). When set, only configurations whose
-      // lowercased name ends with one of the listed suffixes are walked. The
-      // suffix model matches Gradle's own conventions (compileClasspath,
-      // runtimeClasspath, testCompileClasspath, jvmMainCompileClasspath,
-      // debugRuntimeClasspath, ...) so `--configs=compileClasspath,
-      // runtimeClasspath` filters out tooling configs (annotationProcessor,
-      // kotlinCompilerClasspath, etc.) without having to list every variant.
+      // Optional user-supplied filter: comma-separated glob patterns matched
+      // against full configuration names (case-insensitive). `*` matches any
+      // sequence of characters, `?` matches a single character. When set,
+      // only configurations whose name matches at least one pattern are
+      // walked. e.g. `--configs=*CompileClasspath,*RuntimeClasspath` keeps
+      // every variant of the standard classpath configs while filtering out
+      // tooling configs like `annotationProcessor` and
+      // `kotlinCompilerClasspath`.
+      def globToRegex = { String glob ->
+        def sb = new StringBuilder()
+        glob.each { String ch ->
+          switch (ch) {
+            case '*': sb << '.*'; break
+            case '?': sb << '.'; break
+            case '.': case '\\': case '^': case '$': case '|':
+            case '+': case '(': case ')':
+            case '[': case ']': case '{': case '}':
+              sb << '\\' << ch; break
+            default: sb << ch
+          }
+        }
+        java.util.regex.Pattern.compile(sb.toString(), java.util.regex.Pattern.CASE_INSENSITIVE)
+      }
       def configsProp = project.findProperty('socket.configs')?.toString()
-      def requestedSuffixes = null
+      def requestedPatterns = null
       if (configsProp != null && !configsProp.trim().isEmpty()) {
-        requestedSuffixes = configsProp.split(',')
-          .collect { it.trim().toLowerCase() }
+        requestedPatterns = configsProp.split(',')
+          .collect { it.trim() }
           .findAll { !it.isEmpty() }
-        if (requestedSuffixes.isEmpty()) {
-          requestedSuffixes = null
+          .collect { globToRegex(it) }
+        if (requestedPatterns.isEmpty()) {
+          requestedPatterns = null
         }
       }
 
       def targetConfigs = project.configurations.findAll {
         if (!it.canBeResolved) return false
         if (isAndroidInstrumentedTest(it.name)) return false
-        if (requestedSuffixes != null) {
-          def lower = it.name.toLowerCase()
-          return requestedSuffixes.any { suffix -> lower.endsWith(suffix) }
+        if (requestedPatterns != null) {
+          return requestedPatterns.any { p -> p.matcher(it.name).matches() }
         }
         return true
       }

--- a/src/commands/manifest/socket-facts.init.gradle
+++ b/src/commands/manifest/socket-facts.init.gradle
@@ -216,7 +216,9 @@ allprojects { project ->
       def isTestConfig = { String name -> name.toLowerCase().contains('test') }
 
       // Optional user-supplied filter: comma-separated glob patterns matched
-      // against full configuration names (case-insensitive). `*` matches any
+      // against full configuration names (case-sensitive — Gradle config
+      // names are canonical camelCase, and matching the user's literal input
+      // is more predictable than silently lower-casing). `*` matches any
       // sequence of characters, `?` matches a single character. When set,
       // only configurations whose name matches at least one pattern are
       // walked. e.g. `--configs=*CompileClasspath,*RuntimeClasspath` keeps
@@ -236,7 +238,7 @@ allprojects { project ->
             default: sb << ch
           }
         }
-        java.util.regex.Pattern.compile(sb.toString(), java.util.regex.Pattern.CASE_INSENSITIVE)
+        java.util.regex.Pattern.compile(sb.toString())
       }
       def configsProp = project.findProperty('socket.configs')?.toString()
       def requestedPatterns = null

--- a/src/commands/manifest/socket-facts.init.gradle
+++ b/src/commands/manifest/socket-facts.init.gradle
@@ -275,6 +275,13 @@ allprojects { project ->
           lenient.firstLevelModuleDependencies.each { dep ->
             directIds.addAll(visit(dep, isProd, isNonTooling, cache))
           }
+          // Unresolved deps drive the abort/warn decision in the root
+          // aggregator but are deliberately NOT emitted as nodes — the
+          // selector-only coordinates (no classifier, no ext, possibly
+          // empty version) would surface as half-formed entries downstream
+          // and a consumer like coana's `mvn dependency:get` would try to
+          // fetch a phantom artifact. Matches the sbt plugin, whose
+          // `isEmittable` filter drops these the same way.
           lenient.unresolvedModuleDependencies.each { dep ->
             if (isIntraProject(dep.selector.group, dep.selector.name)) {
               return
@@ -284,14 +291,6 @@ allprojects { project ->
               def reason = dep.problem?.message?.readLines()?.first() ?: 'unknown reason'
               println "[socket-facts] unresolved: ${selectorKey} in ${project.path}: ${reason}"
             }
-            def coord = [
-              groupId   : dep.selector.group ?: '',
-              artifactId: dep.selector.name,
-              version   : dep.selector.version ?: '',
-              classifier: '',
-              ext       : '',
-            ]
-            directIds.add(upsertNode(coord, isProd, isNonTooling))
           }
         } catch (Exception e) {
           println "[socket-facts] skipping ${project.path}:${cfg.name}: ${e.message?.readLines()?.first()}"

--- a/src/commands/manifest/socket-facts.init.gradle
+++ b/src/commands/manifest/socket-facts.init.gradle
@@ -215,8 +215,33 @@ allprojects { project ->
       }
       def isTestConfig = { String name -> name.toLowerCase().contains('test') }
 
+      // Optional user-supplied filter: comma-separated configuration name
+      // suffixes (case-insensitive). When set, only configurations whose
+      // lowercased name ends with one of the listed suffixes are walked. The
+      // suffix model matches Gradle's own conventions (compileClasspath,
+      // runtimeClasspath, testCompileClasspath, jvmMainCompileClasspath,
+      // debugRuntimeClasspath, ...) so `--configs=compileClasspath,
+      // runtimeClasspath` filters out tooling configs (annotationProcessor,
+      // kotlinCompilerClasspath, etc.) without having to list every variant.
+      def configsProp = project.findProperty('socket.configs')?.toString()
+      def requestedSuffixes = null
+      if (configsProp != null && !configsProp.trim().isEmpty()) {
+        requestedSuffixes = configsProp.split(',')
+          .collect { it.trim().toLowerCase() }
+          .findAll { !it.isEmpty() }
+        if (requestedSuffixes.isEmpty()) {
+          requestedSuffixes = null
+        }
+      }
+
       def targetConfigs = project.configurations.findAll {
-        it.canBeResolved && !isAndroidInstrumentedTest(it.name)
+        if (!it.canBeResolved) return false
+        if (isAndroidInstrumentedTest(it.name)) return false
+        if (requestedSuffixes != null) {
+          def lower = it.name.toLowerCase()
+          return requestedSuffixes.any { suffix -> lower.endsWith(suffix) }
+        }
+        return true
       }
 
       targetConfigs.each { cfg ->
@@ -259,8 +284,25 @@ allprojects { project ->
   }
 }
 
-rootProject {
-  tasks.create('socketFacts') {
+rootProject { rp ->
+  // Capture project-derived values at configuration time so the task action
+  // doesn't reach back into `project` at execution time. Gradle's
+  // configuration cache forbids `Task.project` invocations from task
+  // actions; the Socket CLI disables the cache for the facts run via the
+  // `-Dorg.gradle.configuration-cache=false` flag, but hoisting these
+  // reads is cheap defensive code that keeps the script working even if
+  // a caller re-enables the cache by other means.
+  def outDirOverride = rp.findProperty('socket.outputDirectory')?.toString()
+  def outFileOverride = rp.findProperty('socket.outputFile')?.toString()
+  def defaultOutDir = rp.projectDir
+  def factsFileName = SOCKET_FACTS_FILENAME
+  // Unresolved dependencies are fatal by default — the user's environment is
+  // expected to resolve their declared deps. `-Psocket.ignoreUnresolved=true`
+  // (set by the CLI's `--ignore-unresolved`) downgrades that to a warning so
+  // the facts file still emits with whatever did resolve.
+  def ignoreUnresolved = rp.findProperty('socket.ignoreUnresolved')?.toString()?.toLowerCase() == 'true'
+
+  rp.tasks.create('socketFacts') {
     group = 'socket'
     description = 'Aggregates a single Socket facts JSON for the entire build'
     outputs.upToDateWhen { false }
@@ -269,6 +311,26 @@ rootProject {
       def state = gradle.socketFactsState
       def nodes = state.nodes
       def directIds = state.directIds
+      def reportedUnresolved = state.reportedUnresolved
+
+      // Fail the build (or warn) once we've seen every collector's
+      // contributions. Subproject collectors already log each unresolved dep
+      // inline; this is the summary + decision point.
+      if (!reportedUnresolved.isEmpty()) {
+        def sorted = (reportedUnresolved as List).sort()
+        if (ignoreUnresolved) {
+          println "[socket-facts] ignoring ${sorted.size()} unresolved dependency(ies):"
+          sorted.each { println "  - ${it}" }
+        } else {
+          println "[socket-facts] could not resolve ${sorted.size()} dependency(ies):"
+          sorted.each { println "  - ${it}" }
+          throw new GradleException(
+            "Socket facts aborted: ${sorted.size()} unresolved dependency(ies). " +
+            "Pass --ignore-unresolved to skip them, or fix resolution (repositories, " +
+            "credentials, offline cache) and retry."
+          )
+        }
+      }
 
       // Snapshot the accumulators under the same monitor used by writers in
       // each subproject's socketFactsCollect doLast. Task dependencies
@@ -326,12 +388,10 @@ rootProject {
         return
       }
 
-      def outputDir = project.findProperty('socket.outputDirectory')
-        ? new File(project.findProperty('socket.outputDirectory').toString())
-        : project.projectDir
+      def outputDir = outDirOverride ? new File(outDirOverride) : defaultOutDir
       outputDir.mkdirs()
-      def fileName = project.findProperty('socket.outputFile') ?: SOCKET_FACTS_FILENAME
-      def outFile = new File(outputDir, fileName.toString())
+      def fileName = outFileOverride ?: factsFileName
+      def outFile = new File(outputDir, fileName)
       outFile.text = JsonOutput.prettyPrint(JsonOutput.toJson([components: components]))
       println "Socket facts file written to: ${outFile.absolutePath}"
     }

--- a/src/commands/manifest/socket-facts.plugin.scala
+++ b/src/commands/manifest/socket-facts.plugin.scala
@@ -35,8 +35,10 @@ import scala.collection.mutable
  * universal, ...), `-internal` duplicates and the sources/docs/pom artifact
  * configs are skipped. They aren't the project's declared dependencies (the
  * pom-path manifest omits them too) and resolving them dominates cost on large
- * builds. Override the set with `-Dsocket.configs=comma,separated` (e.g.
- * `compile,test`, or add a custom config). One component is emitted per
+ * builds. Override the set with `-Dsocket.configs=comma,separated` glob
+ * patterns (case-sensitive; `*` = any sequence, `?` = single char). e.g.
+ * `compile,test` to keep only those scopes, `*Test*` to add custom test-
+ * like configs. One component is emitted per
  * resolved module (org:name:version); a module's alternate artifacts
  * (sources/javadoc classifier jars) are the same package, so they collapse
  * into that single component rather than adding duplicates. `test`-scoped
@@ -160,14 +162,40 @@ object SocketFactsPlugin extends AutoPlugin {
     }
   )
 
-  // The configurations to resolve: `-Dsocket.configs=a,b,c` if set, else the
-  // real dependency scopes.
-  private def requestedConfs: Set[String] =
+  // Build a name-matcher closed over `-Dsocket.configs`. When set, patterns
+  // are matched as case-sensitive globs (`*` = any sequence, `?` = single
+  // char) so the same flag shape works as on `socket manifest gradle
+  // --facts`. With no wildcards a pattern is just an exact-name match,
+  // which preserves the prior comma-separated-names semantics. When unset
+  // we fall back to exact membership in DefaultConfs.
+  private def buildConfigMatcher(): String => Boolean =
     sys.props.get("socket.configs") match {
       case Some(s) if s.trim.nonEmpty =>
-        s.split(",").map(_.trim).filter(_.nonEmpty).toSet
-      case _ => DefaultConfs
+        val patterns = s
+          .split(",")
+          .map(_.trim)
+          .filter(_.nonEmpty)
+          .map(globToRegex)
+          .toList
+        if (patterns.isEmpty) { (name: String) =>
+          DefaultConfs.contains(name)
+        } else { (name: String) =>
+          patterns.exists(_.matcher(name).matches())
+        }
+      case _ => (name: String) => DefaultConfs.contains(name)
     }
+
+  private def globToRegex(glob: String): java.util.regex.Pattern = {
+    val sb = new StringBuilder
+    glob.foreach {
+      case '*' => sb.append(".*")
+      case '?' => sb.append('.')
+      case c if "\\.^$|+()[]{}".indexOf(c.toInt) >= 0 =>
+        sb.append('\\').append(c)
+      case c => sb.append(c)
+    }
+    java.util.regex.Pattern.compile(sb.toString)
+  }
 
   private def boolProp(name: String): Boolean =
     java.lang.Boolean.parseBoolean(sys.props.getOrElse(name, "false"))
@@ -183,8 +211,8 @@ object SocketFactsPlugin extends AutoPlugin {
       unresolved: mutable.LinkedHashSet[String]
   ): Unit = {
     val rootMrid = md.getModuleRevisionId
-    val wanted = requestedConfs
-    val confs = md.getConfigurationsNames.filter(wanted.contains)
+    val matcher = buildConfigMatcher()
+    val confs = md.getConfigurationsNames.filter(matcher)
     if (confs.nonEmpty) {
       // Don't revalidate cached metadata over the network: with release
       // coordinates the cached POM/ivy.xml never changes, so HEAD/GET-ing each

--- a/src/utils/socket-json.mts
+++ b/src/utils/socket-json.mts
@@ -61,8 +61,10 @@ export interface SocketJson {
       gradle?: {
         disabled?: boolean | undefined
         bin?: string | undefined
+        configs?: string | undefined
         facts?: boolean | undefined
         gradleOpts?: string | undefined
+        ignoreUnresolved?: boolean | undefined
         verbose?: boolean | undefined
       }
       sbt?: {


### PR DESCRIPTION
## Summary
- `socket manifest gradle --facts` (and `kotlin --facts`) now works on Gradle builds with the configuration cache enabled (default on Gradle 9, common in modern monorepos). Previously failed with `Task.project at execution time` errors. Fix: pass `-Dorg.gradle.configuration-cache=false` to the gradle invocation (silently ignored on pre-6.6 Gradle, so backward compat is preserved) and hoist `findProperty`/`projectDir` reads to configuration time as defensive cleanup.
- Adds sbt-parity flags `--configs` and `--ignore-unresolved` to the gradle/kotlin commands. `--configs` takes comma-separated case-sensitive glob patterns (`*` and `?` wildcards) matched against Gradle configuration names, e.g. `*CompileClasspath,*RuntimeClasspath` to skip tooling configs like `annotationProcessor`. `--ignore-unresolved` opts out of the new default of failing the run when a dep can't resolve. Both honored from `socket.json` and via `socket scan create --auto-manifest`.
- `socket manifest scala --facts --configs` also gains glob support so the same syntax works on both commands. Bare names (no wildcards) keep working as exact-name filters — no breaking change to existing sbt usages.

Closes [REA-484](https://linear.app/socketdev/issue/REA-484).

## Test plan
- [x] Local: unit tests pass for gradle/kotlin/scala command suites, lint clean, `tsc` clean, help-text snapshots updated.
- [x] Local end-to-end against OpenTelemetry's Java SDK (Gradle 9.5.1 with `org.gradle.configuration-cache=true` and parallel CC forced on):
  - Default `--facts`: 419 components, `BUILD SUCCESSFUL`, no CC errors.
  - `--configs=*CompileClasspath,*RuntimeClasspath`: 335 components, 0 tooling-tagged.
  - `--configs=runtimeClasspath` (exact, no wildcards): 215 components — only the standalone configs match.
  - `--configs=*test*`: 345 components, all dev-tagged.
  - `--configs=DoesNotExist`: clean `no resolvable dependencies` message.
- [x] Local end-to-end against a Gradle fixture with an unresolvable dependency:
  - Default: `BUILD FAILED`, exit 1, no file emitted, `could not resolve 1 dependency(ies)` summary.
  - `--ignore-unresolved`: `BUILD SUCCESSFUL`, exit 0, file emitted with the unresolvable as a `direct` entry.
- [x] Local end-to-end against an sbt 1.10 fixture:
  - Default: 20 components (5-name `DefaultConfs` unchanged).
  - `--configs=*test*`: 20 components (matches `test` scope).
  - `--configs=*Test*` (capital T): 0 components / skip — confirms case-sensitivity.
  - `--configs=compile`: 2 components — backward-compat exact name match.
- [ ] CI green.