### PR TITLE
upgrading coana to version 15.3.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - **Bazel diagnostics** — `socket manifest bazel --verbose` now emits bounded subprocess traces with argv, cwd, duration, exit status, output sizes, and failure stderr tails to make customer log-only triage safer and faster.
 
+## [1.1.111](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.111) - 2026-05-29
+
+### Changed
+- Updated the Coana CLI to v `15.3.15`.
+
 ## [1.1.110](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.110) - 2026-05-29
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.110",
+  "version": "1.1.111",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -96,7 +96,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "15.3.12",
+    "@coana-tech/cli": "15.3.15",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 15.3.12
-        version: 15.3.12
+        specifier: 15.3.15
+        version: 15.3.15
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@15.3.12':
-    resolution: {integrity: sha512-cxv/DBmQm9a+nUk/vjV/vgi4g4YnuGpoMhSTFVfmqmiR5M9XYZ1raLoVZl0x0P53Ux8qZbz0Wmr0+WqziznoNw==}
+  '@coana-tech/cli@15.3.15':
+    resolution: {integrity: sha512-AH6my6LNU61JpP52NAdiYYRlZFGEnRngDAt8yKrLDgnPeuiVWkWnYequcEiPX9RFvhxKO/eW9PN14K/ixdsfkQ==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5385,7 +5385,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@15.3.12': {}
+  '@coana-tech/cli@15.3.15': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 15.3.12 to 15.3.15

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only release with version and lockfile updates; behavior changes depend on Coana 15.3.15 but no Socket CLI source was modified.
> 
> **Overview**
> Releases **Socket CLI v1.1.111** by bumping the published package version and refreshing the lockfile. The bundled **Coana** dev dependency moves from **15.3.12** to **15.3.15**, which is what `socket fix`, reachability scans, and related flows spawn unless overridden with `--fix-version` / `--reach-version`.
> 
> **CHANGELOG** adds a **1.1.111** section noting the Coana upgrade; there are no application source changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73773a377e654a824019ee37322136b3cfc4a961. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->