### PR TITLE
fix(fix): skip unreadable dirs in manifest discovery (EACCES scandir)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - **Bazel diagnostics** — `socket manifest bazel --verbose` now emits bounded subprocess traces with argv, cwd, duration, exit status, output sizes, and failure stderr tails to make customer log-only triage safer and faster.
 
+## [1.1.112](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.112) - 2026-05-29
+
+### Fixed
+- `socket fix` and `socket scan create` no longer abort with `EACCES: permission denied, scandir` when the project contains a directory the running user cannot read (for example a postgres `pgdata` data directory owned by another uid, or a Docker volume mount). Manifest discovery walks a project for `.gitignore` files before applying any path exclusions; that walk now honors `--exclude-paths` and `socket.yml` `projectIgnorePaths`, and skips unreadable directories rather than crashing. This makes `--exclude-paths` effective for unreadable directories — previously the crash happened before the exclusion was ever applied.
+
 ## [1.1.111](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.111) - 2026-05-29
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.111",
+  "version": "1.1.112",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",

--- a/src/utils/glob.mts
+++ b/src/utils/glob.mts
@@ -306,11 +306,14 @@ export async function globWithGitIgnore(
     ignore: hasNegatedPattern
       ? [...defaultIgnore, ...cliMinimatchIgnores]
       : [...ignores, ...cliMinimatchIgnores].map(stripTrailingSlash),
+    ...additionalOptions,
     // Skip directories the running user cannot read rather than aborting the
     // whole walk on the first `EACCES` (see the .gitignore discovery walk
-    // above for the full rationale).
+    // above for the full rationale). Pinned after `...additionalOptions` so a
+    // caller's options bag cannot accidentally flip it back to `false` and
+    // re-introduce the crash — `suppressErrors` is a safety invariant here, not
+    // a tunable.
     suppressErrors: true,
-    ...additionalOptions,
   } as GlobOptions
 
   // When no filter is provided and no negated patterns exist, use the fast path.

--- a/src/utils/glob.mts
+++ b/src/utils/glob.mts
@@ -232,23 +232,48 @@ export async function globWithGitIgnore(
 
   const ignores = new Set<string>(IGNORED_DIR_PATTERNS)
 
+  // CLI-supplied `additionalIgnores` are already anchored minimatch — they
+  // must not pass through the `ignore` package (whose gitignore "match
+  // anywhere" semantics would re-interpret a bare `tests` to match
+  // `subdir/tests/foo.json`). Keep them in fast-glob's ignore list across
+  // both paths; only gitignore-translated entries go into the `ig` matcher.
+  const cliMinimatchIgnores = additionalIgnores ?? []
+
   const projectIgnorePaths = socketConfig?.projectIgnorePaths
-  if (Array.isArray(projectIgnorePaths)) {
-    const ignorePatterns = ignoreFileLinesToGlobPatterns(
-      projectIgnorePaths,
-      path.join(cwd, '.gitignore'),
-      cwd,
-    )
-    for (const pattern of ignorePatterns) {
-      ignores.add(pattern)
-    }
+  const projectIgnoreGlobs = Array.isArray(projectIgnorePaths)
+    ? ignoreFileLinesToGlobPatterns(
+        projectIgnorePaths,
+        path.join(cwd, '.gitignore'),
+        cwd,
+      )
+    : []
+  for (const pattern of projectIgnoreGlobs) {
+    ignores.add(pattern)
   }
 
+  // The .gitignore discovery walk has to honor the same directory exclusions
+  // as the package walk below. Otherwise an unreadable subtree (e.g. a
+  // postgres `pgdata` dir owned by another uid, or a Docker volume mount) makes
+  // fast-glob throw `EACCES: permission denied, scandir` *here* — before
+  // --exclude-paths (`cliMinimatchIgnores`) or projectIgnorePaths are ever
+  // applied to the main walk, which is why excluding the path did not help.
+  // `suppressErrors` is the backstop: a directory the user simply cannot read
+  // cannot contain manifests they could scan anyway, so skip it instead of
+  // aborting the whole `socket fix` / `socket scan` run. Negated patterns are
+  // dropped — for a discovery walk they could only re-include a subtree (never
+  // prevent a crash), and fast-glob treats `!` ignore entries inconsistently.
   const gitIgnoreStream = fastGlob.globStream(['**/.gitignore'], {
     absolute: true,
     cwd,
     dot: true,
-    ignore: DEFAULT_IGNORE_FOR_GIT_IGNORE,
+    ignore: [
+      ...DEFAULT_IGNORE_FOR_GIT_IGNORE,
+      ...projectIgnoreGlobs,
+      ...cliMinimatchIgnores,
+    ]
+      .filter(p => p.charCodeAt(0) !== 33 /*'!'*/)
+      .map(stripTrailingSlash),
+    suppressErrors: true,
   })
   for await (const ignorePatterns of transform(
     gitIgnoreStream,
@@ -273,13 +298,6 @@ export async function globWithGitIgnore(
     }
   }
 
-  // CLI-supplied `additionalIgnores` are already anchored minimatch — they
-  // must not pass through the `ignore` package (whose gitignore "match
-  // anywhere" semantics would re-interpret a bare `tests` to match
-  // `subdir/tests/foo.json`). Keep them in fast-glob's ignore list across
-  // both paths; only gitignore-translated entries go into the `ig` matcher.
-  const cliMinimatchIgnores = additionalIgnores ?? []
-
   const globOptions = {
     __proto__: null,
     absolute: true,
@@ -288,6 +306,10 @@ export async function globWithGitIgnore(
     ignore: hasNegatedPattern
       ? [...defaultIgnore, ...cliMinimatchIgnores]
       : [...ignores, ...cliMinimatchIgnores].map(stripTrailingSlash),
+    // Skip directories the running user cannot read rather than aborting the
+    // whole walk on the first `EACCES` (see the .gitignore discovery walk
+    // above for the full rationale).
+    suppressErrors: true,
     ...additionalOptions,
   } as GlobOptions
 

--- a/src/utils/glob.test.mts
+++ b/src/utils/glob.test.mts
@@ -1,4 +1,13 @@
-import { existsSync, readdirSync, rmSync } from 'node:fs'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -269,6 +278,49 @@ describe('glob utilities', () => {
         `${mockFixturePath}/package.json`,
       ])
     })
+
+    // Reproduces the reported `socket fix` crash: a project containing a
+    // directory the running user cannot enter (e.g. a postgres `pgdata` dir
+    // owned by another uid, mode drwx------) made fast-glob throw
+    // `EACCES: permission denied, scandir` during manifest discovery. Uses the
+    // real filesystem because mock-fs only enforces permissions for non-root
+    // uids; skipped under root (perm checks bypassed) and on Windows (no POSIX
+    // directory perms).
+    const skipUnreadableDirTest =
+      process.platform === 'win32' ||
+      (typeof process.getuid === 'function' && process.getuid() === 0)
+    it.skipIf(skipUnreadableDirTest)(
+      'skips an unreadable directory instead of throwing EACCES',
+      async () => {
+        const realTmp = mkdtempSync(path.join(tmpdir(), 'socket-glob-perm-'))
+        const unreadable = path.join(realTmp, 'data/postgres/pgdata')
+        try {
+          mkdirSync(unreadable, { recursive: true })
+          writeFileSync(path.join(realTmp, 'package.json'), '{}')
+          // Files inside the directory must never surface — the user cannot
+          // read them, so they cannot be scanned.
+          writeFileSync(path.join(unreadable, 'PG_VERSION'), '17')
+          // drwx------ : owner-only, and the running test user is not the owner
+          // in the field report; locally dropping all bits has the same effect
+          // of making scandir fail for the current user.
+          chmodSync(unreadable, 0o000)
+
+          const results = await globWithGitIgnore(['**/*'], {
+            cwd: realTmp,
+          })
+
+          expect(results.map(normalizePath)).toEqual([
+            normalizePath(path.join(realTmp, 'package.json')),
+          ])
+        } finally {
+          // Restore perms so recursive cleanup can descend into the locked dir.
+          try {
+            chmodSync(unreadable, 0o755)
+          } catch {}
+          rmSync(realTmp, { force: true, recursive: true })
+        }
+      },
+    )
   })
 
   describe('createSupportedFilesFilter()', () => {


### PR DESCRIPTION
## Problem

`socket fix` (and `socket scan create` / `socket scan reach`) crash with

```
✖  Unexpected error:  EACCES: permission denied, scandir '.../data/postgres/pgdata'
```

when the project contains a directory the running user cannot enter — e.g. a postgres `pgdata` data directory owned by another uid (mode `drwx------`), or an unreadable Docker volume mount.

#1339 added `--exclude-paths` (and `socket.yml` `projectIgnorePaths` already existed) specifically to skip such directories, but **neither worked** — the command crashed identically even with the path excluded.

## Root cause

`globWithGitIgnore` (`src/utils/glob.mts`) runs **two** fast-glob walks:

1. a **`.gitignore` discovery walk** (`fastGlob.globStream(['**/.gitignore'], …)`) to build the ignore set, then
2. the main package-file walk.

`--exclude-paths` (`additionalIgnores`) and `projectIgnorePaths` were only ever applied to walk **2**. Walk **1** runs **first** with just the default ignore list, so it `scandir`s straight into the unreadable directory and throws before any user exclusion can take effect. That's why excluding the path didn't help.

Verified empirically with a reproduction (`chmod 000` dir): the discovery walk throws `EACCES`; the main walk *with* the exclude succeeds (the #1339 fix is correct, just unreachable); both walks with `suppressErrors` succeed.

## Fix

In `globWithGitIgnore`:

1. **Thread `projectIgnorePaths` + `--exclude-paths` into the `.gitignore` discovery walk** (negations dropped — for a discovery walk they could only re-include a subtree) so explicit exclusions govern the *entire* discovery, as the flag documents.
2. **`suppressErrors: true` on both walks** — a directory the user cannot read cannot contain manifests they could scan anyway, so skip it instead of aborting the whole run. This makes the tool robust **without requiring any flag**.

## Test

New regression test in `src/utils/glob.test.mts` reproduces the scenario with a **real** `chmod 000` directory (skipped under root, where perm checks are bypassed, and on Windows). It fails with the exact `EACCES … scandir` before the fix and passes after.

## Release

Cuts **1.1.112** (`package.json` + `CHANGELOG.md`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared file-walking used by fix and scan; suppressErrors could mask rare filesystem errors, but scope is limited to skipping unreadable paths users could not scan anyway.
> 
> **Overview**
> **v1.1.112** fixes manifest discovery so `socket fix` and `socket scan create` no longer die on `EACCES: permission denied, scandir` when the repo contains directories the current user cannot read (e.g. Postgres `pgdata`, Docker volume mounts).
> 
> `globWithGitIgnore` runs a separate walk to find `**/.gitignore` before the main file walk. **`--exclude-paths`** and **`socket.yml` `projectIgnorePaths`** were only applied to the main walk, so the discovery walk could still enter an unreadable tree and abort before exclusions took effect. The PR applies the same ignore patterns to the discovery walk (dropping negated `!` patterns there) and sets **`suppressErrors: true`** on both walks so unreadable directories are skipped instead of failing the whole command.
> 
> A POSIX integration test uses a real `chmod 000` directory (skipped on Windows and as root).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21c777078bbe0e9feb0b3fabe67a36f3ca09bd6f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->