### PR TITLE
fix: require fixes:list scope for socket fix

### DIFF
--- a/requirements.json
+++ b/requirements.json
@@ -10,7 +10,7 @@
     },
     "fix": {
       "quota": 101,
-      "permissions": ["full-scans:create", "packages:list"]
+      "permissions": ["full-scans:create", "packages:list", "fixes:list"]
     },
     "login": {
       "quota": 1,

--- a/src/commands/fix/cmd-fix.integration.test.mts
+++ b/src/commands/fix/cmd-fix.integration.test.mts
@@ -160,7 +160,7 @@ describe('socket fix', async () => {
 
           API Token Requirements
             - Quota: 101 units
-            - Permissions: full-scans:create and packages:list
+            - Permissions: fixes:list, full-scans:create, and packages:list
 
           Options
             --all               Process all discovered vulnerabilities in local mode. Cannot be used with --id.


### PR DESCRIPTION
## Summary

`socket fix` resolves vulnerabilities via the Coana CLI, which now calls the scoped `GET /v0/orgs/{org}/fixes` endpoint. Coana switched to this endpoint from the unscoped legacy `POST /v0/fixes/compute-fixes` in **15.1.1**. The scoped endpoint requires the `fixes:list` API token scope, but `requirements.json` only advertised `full-scans:create` and `packages:list`.

The result: a token granted exactly the documented scopes hit a **403 Forbidden** on `socket fix` (ENG-5090). The legacy endpoint needed no scope, so this surfaced as a regression once Coana moved to the scoped route.

## Changes

- `requirements.json` — add `fixes:list` to the `fix` command's advertised permissions. This is the canonical source for both `socket fix --help` (via `getFlagApiRequirementsOutput`) and the docs.socket.dev page.
- `src/commands/fix/cmd-fix.integration.test.mts` — update the `--help` inline snapshot to match the regenerated "API Token Requirements" block.

Regenerated `socket fix --help` block:

```
  API Token Requirements
    - Quota: 101 units
    - Permissions: fixes:list, full-scans:create, and packages:list
```

## Testing

`pnpm test:unit src/commands/fix/cmd-fix.integration.test.mts` — the `should support --help` snapshot test passes. (Two unrelated live-network tests in the same file fail in this offline environment; they assert on network error strings and don't touch the permissions array.)

## Related

Part of ENG-5090. Companion changes: the docs.socket.dev `socket-fix` page (advertised scopes) and the Coana CLI (surface the 403 response body so missing-scope errors are diagnosable).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test snapshot only; no runtime auth or fix logic changes in this diff.
> 
> **Overview**
> Documents that **`socket fix`** needs the **`fixes:list`** API token scope, matching Coana’s use of the scoped **`GET /v0/orgs/{org}/fixes`** route (replacing the unscoped legacy compute-fixes API).
> 
> **`requirements.json`** adds **`fixes:list`** to the **`fix`** entry’s **`permissions`** array (alongside **`full-scans:create`** and **`packages:list`**). That list drives **`socket fix --help`** “API Token Requirements” and external docs sourced from the same file.
> 
> **`cmd-fix.integration.test.mts`** updates the **`--help`** inline snapshot so the advertised permissions line includes **`fixes:list`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 805e9ac89f989fd8c92c61d724ba500d5c5f593b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->