### PR TITLE
fix(manifest): stream Coana output and surface the real failure reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.115](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.115) - 2026-06-04
+
+### Fixed
+- `socket manifest gradle`, `kotlin`, and `scala` (including sbt-based projects) now stream the underlying build-tool and Coana output and surface the real failure reason. Previously a generation failure could collapse to an unhelpful `Coana command failed (exit code 1): command failed` with no detail, hiding actionable hints such as unresolved dependencies (re-run with `--ignore-unresolved` / `--exclude-configs`, or `--pom` for the legacy `pom.xml` output).
+
 ## [1.1.114](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.114) - 2026-06-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.114",
+  "version": "1.1.115",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",

--- a/src/utils/dlx.mts
+++ b/src/utils/dlx.mts
@@ -502,7 +502,7 @@ export async function spawnCoanaDlx(
     }
 
     logger.warn(
-      'Coana dlx invocation failed before Coana started; falling back to `npm install` + `node`.',
+      'Coana dlx invocation failed; retrying via `npm install` + `node`.',
     )
 
     const fallbackResult = await spawnCoanaViaNpmInstall(
@@ -618,14 +618,18 @@ function buildDlxErrorResult(e: unknown): CResult<string> {
   // Be honest about WHERE the failure happened. On the dlx path the spawned
   // process is the package-manager launcher (npx / pnpm dlx / yarn dlx), which
   // downloads @coana-tech/cli and only then runs it — so a failure may be the
-  // launcher dying before Coana ever started (e.g. the package failed to
-  // download), not Coana itself. Asserting "Coana command failed" in that case
-  // is misleading.
+  // launcher dying before Coana ever started, not Coana itself. We can only be
+  // CERTAIN of that for a spawn-level error (a string `code` like ENOENT: the
+  // launcher binary could not start, so Coana provably never ran). A non-zero
+  // exit or signal is genuinely ambiguous — Coana may have started, streamed
+  // output, and then died (e.g. OOM), or the launcher may have failed to fetch
+  // the package — and with inherited stdio there is no captured output to tell
+  // them apart, so we must not assert either way.
   let message: string
   if (coanaBannerSeen(e)) {
     message = `Coana command failed${detailSuffix}: ${detail}`
-  } else if (dlxLauncherFailedBeforeCoana(e)) {
-    message = `Failed to launch Coana via the package manager${detailSuffix} — the npx/pnpm-dlx/yarn-dlx launcher exited before Coana started (the package may have failed to download): ${detail}`
+  } else if (typeof (e as any)?.code === 'string') {
+    message = `Failed to launch Coana via the package manager${detailSuffix} — the npx/pnpm-dlx/yarn-dlx launcher could not start (e.g. it is missing from PATH): ${detail}`
   } else {
     message = `Coana failed to run via the package manager${detailSuffix}: ${detail}`
   }

--- a/src/utils/dlx.mts
+++ b/src/utils/dlx.mts
@@ -466,7 +466,12 @@ export async function spawnCoanaDlx(
       args,
       {
         force: true,
-        silent: true,
+        // Do NOT silence the launcher. `--silent` (npm loglevel silent) hides
+        // npm's own download/registry/launch errors, so when npx/pnpm-dlx fails
+        // to fetch @coana-tech/cli the user is left with a bare exit code and no
+        // cause. shadowNpmBase defaults to `--loglevel error`, which keeps real
+        // launcher errors visible while staying quiet on success.
+        silent: false,
         ...dlxOptions,
         ...(requestedStdio === undefined ? {} : { stdio: requestedStdio }),
         env: finalEnv,
@@ -539,10 +544,29 @@ export async function spawnCoanaDlx(
  *    rather than blindly re-running Coana.
  */
 function shouldFallbackOnDlxError(e: unknown): boolean {
-  const capturedStderr = String((e as any)?.stderr ?? '')
-  if (capturedStderr && /Coana CLI version/i.test(capturedStderr)) {
+  // Coana clearly ran (its banner is in the captured stderr) → any later
+  // non-zero exit is a real Coana failure and retrying would hit it again.
+  if (coanaBannerSeen(e)) {
     return false
   }
+  return dlxLauncherFailedBeforeCoana(e)
+}
+
+/**
+ * Heuristic: did the dlx launcher (npx / pnpm dlx / yarn dlx) fail BEFORE the
+ * Coana process itself started? True for spawn-level errors (a string `code`
+ * like ENOENT), signal kills, and exit codes >= 128 (conventionally
+ * signal-derived) — all cases where the launcher, not Coana, is the culprit
+ * (e.g. npx missing from PATH, or @coana-tech/cli failing to download). A small
+ * integer exit code is deliberately NOT treated as a launch failure: Coana's
+ * own exit codes are small integers too, so it is genuinely ambiguous.
+ *
+ * Caveat: a launcher that fails to download the package can also exit with a
+ * small integer (npm/npx often exit 1), which lands in the ambiguous bucket.
+ * We cannot disambiguate those from a real Coana exit without inspecting the
+ * launcher's output, so the npm-install fallback does not fire for them.
+ */
+function dlxLauncherFailedBeforeCoana(e: unknown): boolean {
   const code = (e as any)?.code
   // Spawn-level failure (e.g. ENOENT when npx is missing from PATH).
   if (typeof code === 'string') {
@@ -554,10 +578,18 @@ function shouldFallbackOnDlxError(e: unknown): boolean {
   }
   // Exit codes >= 128 are conventionally signal-derived, and the observed
   // npx-launcher failures in the wild fall into this range (e.g. 249, 254).
-  if (typeof code === 'number' && code >= 128) {
-    return true
-  }
-  return false
+  return typeof code === 'number' && code >= 128
+}
+
+/**
+ * Definitive proof Coana actually booted: its startup banner appears in the
+ * captured stderr. Only available when the launcher's output was piped
+ * (captured); with inherited stdio there is nothing to inspect, so this
+ * returns false (the failure is then classified by exit code / signal alone).
+ */
+function coanaBannerSeen(e: unknown): boolean {
+  const capturedStderr = String((e as any)?.stderr ?? '')
+  return !!capturedStderr && /Coana CLI version/i.test(capturedStderr)
 }
 
 /**
@@ -582,10 +614,21 @@ function buildDlxErrorResult(e: unknown): CResult<string> {
   // logs some failures (e.g. unresolved Gradle dependencies) to stdout, so
   // without the stdout fallback a piped failure collapsed to an unhelpful
   // "command failed" even when the real reason was captured.
-  const captured = stderr || stdout
-  const message = captured
-    ? `Coana command failed${detailSuffix}: ${captured}`
-    : `Coana command failed${detailSuffix}: ${cause}`
+  const detail = stderr || stdout || cause
+  // Be honest about WHERE the failure happened. On the dlx path the spawned
+  // process is the package-manager launcher (npx / pnpm dlx / yarn dlx), which
+  // downloads @coana-tech/cli and only then runs it — so a failure may be the
+  // launcher dying before Coana ever started (e.g. the package failed to
+  // download), not Coana itself. Asserting "Coana command failed" in that case
+  // is misleading.
+  let message: string
+  if (coanaBannerSeen(e)) {
+    message = `Coana command failed${detailSuffix}: ${detail}`
+  } else if (dlxLauncherFailedBeforeCoana(e)) {
+    message = `Failed to launch Coana via the package manager${detailSuffix} — the npx/pnpm-dlx/yarn-dlx launcher exited before Coana started (the package may have failed to download): ${detail}`
+  } else {
+    message = `Coana failed to run via the package manager${detailSuffix}: ${detail}`
+  }
   return {
     ok: false,
     data: e,

--- a/src/utils/dlx.mts
+++ b/src/utils/dlx.mts
@@ -444,6 +444,18 @@ export async function spawnCoanaDlx(
     )
   }
 
+  // `shadowNpmBase` (the dlx launcher) configures the child's stdio from its
+  // `options` arg, NOT from the registry-spawn `extra` arg — the latter only
+  // attaches metadata to the result. Callers that requested streaming via
+  // `spawnExtra` (the 4th arg), e.g. `{ stdio: 'inherit' }` from
+  // `socket manifest gradle`, were therefore silently ignored on this path:
+  // Coana ran piped and its output — including the real failure reason — never
+  // reached the user, leaving only an unhelpful "command failed". Promote the
+  // requested stdio into the dlx options so it is honored here too.
+  // `spawnCoanaScriptViaNode` already reads `spawnExtra.stdio` for the
+  // local-path and npm-install branches, so this aligns all three paths.
+  const requestedStdio = spawnExtra?.['stdio'] ?? getOwn(dlxOptions, 'stdio')
+
   try {
     // Use npm/dlx version.
     const result = await spawnDlx(
@@ -456,6 +468,7 @@ export async function spawnCoanaDlx(
         force: true,
         silent: true,
         ...dlxOptions,
+        ...(requestedStdio === undefined ? {} : { stdio: requestedStdio }),
         env: finalEnv,
         ipc: {
           [constants.SOCKET_CLI_SHADOW_ACCEPT_RISKS]: true,
@@ -553,6 +566,7 @@ function shouldFallbackOnDlxError(e: unknown): boolean {
  */
 function buildDlxErrorResult(e: unknown): CResult<string> {
   const stderr = (e as any)?.stderr
+  const stdout = (e as any)?.stdout
   const exitCode = (e as any)?.code
   const signal = (e as any)?.signal
   const cause = getErrorCause(e)
@@ -564,8 +578,13 @@ function buildDlxErrorResult(e: unknown): CResult<string> {
     details.push(`signal ${signal}`)
   }
   const detailSuffix = details.length ? ` (${details.join(', ')})` : ''
-  const message = stderr
-    ? `Coana command failed${detailSuffix}: ${stderr}`
+  // Prefer captured stderr, then stdout, then the generic spawn error. Coana
+  // logs some failures (e.g. unresolved Gradle dependencies) to stdout, so
+  // without the stdout fallback a piped failure collapsed to an unhelpful
+  // "command failed" even when the real reason was captured.
+  const captured = stderr || stdout
+  const message = captured
+    ? `Coana command failed${detailSuffix}: ${captured}`
     : `Coana command failed${detailSuffix}: ${cause}`
   return {
     ok: false,

--- a/src/utils/dlx.test.mts
+++ b/src/utils/dlx.test.mts
@@ -355,7 +355,10 @@ describe('utils/dlx', () => {
       })
 
       expect(result.ok).toBe(false)
-      expect(result.message).toContain('Failed to launch Coana')
+      // exit 249 is ambiguous, so the message stays neutral about launcher-vs-Coana.
+      expect(result.message).toContain(
+        'Coana failed to run via the package manager',
+      )
       // No npm install was attempted.
       const npmInstallCalls = mockSpawn.mock.calls.filter(
         ([cmd, args]) => cmd === 'npm' && (args as string[])[0] === 'install',
@@ -396,7 +399,9 @@ describe('utils/dlx', () => {
       })
 
       expect(result.ok).toBe(false)
-      expect(result.message).toContain('Failed to launch Coana')
+      expect(result.message).toContain(
+        'Coana failed to run via the package manager',
+      )
       expect(result.message).toContain('npx aborted')
       expect(result.message).toContain('npm-install fallback also failed')
       expect(result.message).toContain('registry unreachable')
@@ -426,11 +431,11 @@ describe('utils/dlx', () => {
       expect(npmInstallCalls).toHaveLength(0)
     })
 
-    it('reports a launch failure (not a Coana failure) when the launcher dies before Coana starts', async () => {
-      // npx aborts (exit 249) before Coana boots and there is no Coana banner.
-      // Disable the fallback so the dlx error itself is surfaced.
+    it('reports a definitive launch failure for a spawn-level error (the launcher could not start)', async () => {
+      // ENOENT: the launcher binary (npx) is missing from PATH, so Coana
+      // provably never ran. Disable the fallback so the dlx error is surfaced.
       process.env['SOCKET_CLI_COANA_DISABLE_NPM_FALLBACK'] = '1'
-      setDlxRejection({ code: 249, stderr: 'npx aborted' })
+      setDlxRejection({ code: 'ENOENT' })
 
       const result = await spawnCoanaDlx(['manifest', 'gradle', '.'], 'acme', {
         coanaVersion: nextVersion(),
@@ -438,8 +443,28 @@ describe('utils/dlx', () => {
 
       expect(result.ok).toBe(false)
       expect(result.message).toContain('Failed to launch Coana')
-      expect(result.message).toContain('before Coana started')
+      expect(result.message).toContain('could not start')
       expect(result.message).not.toContain('Coana command failed')
+    })
+
+    it('does NOT claim a launch failure for an ambiguous signal/high exit code (Coana may have started)', async () => {
+      // exit 137 (OOM-style) is ambiguous: Coana may have started, streamed
+      // output, and been killed — or the launcher may have failed. The message
+      // must not assert either way. Disable the fallback so it is surfaced.
+      process.env['SOCKET_CLI_COANA_DISABLE_NPM_FALLBACK'] = '1'
+      setDlxRejection({ code: 137 })
+
+      const result = await spawnCoanaDlx(['manifest', 'gradle', '.'], 'acme', {
+        coanaVersion: nextVersion(),
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('exit code 137')
+      expect(result.message).toContain(
+        'Coana failed to run via the package manager',
+      )
+      expect(result.message).not.toContain('Failed to launch Coana')
+      expect(result.message).not.toContain('before Coana started')
     })
 
     it('does NOT fall back when captured stderr shows Coana booted', async () => {

--- a/src/utils/dlx.test.mts
+++ b/src/utils/dlx.test.mts
@@ -355,7 +355,7 @@ describe('utils/dlx', () => {
       })
 
       expect(result.ok).toBe(false)
-      expect(result.message).toContain('Coana command failed')
+      expect(result.message).toContain('Failed to launch Coana')
       // No npm install was attempted.
       const npmInstallCalls = mockSpawn.mock.calls.filter(
         ([cmd, args]) => cmd === 'npm' && (args as string[])[0] === 'install',
@@ -396,7 +396,7 @@ describe('utils/dlx', () => {
       })
 
       expect(result.ok).toBe(false)
-      expect(result.message).toContain('Coana command failed')
+      expect(result.message).toContain('Failed to launch Coana')
       expect(result.message).toContain('npx aborted')
       expect(result.message).toContain('npm-install fallback also failed')
       expect(result.message).toContain('registry unreachable')
@@ -413,11 +413,33 @@ describe('utils/dlx', () => {
 
       expect(result.ok).toBe(false)
       expect(result.message).toContain('exit code 1')
+      // A small-int exit is ambiguous (could be Coana, or a launcher/download
+      // failure exiting 1), so the message must not assert Coana itself failed.
+      expect(result.message).not.toContain('Coana command failed')
+      expect(result.message).toContain(
+        'Coana failed to run via the package manager',
+      )
       // No npm install was attempted.
       const npmInstallCalls = mockSpawn.mock.calls.filter(
         ([cmd, args]) => cmd === 'npm' && (args as string[])[0] === 'install',
       )
       expect(npmInstallCalls).toHaveLength(0)
+    })
+
+    it('reports a launch failure (not a Coana failure) when the launcher dies before Coana starts', async () => {
+      // npx aborts (exit 249) before Coana boots and there is no Coana banner.
+      // Disable the fallback so the dlx error itself is surfaced.
+      process.env['SOCKET_CLI_COANA_DISABLE_NPM_FALLBACK'] = '1'
+      setDlxRejection({ code: 249, stderr: 'npx aborted' })
+
+      const result = await spawnCoanaDlx(['manifest', 'gradle', '.'], 'acme', {
+        coanaVersion: nextVersion(),
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('Failed to launch Coana')
+      expect(result.message).toContain('before Coana started')
+      expect(result.message).not.toContain('Coana command failed')
     })
 
     it('does NOT fall back when captured stderr shows Coana booted', async () => {
@@ -577,6 +599,18 @@ describe('utils/dlx', () => {
         stdio?: unknown
       }
       expect(launcherOptions.stdio).toBe('inherit')
+    })
+
+    it('does not pass --silent to the launcher (so npm download/launch errors surface)', async () => {
+      // `--silent` (npm loglevel silent) would hide the very download/registry
+      // errors that explain why npx failed to launch Coana.
+      const result = await spawnCoanaDlx(['manifest', 'gradle', '.'], 'acme', {
+        coanaVersion: nextVersion(),
+      })
+
+      expect(result.ok).toBe(true)
+      const launcherArgs = mockDlxBin.mock.calls[0]![0] as string[]
+      expect(launcherArgs).not.toContain('--silent')
     })
 
     it('forwards options.stdio into the dlx launcher options', async () => {

--- a/src/utils/dlx.test.mts
+++ b/src/utils/dlx.test.mts
@@ -518,4 +518,101 @@ describe('utils/dlx', () => {
       }
     })
   })
+
+  describe('spawnCoanaDlx stdio + error surfacing', () => {
+    let mockDlxBin: ReturnType<typeof vi.fn>
+    let testCounter = 0
+
+    // Exact-pinned versions so the dlx silent/force defaults stay deterministic
+    // and each test stays clear of the module-level install cache.
+    const nextVersion = () => `98.0.${testCounter++}`
+
+    beforeEach(() => {
+      delete process.env['SOCKET_CLI_COANA_FORCE_NPM_INSTALL']
+      delete process.env['SOCKET_CLI_COANA_DISABLE_NPM_FALLBACK']
+      delete process.env['SOCKET_CLI_COANA_LOCAL_PATH']
+
+      // The dlx launcher succeeds by default. spawnDlx picks the shadow bin by
+      // lockfile, so wire all three (npm/pnpm/yarn) to the same mock.
+      mockDlxBin = vi.fn().mockImplementation(async () => ({
+        spawnPromise: Promise.resolve({ stdout: 'coana-ok', stderr: '' }),
+      }))
+      for (const binPath of [
+        constants.shadowNpxBinPath,
+        constants.shadowPnpmBinPath,
+        constants.shadowYarnBinPath,
+      ]) {
+        // @ts-ignore
+        require.cache[binPath] = { exports: mockDlxBin }
+      }
+    })
+
+    afterEach(() => {
+      for (const binPath of [
+        constants.shadowNpxBinPath,
+        constants.shadowPnpmBinPath,
+        constants.shadowYarnBinPath,
+      ]) {
+        // @ts-ignore
+        delete require.cache[binPath]
+      }
+    })
+
+    it('forwards spawnExtra.stdio into the dlx launcher options (regression)', async () => {
+      // `socket manifest gradle` passes `{ stdio: 'inherit' }` as spawnExtra so
+      // Coana's gradle output streams to the user. Before the fix this was
+      // dropped — the launcher reads stdio from its options, not the registry
+      // spawn `extra` arg — so Coana ran piped and the real failure reason was
+      // hidden behind a bare "command failed".
+      const result = await spawnCoanaDlx(
+        ['manifest', 'gradle', '.'],
+        'acme',
+        { coanaVersion: nextVersion() },
+        { stdio: 'inherit' },
+      )
+
+      expect(result.ok).toBe(true)
+      expect(mockDlxBin).toHaveBeenCalledTimes(1)
+      const launcherOptions = mockDlxBin.mock.calls[0]![1] as {
+        stdio?: unknown
+      }
+      expect(launcherOptions.stdio).toBe('inherit')
+    })
+
+    it('forwards options.stdio into the dlx launcher options', async () => {
+      const result = await spawnCoanaDlx(['run', '.'], 'acme', {
+        coanaVersion: nextVersion(),
+        stdio: 'inherit',
+      })
+
+      expect(result.ok).toBe(true)
+      const launcherOptions = mockDlxBin.mock.calls[0]![1] as {
+        stdio?: unknown
+      }
+      expect(launcherOptions.stdio).toBe('inherit')
+    })
+
+    it('surfaces captured stdout when stderr is empty (Coana logs some failures to stdout)', async () => {
+      mockDlxBin.mockReset()
+      mockDlxBin.mockImplementation(async () => {
+        const rejected = Promise.reject(
+          Object.assign(new Error('command failed'), {
+            code: 1,
+            stdout: 'error: Could not resolve 1 dependency(ies)',
+            stderr: '',
+          }),
+        )
+        rejected.catch(() => {})
+        return { spawnPromise: rejected }
+      })
+
+      const result = await spawnCoanaDlx(['manifest', 'gradle', '.'], 'acme', {
+        coanaVersion: nextVersion(),
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('exit code 1')
+      expect(result.message).toContain('Could not resolve 1 dependency(ies)')
+    })
+  })
 })


### PR DESCRIPTION
## Problem

`socket manifest gradle .` (and `kotlin`/`scala`) can fail in CI with:

```
✖ Coana command failed (exit code 1): command failed
```

…with **no Coana/gradle output** and no indication of *why* it failed — and, as it turns out, no guarantee that "Coana" is even what failed.

Since #1352 (CLI 1.1.114), `socket manifest {gradle,kotlin,scala}` (the latter including sbt-based projects) delegate Socket facts generation to the Coana CLI via `spawnCoanaDlx`, passing `{ stdio: 'inherit' }` so the build-tool and Coana output streams to the terminal.

### Bug 1 — the requested stdio was dropped

On the **dlx path** (the default in CI) that `stdio` was silently dropped:

- `runCoanaManifestFacts` passes `{ stdio: 'inherit' }` as the **4th arg** (`spawnExtra`).
- `shadowNpmBase` configures the child's stdio from its **`options`** arg, not the registry-spawn **`extra`** arg (which only attaches metadata to the result — confirmed in `@socketsecurity/registry`).
- So Coana ran with the default piped stdio (`['pipe','pipe','pipe','ipc']`), its output never reached the terminal, and a real failure collapsed to `Coana command failed (exit code 1): command failed`.

It's a "works on my machine" bug: the `SOCKET_CLI_COANA_LOCAL_PATH` and npm-install fallback branches go through `spawnCoanaScriptViaNode`, which *does* read `spawnExtra.stdio`, so local testing showed full output. Only the real dlx path hid it.

### Bug 2 — the error blamed Coana, and the launcher was muzzled

On the dlx path the spawned process is the **package-manager launcher** (`npx` / `pnpm dlx` / `yarn dlx`), which downloads `@coana-tech/cli` and *only then* runs it. So a failure can be the launcher dying **before Coana ever started** (registry/network error, 404/auth, `ENOENT`). But `buildDlxErrorResult` unconditionally said `Coana command failed`, and `spawnCoanaDlx` forced `--silent` (npm loglevel silent), which **hid npm's own download/launch errors**. The result: a bare exit code, no cause, and a message that wrongly blamed Coana for something that may have failed before Coana ran.

The underlying exit-1 trigger is project-specific — most commonly an **unresolved Gradle dependency**, which facts generation treats as fatal (the legacy `--pom` default did not). Reproduced locally: `coana manifest gradle` on a project with an unresolvable dep exits 1, writes no facts file, and prints a `--ignore-unresolved` / `--exclude-configs` hint — all of which were being swallowed.

## Fix

- **stdio is honored on the dlx path.** `spawnCoanaDlx` now promotes the requested stdio (from `spawnExtra`, falling back to `options`) into the dlx launcher options, aligning the dlx path with the local-path and npm-install branches. No behavior change for callers that pass `stdio: 'pipe'` via `spawnExtra` (e.g. `socket fix`) — the default was already pipe.
- **Launcher is no longer muzzled.** Dropped the forced `--silent` on the Coana launcher; `shadowNpmBase` still defaults to `--loglevel error`, so real download/launch errors surface while success stays quiet.
- **Honest failure messages.** `buildDlxErrorResult` only claims a *launch* failure when it is **certain** — a spawn-level error (a string `code` like `ENOENT`, where the launcher binary could not start, so Coana provably never ran) → `Failed to launch Coana via the package manager … the launcher could not start`. A non-zero exit or signal is genuinely ambiguous (Coana may have started and died, e.g. OOM, or the launcher may have failed to download), so it gets neutral wording → `Coana failed to run via the package manager (exit code N)`. Only a captured Coana banner yields `Coana command failed`. It also falls back to captured **stdout** when stderr is empty, since Coana logs some failures to stdout.

## Related: the npx-launcher fallback (#1327)

#1327 added an `npm install` + `node` fallback for when the dlx launcher fails *before* Coana starts. That fallback is shared by this path; `shouldFallbackOnDlxError` fires it for spawn errors (`ENOENT`), signals, or exit codes **≥ 128** — **not** for a small-integer exit. A broken `npx` that exits `1` (common for npm download failures) is therefore *not* auto-recovered today.

So this could be the same broken-npx problem as #1327, just a manifestation the gate misses. This PR makes that case **diagnosable** (the npm error is now visible and the message no longer blames Coana), but does not change the fallback gating.

## Review note (Cursor Bugbot)

Bugbot flagged that with `stdio: 'inherit'` the spawn rejection carries no captured output, so the `Coana CLI version` banner check is always false and a Coana process that *started* then died by signal/exit ≥ 128 (e.g. OOM, exit 137) could be reported as a launcher failure. Confirmed empirically that `coana manifest gradle` writes everything to **stdout** and never prints that banner, so banner-based detection never worked for the inherit paths regardless. The fix above addresses the reported harm by **only asserting a launch failure for a definitive spawn-level error** and staying neutral for ambiguous signal/exit codes (and dropping the matching "before Coana started" wording from the fallback warning).

The fallback *retry* on signal/exit ≥ 128 is unchanged, pre-existing #1327 behavior. Reliably suppressing a retry when Coana actually ran would require capturing the launcher output to disambiguate, which conflicts with live streaming (and the reachability spinner) — a possible follow-up, not done here.

## Tests

- `dlx.test.mts`: `spawnExtra.stdio` / `options.stdio` are forwarded into the launcher options; `--silent` is no longer passed; definitive (ENOENT) vs ambiguous (signal / ≥ 128) messages are asserted; `buildDlxErrorResult` surfaces stdout when stderr is empty.
- `pnpm check:tsc`, `eslint`, and the manifest + reachability + fix suites pass.

## Workaround (pre-fix)

Re-run with `--ignore-unresolved` / `--exclude-configs=…`, or `--pom` to restore the legacy `pom.xml` output.
