### PR TITLE
fix(ci): resolve default org by slug, not display name

### DIFF
--- a/src/commands/ci/fetch-default-org-slug.mts
+++ b/src/commands/ci/fetch-default-org-slug.mts
@@ -45,7 +45,11 @@ export async function getDefaultOrgSlug(
     }
   }
 
-  const slug = (organizations as any)[keys[0]!]?.name ?? undefined
+  // Use the org's URL-safe `slug`, not its display `name`: this value is
+  // exported as SOCKET_ORG_SLUG for the Coana CLI, which resolves the org by
+  // slug. `name` is the human-readable display name (and may be null), so using
+  // it here produced a wrong/empty org identifier.
+  const slug = organizations[0]?.slug ?? undefined
   if (!slug) {
     return {
       ok: false,

--- a/src/commands/ci/fetch-default-org-slug.test.mts
+++ b/src/commands/ci/fetch-default-org-slug.test.mts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getDefaultOrgSlug } from './fetch-default-org-slug.mts'
+import { fetchOrganization } from '../organization/fetch-organization-list.mts'
+import { getConfigValueOrUndef } from '../../utils/config.mts'
+
+vi.mock('../organization/fetch-organization-list.mts', () => ({
+  fetchOrganization: vi.fn(),
+}))
+vi.mock('../../utils/config.mts', () => ({
+  getConfigValueOrUndef: vi.fn(() => undefined),
+}))
+// Keep SOCKET_CLI_ORG_SLUG unset so the resolver falls through to the API path.
+vi.mock('../../constants.mts', () => ({
+  default: { ENV: {} },
+}))
+
+describe('getDefaultOrgSlug', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getConfigValueOrUndef).mockReturnValue(undefined)
+  })
+
+  it('resolves the org slug (not the display name) from the API', async () => {
+    vi.mocked(fetchOrganization).mockResolvedValue({
+      ok: true,
+      data: {
+        organizations: [
+          {
+            id: 'org-id',
+            name: 'Display Name',
+            image: null,
+            plan: 'free',
+            slug: 'my-org-slug',
+          },
+        ],
+      },
+    } as any)
+
+    const result = await getDefaultOrgSlug()
+
+    expect(result.ok).toBe(true)
+    // Regression guard: must be the URL-safe slug, never the display name.
+    expect(result.ok && result.data).toBe('my-org-slug')
+  })
+
+  it('resolves the slug even when the display name is null', async () => {
+    vi.mocked(fetchOrganization).mockResolvedValue({
+      ok: true,
+      data: {
+        organizations: [
+          {
+            id: 'org-id',
+            name: null,
+            image: null,
+            plan: 'free',
+            slug: 'slug-only',
+          },
+        ],
+      },
+    } as any)
+
+    const result = await getDefaultOrgSlug()
+
+    expect(result.ok).toBe(true)
+    expect(result.ok && result.data).toBe('slug-only')
+  })
+
+  it('prefers the defaultOrg config value without calling the API', async () => {
+    vi.mocked(getConfigValueOrUndef).mockReturnValue('configured-org')
+
+    const result = await getDefaultOrgSlug()
+
+    expect(result.ok).toBe(true)
+    expect(result.ok && result.data).toBe('configured-org')
+    expect(fetchOrganization).not.toHaveBeenCalled()
+  })
+
+  it('fails when the API returns no organizations', async () => {
+    vi.mocked(fetchOrganization).mockResolvedValue({
+      ok: true,
+      data: { organizations: [] },
+    } as any)
+
+    const result = await getDefaultOrgSlug()
+
+    expect(result.ok).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem
`getDefaultOrgSlug()` exported the org's display **name** as `SOCKET_ORG_SLUG` for the Coana CLI, but Coana resolves the org by its URL-safe **slug**. The display name can differ from the slug and may be `null`, producing a wrong or empty org identifier — and a hard failure for tokens that can only ever see a single org.

This surfaced for repository-scoped tokens running `socket manifest gradle`: the org-list lookup would `403` (fixed backend-side in SocketDev/depscan#21010), and even once that call succeeds the wrong field was being forwarded to Coana.

## Fix
Use the `slug` field instead of `name`, and drop the unnecessary `as any` index. Add unit coverage:
- returns the slug (not the display name)
- resolves the slug even when the display name is `null`
- prefers the `defaultOrg` config value without calling the API
- fails when the API returns no organizations

## Related
- Backend companion (the actual `403`): SocketDev/depscan#21010

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fix to org resolution for CI env export plus tests; no auth or broad behavioral surface beyond correct slug forwarding.
> 
> **Overview**
> **Fixes wrong org identifier for Coana / CI:** `getDefaultOrgSlug()` now reads the first org’s URL-safe **`slug`** instead of its display **`name`** when building the value exported as `SOCKET_ORG_SLUG`. Display names can differ from slugs or be `null`, which previously yielded incorrect or empty org IDs for the Coana CLI (which resolves orgs by slug). Selection is simplified to `organizations[0]?.slug` on the array-shaped org list, removing the `as any` object-key/`name` path.
> 
> **Tests:** New Vitest coverage for slug vs display name, null display name, `defaultOrg` config short-circuit, and empty org list failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c0ff744f63023950e77510ade1d03cc66e229d1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->