### PR TITLE
upgrading coana to version 15.3.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.115](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.115) - 2026-06-06
+
+### Changed
+- Updated the Coana CLI to v `15.3.22`.
+
 ## [1.1.114](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.114) - 2026-06-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.114",
+  "version": "1.1.115",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT AND OFL-1.1",
@@ -96,7 +96,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "15.3.21",
+    "@coana-tech/cli": "15.3.22",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 15.3.21
-        version: 15.3.21
+        specifier: 15.3.22
+        version: 15.3.22
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@15.3.21':
-    resolution: {integrity: sha512-94KJvYRm+ouhiYpRq/sSpSZCgZNDfGYRVuocgG6PHc7Byn9qtjHXpExcsxY019wNDcM2goiLMSeEhql0FVwMBQ==}
+  '@coana-tech/cli@15.3.22':
+    resolution: {integrity: sha512-IrndpxacqZP7yux5CGT6XdfrV1PSlriBsjp0YB5ScR+y3bxZAPO6vwZ9xYfz9Mt2X3RMSI9vBjNhT184mLumjQ==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5385,7 +5385,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@15.3.21': {}
+  '@coana-tech/cli@15.3.22': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 15.3.21 to 15.3.22

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and version bump only; no Socket CLI application code changes, though Coana behavior may differ for reach/fix workloads.
> 
> **Overview**
> Bumps **Socket CLI** to **1.1.115** and pins **`@coana-tech/cli`** from **15.3.21** to **15.3.22** in `devDependencies`, with matching lockfile updates. **CHANGELOG** records the Coana upgrade; there are no Socket CLI source or command changes in this diff.
> 
> Reachability (`socket scan create --reach`, `socket scan reach`) and **`socket fix`** flows that spawn the bundled Coana CLI will run the new Coana version after release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25d420a5cfd4fa386a50e0455f32a3038c6c5fd3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->