### PR TITLE
fix(license): drop unused OFL-1.1 font from the published package

### DIFF
--- a/.config/rollup.dist.config.mjs
+++ b/.config/rollup.dist.config.mjs
@@ -121,7 +121,13 @@ async function copyExternalPackages() {
   // Cleanup package files.
   await Promise.all(
     [
-      [blessedPath, ['lib/**/*.js', 'usr/**/**', 'vendor/**/*.js']],
+      // Keep blessed's terminfo (the flat files in usr/, e.g. usr/xterm) but
+      // NOT usr/fonts/** — the OFL-1.1 Terminus bitmap font is only used by the
+      // unused BigText widget, and shipping it forces an OFL-1.1 license. The
+      // 'usr/*' glob matches one level deep, so usr/fonts/<file> is dropped.
+      // Re-verify usr/ contents on a blessed upgrade (a nested terminfo dir
+      // would be dropped too).
+      [blessedPath, ['lib/**/*.js', 'usr/*', 'vendor/**/*.js']],
       [blessedContribPath, ['lib/**/*.js', 'index.js']],
       [
         socketRegistryPath,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.117](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.117) - 2026-06-08
+
+### Changed
+- The published package no longer bundles the unused Terminus bitmap font (pulled in transitively by the vendored `blessed` dependency), so its declared license is now `MIT` instead of `MIT AND OFL-1.1`.
+
 ## [1.1.116](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.116) - 2026-06-06
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "socket",
-  "version": "1.1.116",
+  "version": "1.1.117",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
-  "license": "MIT AND OFL-1.1",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/SocketDev/socket-cli.git"


### PR DESCRIPTION
## Why

npm reports `socket` as `MIT AND OFL-1.1` even though the project's own code is MIT. The `OFL-1.1` comes from the **Terminus bitmap font** (`external/blessed/usr/fonts/ter-u14{n,b}.json`), which lands in the tarball as a byproduct of vendoring the entire `blessed` library wholesale.

The font is **dead weight**: it's read only by blessed's `BigText` widget, and the CLI never instantiates `BigText` (it uses `screen`/`box`/`table`/`grid`/`bar`/`line`, and `require`s those widget files directly — it never imports blessed's index, so `bigtext.js` isn't even loaded).

## What

- **`.config/rollup.dist.config.mjs`** — scope the blessed vendoring keep-list from `usr/**/**` to `usr/*`. This keeps the flat terminfo files (`usr/xterm`, `usr/linux`, …) that blessed actually needs, but drops `usr/fonts/**` (the OFL font + its AUTHORS/README/LICENSE). Added a comment documenting the scoping and a reminder to re-verify `usr/` on a blessed upgrade.
- **`package.json`** — `license` `MIT AND OFL-1.1` → `MIT`; version `1.1.116` → `1.1.117`.
- **`CHANGELOG.md`** — `1.1.117` entry.

`external/` is a gitignored build artifact, so no vendored files are committed — the change is the build config that regenerates it.

## Verification

- `pnpm build:dist:src` → exit 0; `socket --version` → `1.1.117`
- `external/blessed/usr/fonts/` gone; terminfo retained
- `npm pack --dry-run` publish set: no `usr/fonts`/`ter-u14`/OFL entries
- Every remaining LICENSE file in the publish set is MIT (root, blessed, blessed-contrib, @socketsecurity/registry) — so the `MIT` field now agrees with file-content scanning, not just the manifest.

## Notes / follow-ups

- After publish, re-scan `socket@1.1.117` with whatever originally flagged OFL to confirm it's cleared end-to-end.
- `external/blessed/lib/widgets/bigtext.js` is left in place (MIT, harmless dead code; ENOENT only on an explicit `new BigText()`, which never happens). Optional future cleanup.
- Publish is the manual `provenance.yml` `workflow_dispatch`, which reads `version` from `package.json` and tags `v1.1.117`.

Base branch is **`v1.x`** (the 1.x release line) — retarget if a patch should go elsewhere.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with no CLI behavior change; the only caveat is a future blessed `usr/` layout change could drop needed terminfo if not re-verified.
> 
> **Overview**
> The published **`socket`** npm package no longer ships the unused Terminus bitmap font from vendored **`blessed`** (`usr/fonts/**`, OFL-1.1). **`.config/rollup.dist.config.mjs`** tightens the blessed keep-list from `usr/**/**` to **`usr/*`**, so flat terminfo files (e.g. `usr/xterm`) still land in the tarball while nested font assets are stripped at build time; comments call out re-checking `usr/` on blessed upgrades.
> 
> **`package.json`** declares **`MIT`** only (was `MIT AND OFL-1.1`) and bumps to **1.1.117**; **`CHANGELOG.md`** documents the licensing/packaging change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72a7d4243288bdbc34a3add3b668f84603383393. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->