### PR TITLE
upgrading coana to version 15.3.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.118](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.118) - 2026-06-08
+
+### Changed
+- Updated the Coana CLI to v `15.3.24`.
+
 ## [1.1.117](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.117) - 2026-06-08
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.117",
+  "version": "1.1.118",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT",
@@ -96,7 +96,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "15.3.22",
+    "@coana-tech/cli": "15.3.24",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 15.3.22
-        version: 15.3.22
+        specifier: 15.3.24
+        version: 15.3.24
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@15.3.22':
-    resolution: {integrity: sha512-IrndpxacqZP7yux5CGT6XdfrV1PSlriBsjp0YB5ScR+y3bxZAPO6vwZ9xYfz9Mt2X3RMSI9vBjNhT184mLumjQ==}
+  '@coana-tech/cli@15.3.24':
+    resolution: {integrity: sha512-wt6mYAnHCbuZieyHyJUgFNNfjjtrYkK1TrKwkLN+xSeMVIw3VSQypwl79fz5EbexZVLbxWE+kxzhRIm4StfEcQ==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5385,7 +5385,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@15.3.22': {}
+  '@coana-tech/cli@15.3.24': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 15.3.22 to 15.3.24

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine vendored Coana version bump with no socket-cli code changes; any behavioral impact is confined to Coana-driven analysis/manifest paths.
> 
> **Overview**
> Bumps the bundled **Coana CLI** from `15.3.22` to **`15.3.24`** and cuts release **`1.1.118`**.
> 
> Changes are limited to `package.json` (`@coana-tech/cli` devDependency and package version), `pnpm-lock.yaml`, and a **CHANGELOG** entry noting the Coana update. There are no Socket CLI source changes; behavior for Coana-backed flows (e.g. manifest Gradle/Kotlin/Scala, reach scans, `socket fix`) follows whatever is in the new Coana release—see the [Coana changelogs](https://docs.coana.tech/changelogs) for details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fecc8aae87c62e0cbf57bb035b03d0af2f786ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->