### PR TITLE
upgrading coana to version 15.3.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.119](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.119) - 2026-06-11
+
+### Changed
+- Updated the Coana CLI to v `15.3.26`.
+
 ## [1.1.118](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.118) - 2026-06-08
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.118",
+  "version": "1.1.119",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT",
@@ -96,7 +96,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "15.3.24",
+    "@coana-tech/cli": "15.3.26",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 15.3.24
-        version: 15.3.24
+        specifier: 15.3.26
+        version: 15.3.26
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@15.3.24':
-    resolution: {integrity: sha512-wt6mYAnHCbuZieyHyJUgFNNfjjtrYkK1TrKwkLN+xSeMVIw3VSQypwl79fz5EbexZVLbxWE+kxzhRIm4StfEcQ==}
+  '@coana-tech/cli@15.3.26':
+    resolution: {integrity: sha512-l7Jnto1dCOUKVSxdzfJhmv+6VHi57b00z5IjTda45XxbSGVirFJUYxdhNMXjijYYQHc1bUf0b1Nh9VNWhZryug==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5385,7 +5385,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@15.3.24': {}
+  '@coana-tech/cli@15.3.26': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades @coana-tech/cli from 15.3.24 to 15.3.26

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine dependency pin and release bookkeeping; behavior changes, if any, come from the external Coana CLI version only.
> 
> **Overview**
> Bumps **socket** to **1.1.119** and upgrades the vendored **`@coana-tech/cli`** dev dependency from **15.3.24** to **15.3.26**, with matching **`pnpm-lock.yaml`** resolution updates and a **CHANGELOG** entry for the release.
> 
> There are no changes to Socket CLI application source in this PR—only version, lockfile, and changelog metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68770fe8c13faf5a087e5e3816a387edc3235c59. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->