### PR TITLE
bump coana to 15.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.122](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.122) - 2026-06-17
+
+### Changed
+- Updated the Coana CLI to v `15.4.6`.
+
 ## [1.1.121](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.121) - 2026-06-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "15.4.5",
+    "@coana-tech/cli": "15.4.6",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 15.4.5
-        version: 15.4.5
+        specifier: 15.4.6
+        version: 15.4.6
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@15.4.5':
-    resolution: {integrity: sha512-XH1fTJNZpRQAVErIn1Fntsy+iRHDlpxNTm9O7gjhVSCUVGZxShv7SsVeB+zNVLoTRiLQjJWuGJ5OtueMQHRxHQ==}
+  '@coana-tech/cli@15.4.6':
+    resolution: {integrity: sha512-U++rLRiCOxsiYoGlxDVH0clF2eaqBcAnxvQmIxBtcPpq0CvJVWyJ8+JYODo31RMst8dDfPtnE/h9ONHcuVc5hA==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5385,7 +5385,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@15.4.5': {}
+  '@coana-tech/cli@15.4.6': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Routine patch-level dependency bump with no application code changes; behavior follows whatever is in Coana 15.4.6.
> 
> **Overview**
> Bumps the bundled **Coana CLI** from `15.4.5` to **`15.4.6`** by updating `@coana-tech/cli` in `package.json` and refreshing `pnpm-lock.yaml`.
> 
> Documents the change under **1.1.122** in `CHANGELOG.md`. No Socket CLI source changes—only the vendored Coana version used for reachability, manifest, and fix flows that spawn Coana.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b336851dbc0881e810477315d8271929fc538548. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->