### PR TITLE
fix(cli): interrupt running commands cleanly on Ctrl+C

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -38,9 +38,39 @@ void (async () => {
     },
   )
 
+  // The child shares our process group and handles the signal itself; wait briefly for it
+  // to exit (so its final output isn't printed after the prompt returns) and mirror its
+  // exit below. SIGKILL and leave if it outlasts the grace, or on a second signal.
+  const SHUTDOWN_GRACE_MS = 3_000
+  const hardAbort = signalName => {
+    const child = spawnPromise.process
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGKILL')
+    }
+    // eslint-disable-next-line n/no-process-exit
+    process.exit(signalName === 'SIGTERM' ? 143 : 130)
+  }
+  let sawSignal = false
+  const onSignal = signalName => {
+    if (sawSignal) {
+      hardAbort(signalName)
+      return
+    }
+    sawSignal = true
+    setTimeout(() => hardAbort(signalName), SHUTDOWN_GRACE_MS).unref?.()
+  }
+  const onSigint = () => onSignal('SIGINT')
+  const onSigterm = () => onSignal('SIGTERM')
+  process.on('SIGINT', onSigint)
+  process.on('SIGTERM', onSigterm)
+
   // See https://nodejs.org/api/child_process.html#event-exit.
   spawnPromise.process.on('exit', (code, signalName) => {
     if (signalName) {
+      // Mirror a signal death. Drop our own handlers first so the re-raise actually
+      // terminates us instead of being swallowed by onSigint/onSigterm above.
+      process.removeListener('SIGINT', onSigint)
+      process.removeListener('SIGTERM', onSigterm)
       process.kill(process.pid, signalName)
     } else if (typeof code === 'number') {
       // eslint-disable-next-line n/no-process-exit

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,6 +3,7 @@
 
 void (async () => {
   const Module = require('node:module')
+  const os = require('node:os')
   const path = require('node:path')
   const rootPath = path.join(__dirname, '..')
   Module.enableCompileCache?.(path.join(rootPath, '.cache'))
@@ -67,11 +68,12 @@ void (async () => {
   // See https://nodejs.org/api/child_process.html#event-exit.
   spawnPromise.process.on('exit', (code, signalName) => {
     if (signalName) {
-      // Mirror a signal death. Drop our own handlers first so the re-raise actually
-      // terminates us instead of being swallowed by onSigint/onSigterm above.
-      process.removeListener('SIGINT', onSigint)
-      process.removeListener('SIGTERM', onSigterm)
-      process.kill(process.pid, signalName)
+      // Mirror a signal death as the conventional 128 + signum exit code. Exit explicitly
+      // rather than re-raising the signal: with our handlers installed the re-raise would
+      // race `await spawnPromise` resolving and could leave the default exitCode of 1.
+      const signum = os.constants.signals[signalName] ?? 0
+      // eslint-disable-next-line n/no-process-exit
+      process.exit(128 + signum)
     } else if (typeof code === 'number') {
       // eslint-disable-next-line n/no-process-exit
       process.exit(code)


### PR DESCRIPTION
## What

The launcher (`bin/cli.js`) spawns the real CLI as a child process with inherited stdio. Previously the launcher was torn down by `SIGINT` before that child finished, so on `Ctrl+C` the child's final status could print *after* the shell prompt had already returned — and the child could be left running in the background.

This makes the launcher wait for the child to handle the interrupt itself and then mirror its exit, so output stays ordered.

## How

- On the first `SIGINT`/`SIGTERM`, stay alive and let the child (which shares our process group and receives the signal directly) run its own teardown; exit by mirroring the child's real exit.
- The wait is **bounded**: if the child outlives a short grace period (`SHUTDOWN_GRACE_MS`, 3s), or on a second `Ctrl+C`, `SIGKILL` it and exit with the conventional `128 + signum` code.
- The grace timer is `unref`'d, so a child that exits on its own is mirrored with **no added latency** — the cap only applies to a slow or wedged child.

## Notes

- Applies to **all** commands, not any one in particular.
- Independent change; no dependency on other repos.
- No version bump / changelog entry — internal interrupt-handling plumbing, left for the next release to fold in.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Launcher-only process/signal plumbing in bin/cli.js; no auth, data, or business-logic changes, with bounded fallback via SIGKILL.
> 
> **Overview**
> The CLI launcher (`bin/cli.js`) now **coordinates shutdown** when you hit Ctrl+C or send `SIGTERM`, instead of exiting before the spawned CLI child finishes.
> 
> On the first signal it **stays alive** so the child (same process group, inherited stdio) can tear down and print final output in order; the parent then **mirrors** the child’s exit. If the child doesn’t exit within **3s**, or you signal again, it **SIGKILL**s the child and exits with **130** (`SIGINT`) or **143** (`SIGTERM`). The grace timer is **unref**’d so a normal fast exit isn’t delayed.
> 
> When the child exits on a signal, the launcher **removes its own handlers** before re-raising so the parent actually terminates instead of swallowing the signal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 010d858d6834c36b368213c24183e04238f94a8e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->