### PR TITLE
fix(scan): isolate --json/--markdown output during reachability analysis

### DIFF
--- a/src/commands/scan/handle-create-new-scan.mts
+++ b/src/commands/scan/handle-create-new-scan.mts
@@ -238,6 +238,7 @@ export async function handleCreateNewScan({
       branchName,
       cwd,
       orgSlug,
+      outputKind,
       packagePaths,
       reachabilityOptions: mergedReachabilityOptions,
       repoName,

--- a/src/commands/scan/handle-scan-reach.mts
+++ b/src/commands/scan/handle-scan-reach.mts
@@ -95,6 +95,7 @@ export async function handleScanReach({
   const result = await performReachabilityAnalysis({
     cwd,
     orgSlug,
+    outputKind,
     outputPath,
     packagePaths,
     reachabilityOptions: mergedReachabilityOptions,

--- a/src/commands/scan/perform-reachability-analysis.mts
+++ b/src/commands/scan/perform-reachability-analysis.mts
@@ -15,10 +15,11 @@ import { setupSdk } from '../../utils/sdk.mts'
 import { socketDevLink } from '../../utils/terminal-link.mts'
 import { fetchOrganization } from '../organization/fetch-organization-list.mts'
 
-import type { CResult } from '../../types.mts'
+import type { CResult, OutputKind } from '../../types.mts'
 import type { AutoManifestConfig } from '../../utils/auto-manifest-config.mts'
 import type { PURL_Type } from '../../utils/ecosystem.mts'
 import type { Spinner } from '@socketsecurity/registry/lib/spinner'
+import type { StdioOptions } from 'node:child_process'
 
 export type ReachabilityOptions = {
   autoManifestConfig?: AutoManifestConfig | undefined
@@ -47,6 +48,7 @@ export type ReachabilityAnalysisOptions = {
   branchName?: string | undefined
   cwd?: string | undefined
   orgSlug?: string | undefined
+  outputKind?: OutputKind | undefined
   outputPath?: string | undefined
   packagePaths?: string[] | undefined
   reachabilityOptions: ReachabilityOptions
@@ -68,6 +70,7 @@ export async function performReachabilityAnalysis(
     branchName,
     cwd = process.cwd(),
     orgSlug,
+    outputKind = 'text',
     outputPath,
     packagePaths,
     reachabilityOptions,
@@ -270,6 +273,14 @@ export async function performReachabilityAnalysis(
     coanaEnv['SOCKET_BRANCH_NAME'] = branchName
   }
 
+  // In machine-readable modes (--json/--markdown) the final payload is written
+  // to stdout by the output layer. Coana streams progress/logs over stdout
+  // under `inherit`, which would corrupt that payload, so redirect the child's
+  // stdout to our stderr (fd 2). Progress stays visible for humans and
+  // `2>/dev/null` isolates the JSON/markdown. stdin and stderr stay inherited.
+  const coanaStdio: StdioOptions =
+    outputKind === 'text' ? 'inherit' : ['inherit', 2, 'inherit']
+
   try {
     // Run Coana with the manifests tar hash.
     const coanaResult = await spawnCoanaDlx(coanaArgs, orgSlug, {
@@ -277,7 +288,7 @@ export async function performReachabilityAnalysis(
       cwd,
       env: coanaEnv,
       spinner,
-      stdio: 'inherit',
+      stdio: coanaStdio,
     })
 
     if (wasSpinning) {

--- a/src/commands/scan/perform-reachability-analysis.test.mts
+++ b/src/commands/scan/perform-reachability-analysis.test.mts
@@ -162,3 +162,77 @@ describe('performReachabilityAnalysis facts-file resolution', () => {
     expect(result.ok && result.data.tier1ReachabilityScanId).toBeUndefined()
   })
 })
+
+describe('performReachabilityAnalysis stdio routing by output kind', () => {
+  let scanCwd: string
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetchOrganization.mockResolvedValue({
+      ok: true,
+      data: { organizations: {} },
+    })
+    mockHasEnterpriseOrgPlan.mockReturnValue(true)
+    mockSpawnCoanaDlx.mockResolvedValue({ ok: true, data: '' })
+    scanCwd = mkdtempSync(path.join(tmpdir(), 'socket-rea-stdio-'))
+    writeFileSync(
+      path.join(scanCwd, '.socket.facts.json'),
+      JSON.stringify({ components: [] }),
+    )
+  })
+
+  afterEach(() => {
+    rmSync(scanCwd, { force: true, recursive: true })
+  })
+
+  it('inherits stdio in text output mode', async () => {
+    await performReachabilityAnalysis({
+      cwd: scanCwd,
+      outputKind: 'text',
+      reachabilityOptions: makeReachabilityOptions(),
+      target: scanCwd,
+    })
+
+    expect(mockSpawnCoanaDlx.mock.calls[0]![2]).toMatchObject({
+      stdio: 'inherit',
+    })
+  })
+
+  it('defaults to inheriting stdio when no output kind is given', async () => {
+    await performReachabilityAnalysis({
+      cwd: scanCwd,
+      reachabilityOptions: makeReachabilityOptions(),
+      target: scanCwd,
+    })
+
+    expect(mockSpawnCoanaDlx.mock.calls[0]![2]).toMatchObject({
+      stdio: 'inherit',
+    })
+  })
+
+  it('redirects Coana stdout to stderr (fd 2) in json output mode', async () => {
+    await performReachabilityAnalysis({
+      cwd: scanCwd,
+      outputKind: 'json',
+      reachabilityOptions: makeReachabilityOptions(),
+      target: scanCwd,
+    })
+
+    expect(mockSpawnCoanaDlx.mock.calls[0]![2]).toMatchObject({
+      stdio: ['inherit', 2, 'inherit'],
+    })
+  })
+
+  it('redirects Coana stdout to stderr (fd 2) in markdown output mode', async () => {
+    await performReachabilityAnalysis({
+      cwd: scanCwd,
+      outputKind: 'markdown',
+      reachabilityOptions: makeReachabilityOptions(),
+      target: scanCwd,
+    })
+
+    expect(mockSpawnCoanaDlx.mock.calls[0]![2]).toMatchObject({
+      stdio: ['inherit', 2, 'inherit'],
+    })
+  })
+})


### PR DESCRIPTION
## Problem

`socket scan create --reach --json` (and `socket scan reach --json`) cannot have its output isolated to just the JSON payload. For a non-reach scan you can do `socket scan create --json 2>/dev/null`, because the CLI sends all human-facing text (banner, spinner, progress, success/info/warn) to **stderr** and only the machine-readable result to **stdout**.

Reachability analysis spawned the Coana CLI with `stdio: 'inherit'`, so Coana's progress/log output was wired straight to the parent's **stdout** and interleaved with the final JSON. Since `2>/dev/null` only drops stderr, there was no way to get a clean JSON stream. Coana's actual result is written to a file (`--socket-mode` / `--output-dir`), so its stdout is purely diagnostic noise.

## Fix

Make the Coana `stdio` output-kind aware:

- **text** mode → `'inherit'` (unchanged; Coana streams to the terminal as before).
- **json / markdown** mode → `['inherit', 2, 'inherit']`, which redirects the Coana child's **stdout** to the parent's **stderr** (fd 2). stdin and stderr stay inherited.

Result: in machine-readable modes the final `logger.log(...)` payload is alone on stdout, Coana's progress stays visible on stderr, and `2>/dev/null` now isolates the JSON/markdown — matching the behavior of a non-reach scan. This is preferred over piping/capturing because it preserves real-time progress streaming.

This relies only on standard Node stdio fd-sharing, already plumbed end-to-end through the dlx launcher, local-path, and npm-install spawn paths in `spawnCoanaDlx`.

## Changes

- `src/commands/scan/perform-reachability-analysis.mts` — add `outputKind` option; compute the stdio and pass it to `spawnCoanaDlx` (replacing the hardcoded `'inherit'`).
- `src/commands/scan/handle-create-new-scan.mts` — pass `outputKind` (`socket scan create --reach`).
- `src/commands/scan/handle-scan-reach.mts` — pass `outputKind` (`socket scan reach`).
- `src/commands/scan/perform-reachability-analysis.test.mts` — 4 new tests asserting stdio routing (text/default → `'inherit'`; json/markdown → `['inherit', 2, 'inherit']`).

## Testing

- `pnpm check:tsc` — clean
- `eslint` on changed files — clean
- `pnpm test:unit` on the reachability + both handler test files — 22/22 pass (2 pre-existing + 4 new)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to child-process stdio wiring for reach scans; text mode unchanged and behavior is covered by new tests.
> 
> **Overview**
> **Reachability scans with `--json` or `--markdown` now keep machine-readable output on stdout only**, matching non-reach scan behavior.
> 
> Coana was spawned with `stdio: 'inherit'`, so its progress/logs went to stdout and mixed with the CLI’s final JSON/markdown. `performReachabilityAnalysis` now takes `outputKind` (default `text`) and passes **`'inherit'`** in text mode or **`['inherit', 2, 'inherit']`** in json/markdown so Coana’s stdout is redirected to the parent’s stderr. Callers **`socket scan create --reach`** and **`socket scan reach`** forward `outputKind`. Four unit tests assert the stdio passed to `spawnCoanaDlx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 733b293019b4577f0989f0ad5f5fe51288dc09b9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->