### PR TITLE
chore: bump Coana CLI to 15.5.9 (1.1.127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.127](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.127) - 2026-06-24
+
+### Changed
+- Updated the Coana CLI to v `15.5.9`.
+
 ## [1.1.126](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.126) - 2026-06-22
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.126",
+  "version": "1.1.127",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT",
@@ -96,7 +96,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "15.5.7",
+    "@coana-tech/cli": "15.5.9",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 15.5.7
-        version: 15.5.7
+        specifier: 15.5.9
+        version: 15.5.9
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@15.5.7':
-    resolution: {integrity: sha512-WVO66QAD/rp8hTZEkLr5fW+VXKH2GFxRWQVTueFw2EmfJnxcPUB2yfQr37qMyHVp9hUwS35OsoCrFMcWd4mqlA==}
+  '@coana-tech/cli@15.5.9':
+    resolution: {integrity: sha512-IZd+XArq7IeIHGZTIOfrz/fIKfoSwTS7TYIjLxSSqsHTiRF2X2btjJsAh0je/4hv+thRSA0SROlVLm0sKKAvZQ==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5385,7 +5385,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@15.5.7': {}
+  '@coana-tech/cli@15.5.9': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades `@coana-tech/cli` from `15.5.7` to `15.5.9`.
- Bumps the CLI package version `1.1.126` → `1.1.127` and adds a changelog entry.

Companion bump for the Python CLI is tracked in a separate PR (`socket-python-cli`).

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine dependency and version bump only; no application logic changes in the diff.
> 
> **Overview**
> **Release 1.1.127** bumps the bundled **Coana** dependency from `15.5.7` to **`15.5.9`** in `package.json` / `pnpm-lock.yaml`, with no Socket CLI source changes in this diff.
> 
> The published **`socket`** package version moves **`1.1.126` → `1.1.127`**, and **CHANGELOG** documents the Coana upgrade. Reachability (`socket scan create --reach`, `socket scan reach`) and **`socket fix`** will run the newer Coana build via the existing spawn path; behavior details are in the [Coana changelogs](https://docs.coana.tech/changelogs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d83df39a6839331939ca22a6c776144697ef553. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->