### PR TITLE
fix(scan): ignore project .pnpmfile.cjs when launching tools via pnpm dlx (1.1.130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.130](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.130) - 2026-06-29
+
+### Fixed
+- Reachability analysis no longer fails to start in pnpm workspaces that define a `.pnpmfile.cjs`. Socket now launches its bundled analysis tools without running the project's pnpm hooks, so a broken or environment-specific hook (for example, one that loads a file managed by Git LFS) can no longer stop a scan before it begins.
+
 ## [1.1.129](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.129) - 2026-06-26
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.129",
+  "version": "1.1.130",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT",

--- a/src/utils/dlx.mts
+++ b/src/utils/dlx.mts
@@ -128,19 +128,26 @@ export async function spawnDlx(
       spawnArgs.push(FLAG_SILENT)
     }
     spawnArgs.push('dlx')
+    // Never let the target project's `.pnpmfile.cjs` hooks run while we launch
+    // a third-party tool via `pnpm dlx`. In a pnpm workspace root, `pnpm dlx`
+    // loads the cwd's `.pnpmfile.cjs`, so a broken hook there (e.g. a `require`
+    // of an unresolved Git LFS pointer) crashes the launcher with a bare exit
+    // code before our tool ever starts. The dlx tool installs into an isolated
+    // store, so the project's install hooks are irrelevant to it. pnpm honors
+    // this only as a config setting, not as a `dlx` CLI flag, so it must be set
+    // via the npm_config_ env var. See: https://pnpm.io/npmrc#settings
+    const pnpmEnv: Record<string, string | undefined> = {
+      ...getOwn(finalShadowOptions, 'env'),
+      npm_config_ignore_pnpmfile: 'true',
+    }
     if (force) {
-      // For pnpm, set dlx-cache-max-age to 0 via env to force fresh download.
-      // This ensures we always get the latest version within the range.
-      finalShadowOptions = {
-        ...finalShadowOptions,
-        env: {
-          ...getOwn(finalShadowOptions, 'env'),
-          // Set dlx cache max age to 0 minutes to bypass cache.
-          // The npm_config_ prefix is how pnpm reads config from environment variables.
-          // See: https://pnpm.io/npmrc#settings
-          npm_config_dlx_cache_max_age: '0',
-        },
-      }
+      // Set dlx-cache-max-age to 0 minutes to bypass cache and force a fresh
+      // download. This ensures we always get the latest version within the range.
+      pnpmEnv['npm_config_dlx_cache_max_age'] = '0'
+    }
+    finalShadowOptions = {
+      ...finalShadowOptions,
+      env: pnpmEnv,
     }
     spawnArgs.push(packageString, ...args)
 

--- a/src/utils/dlx.test.mts
+++ b/src/utils/dlx.test.mts
@@ -181,6 +181,25 @@ describe('utils/dlx', () => {
       expect(options.env.npm_config_dlx_cache_max_age).toBe('0')
     })
 
+    it('should set npm_config_ignore_pnpmfile env var for pnpm regardless of force', async () => {
+      const packageSpec: DlxPackageSpec = {
+        name: '@coana-tech/cli',
+        version: '1.0.0',
+      }
+
+      // force defaults to false here, exercising the non-force path.
+      await spawnDlx(packageSpec, ['run', '/some/path'], { agent: 'pnpm' })
+
+      expect(mockShadowPnpmBin).toHaveBeenCalledTimes(1)
+      const [, options] = mockShadowPnpmBin.mock.calls[0]
+
+      // The target project's `.pnpmfile.cjs` must be ignored so a broken hook
+      // (e.g. a require of an unresolved Git LFS pointer) cannot crash the
+      // `pnpm dlx` launcher before the tool starts.
+      expect(options.env).toBeDefined()
+      expect(options.env.npm_config_ignore_pnpmfile).toBe('true')
+    })
+
     it('should handle pinned version without silent flag by default', async () => {
       const packageSpec: DlxPackageSpec = {
         name: '@coana-tech/cli',


### PR DESCRIPTION
## Problem

Reachability scans (`socket scan create --reach`) can fail to start with a confusing error when run inside a **pnpm workspace** whose root defines a `.pnpmfile.cjs`:

```
A syntax error in the ".../.pnpmfile.cjs"
.../some-file.js:1
version https://git-lfs.github.com/spec/v1
        ^^^^^
SyntaxError: Unexpected identifier 'https'
...
⠇ Coana reachability analysis failed ...
Details: Coana failed to run via the package manager (exit code 1): command failed
```

## Root cause

Socket CLI launches its bundled analysis tools (Coana, and similarly cdxgen/synp) via `pnpm dlx <pkg>` with the **target repo as the working directory** (`src/utils/dlx.mts` → `spawnDlx`).

When that working directory is a **pnpm workspace root**, `pnpm dlx` evaluates the repo's root `.pnpmfile.cjs` before doing anything else. If a hook in that file throws at load time — for example a top-level `require()` of a file that is still an **unresolved Git LFS pointer** (so its contents are the LFS spec text, not JavaScript) — pnpm crashes with a bare exit code **before the analysis tool ever boots**. The CLI then surfaces only the generic "Coana failed to run via the package manager (exit code 1)".

Notes confirmed while debugging:
- `pnpm dlx` loads the cwd's `.pnpmfile.cjs` **only** when the cwd is a workspace root; a standalone project dir is unaffected. This is why it only reproduces in monorepos.
- The tool never started (no tool banner in the output), so this is purely a launcher problem — not a bug in the analysis tool itself.

## Fix

In the pnpm branch of `spawnDlx`, always set `npm_config_ignore_pnpmfile=true` on the launch environment, so `pnpm dlx` never runs the target project's pnpm hooks. The dlx tool is installed into an isolated store, so the project's install hooks are irrelevant to it. This covers the Coana, cdxgen, and synp dlx launches.

The `--ignore-pnpmfile` *CLI flag* is rejected by `pnpm dlx` ("Unknown option"); only the `npm_config_ignore_pnpmfile` env/config form is honored — verified against pnpm 10.28.0/10.33.0.

## Testing

- Reproduced the original failure byte-for-byte locally, then confirmed the injected env var makes the same `pnpm dlx` launch in a workspace root succeed.
- Added a unit test asserting the pnpm dlx launch sets `npm_config_ignore_pnpmfile=true` regardless of the `force` flag.
- `pnpm test:unit src/utils/dlx.test.mts` — 29 pass.
- `pnpm check:tsc` clean; eslint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to pnpm dlx spawn env in dlx.mts; skips project hooks only for isolated dlx installs, with unit test coverage.
> 
> **Overview**
> Fixes reachability and other scans that launch bundled tools (Coana, cdxgen, synp) with **`pnpm dlx`** from a **pnpm workspace root**, where **`pnpm dlx` was loading the repo’s `.pnpmfile.cjs`** and could exit before the tool started (e.g. hooks that `require` Git LFS pointer files).
> 
> **`spawnDlx`** now always sets **`npm_config_ignore_pnpmfile=true`** on the pnpm launch environment so project install hooks are skipped; the existing **`force`** path still sets **`npm_config_dlx_cache_max_age=0`** in the same env block. Release **1.1.130** with changelog; unit test asserts the env var is set regardless of **`force`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d7ed411eefc6d798964153e86426420e2b00172. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->