### PR TITLE
fix(scan): honor `.socket.facts.json` under --reach-use-only-pregenerated-sboms (1.1.134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.134](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.134) - 2026-07-01
+
+### Fixed
+- `--reach-use-only-pregenerated-sboms` now recognizes Socket facts files (`.socket.facts.json`) as pre-generated SBOMs, alongside CycloneDX and SPDX — matching what the reachability analyzer accepts. Previously a project whose only pre-generated SBOM was a `.socket.facts.json` was ignored by this flag.
+
 ## [1.1.133](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.133) - 2026-07-01
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.133",
+  "version": "1.1.134",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT",

--- a/src/commands/scan/handle-create-new-scan.mts
+++ b/src/commands/scan/handle-create-new-scan.mts
@@ -31,14 +31,17 @@ import type { ResolvedPathsSidecar } from '../manifest/scripts/sidecar.mts'
 import type { Remap } from '@socketsecurity/registry/lib/objects'
 import type { SocketSdkSuccessResult } from '@socketsecurity/sdk'
 
-// Keys for CDX and SPDX in the supported files response.
-const CDX_SPDX_KEYS = ['cdx', 'spdx']
+// Supported-files response keys whose files count as pre-generated SBOMs:
+// CycloneDX, SPDX, and Socket facts (`.socket.facts.json`, under `socket`).
+// Kept in sync with Coana's `--use-only-pregenerated-sboms` selection
+// (extractPregeneratedSbomPatterns), which matches the same three keys.
+const PREGENERATED_SBOM_KEYS = ['cdx', 'socket', 'spdx']
 
-function getCdxSpdxPatterns(
+function getPregeneratedSbomPatterns(
   supportedFiles: SocketSdkSuccessResult<'getReportSupportedFiles'>['data'],
 ): string[] {
   const patterns: string[] = []
-  for (const key of CDX_SPDX_KEYS) {
+  for (const key of PREGENERATED_SBOM_KEYS) {
     const supported = supportedFiles[key]
     if (supported) {
       for (const entry of Object.values(supported)) {
@@ -49,13 +52,15 @@ function getCdxSpdxPatterns(
   return patterns
 }
 
-function filterToCdxSpdxOnly(
+function filterToPregeneratedSboms(
   filepaths: string[],
   supportedFiles: SocketSdkSuccessResult<'getReportSupportedFiles'>['data'],
 ): string[] {
-  const patterns = getCdxSpdxPatterns(supportedFiles)
+  const patterns = getPregeneratedSbomPatterns(supportedFiles)
+  // `dot: true` lets `*`-prefixed patterns match leading-dot filenames such as
+  // `.socket.facts.json` (advertised as `*.socket.facts.json`).
   return filepaths.filter(filepath =>
-    micromatch.some(filepath, patterns, { nocase: true }),
+    micromatch.some(filepath, patterns, { dot: true, nocase: true }),
   )
 }
 
@@ -263,19 +268,24 @@ export async function handleCreateNewScan({
 
     reachabilityReport = reachResult.data?.reachabilityReport
 
-    // Ensure the .socket.facts.json isn't duplicated in case it happened
-    // to be in the scan folder before the analysis was run.
-    const filteredPackagePaths = packagePaths.filter(
-      p => path.basename(p) !== constants.DOT_SOCKET_DOT_FACTS_JSON,
-    )
-
-    // When using pregenerated SBOMs only, filter to CDX/SPDX files.
+    // When using only pre-generated SBOMs, build the scan from those inputs —
+    // CycloneDX, SPDX, and Socket facts (`.socket.facts.json`) — matching
+    // Coana's `--use-only-pregenerated-sboms` selection. Otherwise drop any
+    // stray `.socket.facts.json`; coana's fresh reachability report (appended
+    // below) is the authoritative facts file for the scan.
     const pathsForScan = reach.reachUseOnlyPregeneratedSboms
-      ? filterToCdxSpdxOnly(filteredPackagePaths, supportedFiles)
-      : filteredPackagePaths
+      ? filterToPregeneratedSboms(packagePaths, supportedFiles)
+      : packagePaths.filter(
+          p => path.basename(p) !== constants.DOT_SOCKET_DOT_FACTS_JSON,
+        )
 
+    // Append coana's reachability report, but not twice: a pre-generated facts
+    // input can resolve to the same path coana wrote its report to.
+    const reportPath = reachabilityReport
+      ? path.resolve(cwd, reachabilityReport)
+      : undefined
     scanPaths = [
-      ...pathsForScan,
+      ...pathsForScan.filter(p => path.resolve(cwd, p) !== reportPath),
       ...(reachabilityReport ? [reachabilityReport] : []),
     ]
 


### PR DESCRIPTION
## Summary

`--reach-use-only-pregenerated-sboms` restricted the scan to **CycloneDX/SPDX** files only, so a project whose sole pre-generated SBOM was a Socket facts file (`.socket.facts.json`) was silently ignored by the flag.

The reachability analyzer already treats `.socket.facts.json` as a pre-generated SBOM — its selection matches the supported-files `cdx`, `spdx`, **and** `socket` keys. socket-cli only matched `cdx`/`spdx`, so the two were inconsistent.

This aligns socket-cli with the analyzer:
- Recognize the `socket` key (`.socket.facts.json`) as a pre-generated SBOM alongside CDX/SPDX (`filterToCdxSpdxOnly` → `filterToPregeneratedSboms`), matching leading-dot filenames with `dot: true`.
- Under the flag, the scan is built from the pre-generated SBOMs found in the package paths (CDX/SPDX/facts) rather than the facts-stripped list; coana's reachability report is appended once, de-duplicated so a facts input at the same path isn't uploaded twice.

Closes REA-620.

## Verification

Type-check + lint clean; `handle-create-new-scan` and `cmd-scan-create` unit suites pass (39). Coana's side was audited to confirm it honors `.socket.facts.json` under `--use-only-pregenerated-sboms` (its `extractPregeneratedSbomPatterns` reads the `cdx`/`spdx`/`socket` keys).

## Note for reviewers

The change to the scan-path assembly (building from `packagePaths` pre-generated SBOMs + de-duplicating the reachability report by resolved path) is the one spot worth a sanity check against the intended reachability-upload contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which files are uploaded for reachability scans under `--reach-use-only-pregenerated-sboms`, including scan-path assembly and duplicate facts handling; behavior is intentional but worth validating against the upload contract.
> 
> **Overview**
> **`--reach-use-only-pregenerated-sboms`** now treats Socket facts (`.socket.facts.json`) as a pre-generated SBOM alongside CycloneDX and SPDX, matching Coana’s `--use-only-pregenerated-sboms` behavior. Previously only `cdx`/`spdx` supported-files keys were used, so a repo whose only pre-generated SBOM was a facts file was effectively ignored by the flag.
> 
> In `handle-create-new-scan`, pre-generated SBOM filtering adds the `socket` key, enables `micromatch` **`dot: true`** so patterns like `*.socket.facts.json` match dotfiles, and renames the helpers to `filterToPregeneratedSboms`. When the flag is on, scan inputs come from those filtered paths instead of always stripping `.socket.facts.json` first; Coana’s reachability report is still appended once, with path de-duplication when a pre-generated facts file is the same file Coana wrote.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45149532c5ac6ca66daf4c10293cbb2bd0fff96e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->