### PR TITLE
fix(cli): use the public npm registry for the self-update check

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,8 +174,6 @@
     "oxlint": "1.15.0",
     "pony-cause": "2.1.11",
     "postject": "1.0.0-alpha.6",
-    "registry-auth-token": "5.1.0",
-    "registry-url": "7.2.0",
     "rollup": "4.50.1",
     "semver": "7.7.2",
     "synp": "1.9.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,12 +358,6 @@ importers:
       postject:
         specifier: 1.0.0-alpha.6
         version: 1.0.0-alpha.6
-      registry-auth-token:
-        specifier: 5.1.0
-        version: 5.1.0
-      registry-url:
-        specifier: 7.2.0
-        version: 7.2.0
       rollup:
         specifier: 4.50.1
         version: 4.50.1(patch_hash=071f391315feb3e71235ac70bfbf18a993f10a53259f3ec37507a614a5645f9f)
@@ -1397,10 +1391,6 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@pnpm/config.env-replace@1.1.0':
-    resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
-    engines: {node: '>=12.22.0'}
-
   '@pnpm/constants@1001.3.0':
     resolution: {integrity: sha512-ZFRekNHbDlu//67Byg+mG8zmtmCsfBhNsg1wKBLRtF7VjH+Q5TDGMX0+8aJYSikQDuzM2FOhvQcDwyjILKshJQ==}
     engines: {node: '>=18.12'}
@@ -1454,14 +1444,6 @@ packages:
   '@pnpm/logger@1001.0.0':
     resolution: {integrity: sha512-nj80XtTHHt7T+b5stLWszzd166MbGx4eTOu9+6h6RdelKMlSWhrb7KUb0j90tYk+yoGx8TeMVdJCaoBnkLp8xw==}
     engines: {node: '>=18.12'}
-
-  '@pnpm/network.ca-file@1.0.2':
-    resolution: {integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==}
-    engines: {node: '>=12.22.0'}
-
-  '@pnpm/npm-conf@2.3.1':
-    resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
-    engines: {node: '>=12'}
 
   '@pnpm/object.key-sorting@1000.0.1':
     resolution: {integrity: sha512-YTJCXyUGOrJuj4QqhSKqZa1vlVAm82h1/uw00ZmD/kL2OViggtyUwWyIe62kpwWVPwEYixfGjfvaFKVJy2mjzA==}
@@ -2581,9 +2563,6 @@ packages:
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
-
-  config-chain@1.1.13:
-    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
   connect@3.7.0:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
@@ -4157,9 +4136,6 @@ packages:
     resolution: {integrity: sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==}
     engines: {node: '>=18'}
 
-  proto-list@1.2.4:
-    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
-
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -4226,14 +4202,6 @@ packages:
   regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
     hasBin: true
-
-  registry-auth-token@5.1.0:
-    resolution: {integrity: sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==}
-    engines: {node: '>=14'}
-
-  registry-url@7.2.0:
-    resolution: {integrity: sha512-I5UEBQ+09LWKInA1fPswOMZps0cs2Z+IQXb5Z5EkTJiUmIN52Vm/FD3ji5X82c5jIXL3nWEWOrYK0RkON6Oqyg==}
-    engines: {node: '>=18'}
 
   regjsparser@0.10.0:
     resolution: {integrity: sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==}
@@ -6083,8 +6051,6 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@pnpm/config.env-replace@1.1.0': {}
-
   '@pnpm/constants@1001.3.0': {}
 
   '@pnpm/crypto.hash@1000.2.0':
@@ -6168,16 +6134,6 @@ snapshots:
     dependencies:
       bole: 5.0.21
       ndjson: 2.0.0
-
-  '@pnpm/network.ca-file@1.0.2':
-    dependencies:
-      graceful-fs: 4.2.11(patch_hash=17007d43dcc01ee2047730ab13eb23c41adc01ae0f24ee872b1fe69142db5200)
-
-  '@pnpm/npm-conf@2.3.1':
-    dependencies:
-      '@pnpm/config.env-replace': 1.1.0
-      '@pnpm/network.ca-file': 1.0.2
-      config-chain: 1.1.13
 
   '@pnpm/object.key-sorting@1000.0.1':
     dependencies:
@@ -7268,11 +7224,6 @@ snapshots:
 
   confbox@0.1.8: {}
 
-  config-chain@1.1.13:
-    dependencies:
-      ini: 1.3.8
-      proto-list: 1.2.4
-
   connect@3.7.0:
     dependencies:
       debug: 2.6.9
@@ -8028,7 +7979,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@1.3.8: {}
+  ini@1.3.8:
+    optional: true
 
   ini@5.0.0: {}
 
@@ -8976,8 +8928,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  proto-list@1.2.4: {}
-
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -9057,15 +9007,6 @@ snapshots:
       esprima: 4.0.1
 
   regexp-tree@0.1.27: {}
-
-  registry-auth-token@5.1.0:
-    dependencies:
-      '@pnpm/npm-conf': 2.3.1
-
-  registry-url@7.2.0:
-    dependencies:
-      find-up-simple: 1.0.1
-      ini: 5.0.0
 
   regjsparser@0.10.0:
     dependencies:

--- a/src/cli.mts
+++ b/src/cli.mts
@@ -4,10 +4,6 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 
 import meow from 'meow'
 import { messageWithCauses, stackWithCauses } from 'pony-cause'
-import lookupRegistryAuthToken from 'registry-auth-token'
-import lookupRegistryUrl from 'registry-url'
-import updateNotifier from 'tiny-updater'
-import colors from 'yoctocolors-cjs'
 
 import { debugDir, debugFn } from '@socketsecurity/registry/lib/debug'
 import { logger } from '@socketsecurity/registry/lib/logger'
@@ -17,6 +13,7 @@ import constants from './constants.mts'
 import { AuthError, InputError, captureException } from './utils/errors.mts'
 import { failMsgWithBadge } from './utils/fail-msg-with-badge.mts'
 import { meowWithSubcommands } from './utils/meow-with-subcommands.mts'
+import { runSelfUpdateCheck } from './utils/self-update.mts'
 import { serializeResultJson } from './utils/serialize-result-json.mts'
 import {
   finalizeTelemetry,
@@ -25,7 +22,6 @@ import {
   trackCliError,
   trackCliStart,
 } from './utils/telemetry/integration.mts'
-import { socketPackageLink } from './utils/terminal-link.mts'
 
 const __filename = fileURLToPath(import.meta.url)
 
@@ -39,22 +35,7 @@ void (async () => {
   // Track CLI start for telemetry.
   await trackCliStart(process.argv)
 
-  const registryUrl = lookupRegistryUrl()
-  await updateNotifier({
-    authInfo: lookupRegistryAuthToken(registryUrl, { recursive: true }),
-    name: constants.SOCKET_CLI_BIN_NAME,
-    registryUrl,
-    ttl: 86_400_000 /* 24 hours in milliseconds */,
-    version: constants.ENV.INLINED_SOCKET_CLI_VERSION,
-    logCallback: (name: string, version: string, latest: string) => {
-      logger.log(
-        `\n\n📦 Update available for ${colors.cyan(name)}: ${colors.gray(version)} → ${colors.green(latest)}`,
-      )
-      logger.log(
-        `📝 ${socketPackageLink('npm', name, `files/${latest}/CHANGELOG.md`, 'View changelog')}`,
-      )
-    },
-  })
+  await runSelfUpdateCheck()
 
   try {
     await meowWithSubcommands(

--- a/src/utils/self-update.mts
+++ b/src/utils/self-update.mts
@@ -1,0 +1,25 @@
+import updateNotifier from 'tiny-updater'
+import colors from 'yoctocolors-cjs'
+
+import { logger } from '@socketsecurity/registry/lib/logger'
+
+import constants from '../constants.mts'
+import { socketPackageLink } from './terminal-link.mts'
+
+// Check the public npm registry for a newer socket release.
+export async function runSelfUpdateCheck(): Promise<void> {
+  await updateNotifier({
+    name: constants.SOCKET_CLI_BIN_NAME,
+    registryUrl: 'https://registry.npmjs.org/',
+    ttl: 86_400_000 /* 24 hours in milliseconds */,
+    version: constants.ENV.INLINED_SOCKET_CLI_VERSION,
+    logCallback: (name: string, version: string, latest: string) => {
+      logger.log(
+        `\n\n📦 Update available for ${colors.cyan(name)}: ${colors.gray(version)} → ${colors.green(latest)}`,
+      )
+      logger.log(
+        `📝 ${socketPackageLink('npm', name, `files/${latest}/CHANGELOG.md`, 'View changelog')}`,
+      )
+    },
+  })
+}

--- a/src/utils/self-update.test.mts
+++ b/src/utils/self-update.test.mts
@@ -1,0 +1,19 @@
+import updateNotifier from 'tiny-updater'
+import { describe, expect, it, vi } from 'vitest'
+
+import { runSelfUpdateCheck } from './self-update.mts'
+
+vi.mock('tiny-updater', () => ({
+  default: vi.fn(async () => false),
+}))
+
+describe('runSelfUpdateCheck', () => {
+  it('checks the public npm registry', async () => {
+    await runSelfUpdateCheck()
+
+    expect(updateNotifier).toHaveBeenCalledTimes(1)
+    const options = vi.mocked(updateNotifier).mock.calls[0]![0]
+    expect(options.registryUrl).toBe('https://registry.npmjs.org/')
+    expect('authInfo' in options).toBe(false)
+  })
+})


### PR DESCRIPTION
The self-update check now always uses the public npm registry instead of resolving it from the local npm config, so it behaves the same regardless of the directory the CLI runs in.

- Extracted into `runSelfUpdateCheck()` with a unit test covering the pinned registry.
- Dropped the now-unused `registry-url` / `registry-auth-token` dependencies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small startup-path refactor with a pinned public registry URL; behavior change is intentional and covered by a unit test.
> 
> **Overview**
> The CLI **self-update notice** no longer derives the registry URL or auth from the user’s npm config (cwd-sensitive). It always queries **`https://registry.npmjs.org/`** via a new **`runSelfUpdateCheck()`** helper, so update availability is consistent everywhere the binary runs.
> 
> **`src/cli.mts`** delegates startup to that helper instead of inlining `registry-url`, `registry-auth-token`, and `tiny-updater` setup. **`registry-url`** and **`registry-auth-token`** are removed from **`package.json`** / lockfile. A unit test asserts the pinned registry and that **`authInfo`** is not passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44bec129ca44938b57492a054ada7cb34134ec57. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->