### PR TITLE
fix(blessed): use hex escapes for Node 24 strict-mode compatibility

### DIFF
--- a/patches/blessed@0.1.81.patch
+++ b/patches/blessed@0.1.81.patch
@@ -52,7 +52,7 @@ index 0b1e56fadcf60719ca2e5231447ad2f8ace44bda..1494b715fb8f2143505bb2b5cea053d8
  
  Program.prototype.bel =
 diff --git a/lib/tput.js b/lib/tput.js
-index 2a57f58b08e797e9751983eef917c127481770d5..aec81d28014cd7b9527d114dd0e9530acf1535ab 100644
+index 2a57f58b08e797e9751983eef917c127481770d5..ddfb9b88f64829ac0db9da4a200d874a7a88b0bc 100644
 --- a/lib/tput.js
 +++ b/lib/tput.js
 @@ -366,7 +366,7 @@ Tput.prototype.parseTerminfo = function(data, file) {
@@ -91,6 +91,15 @@ index 2a57f58b08e797e9751983eef917c127481770d5..aec81d28014cd7b9527d114dd0e9530a
        _strings.push(-1);
      } else {
        _strings.push((data[i + 1] << 8) | data[i]);
+@@ -884,7 +884,7 @@ Tput.prototype._compile = function(info, key, str) {
+           ch = ':';
+           break;
+         case '0':
+-          ch = '\200';
++          ch = '\x80';
+           break;
+         case 'a':
+           ch = '\x07';
 @@ -926,7 +926,7 @@ Tput.prototype._compile = function(info, key, str) {
          echo('sprintf("'+ cap[0].replace(':-', '-') + '", stack.pop())');
        } else if (cap[3] === 'c') {
@@ -100,6 +109,21 @@ index 2a57f58b08e797e9751983eef917c127481770d5..aec81d28014cd7b9527d114dd0e9530a
        } else {
          echo('stack.pop()');
        }
+@@ -2094,10 +2094,10 @@ Tput.prototype.detectBrokenACS = function(info) {
+       && process.env.TERMCAP
+       && ~process.env.TERMCAP.indexOf('screen')
+       && ~process.env.TERMCAP.indexOf('hhII00')) {
+-    if (~info.strings.enter_alt_charset_mode.indexOf('\016')
+-        || ~info.strings.enter_alt_charset_mode.indexOf('\017')
+-        || ~info.strings.set_attributes.indexOf('\016')
+-        || ~info.strings.set_attributes.indexOf('\017')) {
++    if (~info.strings.enter_alt_charset_mode.indexOf('\x0e')
++        || ~info.strings.enter_alt_charset_mode.indexOf('\x0f')
++        || ~info.strings.set_attributes.indexOf('\x0e')
++        || ~info.strings.set_attributes.indexOf('\x0f')) {
+       return true;
+     }
+   }
 @@ -2276,7 +2276,7 @@ function sprintf(src) {
          break;
        case 'c': // char

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ patchedDependencies:
     hash: 2c9f0a87aa8ce9ed95ce201819ef3fcdb9a00f1cabe12815f586d2a3c0bff69e
     path: patches/blessed-contrib@4.11.0.patch
   blessed@0.1.81:
-    hash: cae83aa371bddce36c7a03bac146da97b1da2ce16059ce29e25c3af0182331a3
+    hash: cab33a0881f68052e914af0948c3b5964e8dafe16980ba0027cbe6d9d216082d
     path: patches/blessed@0.1.81.patch
   brace-expansion@2.0.2:
     hash: eac47f4a81cd7be766bd391c6bf91ac462816eb2f3c5f99270419ac752d6f02d
@@ -264,7 +264,7 @@ importers:
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.1)(jiti@2.6.1)(yaml@2.8.1))
       blessed:
         specifier: 0.1.81
-        version: 0.1.81(patch_hash=cae83aa371bddce36c7a03bac146da97b1da2ce16059ce29e25c3af0182331a3)
+        version: 0.1.81(patch_hash=cab33a0881f68052e914af0948c3b5964e8dafe16980ba0027cbe6d9d216082d)
       blessed-contrib:
         specifier: 4.11.0
         version: 4.11.0(patch_hash=2c9f0a87aa8ce9ed95ce201819ef3fcdb9a00f1cabe12815f586d2a3c0bff69e)
@@ -6984,7 +6984,7 @@ snapshots:
       term-canvas: 0.0.5
       x256: 0.0.2
 
-  blessed@0.1.81(patch_hash=cae83aa371bddce36c7a03bac146da97b1da2ce16059ce29e25c3af0182331a3): {}
+  blessed@0.1.81(patch_hash=cab33a0881f68052e914af0948c3b5964e8dafe16980ba0027cbe6d9d216082d): {}
 
   body-parser@2.2.2:
     dependencies:

--- a/test/blessed-node24-strict.test.mts
+++ b/test/blessed-node24-strict.test.mts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+
+// Regression for Node 24 compatibility: blessed's lib/tput.js used octal escape
+// sequences ('\200', '\016', '\017') that throw "Octal escape sequences are not
+// allowed in strict mode" when the CLI's strict/bundled output loads it, so the
+// CLI crashed on startup under Node 24. The blessed pnpm patch rewrites them as
+// hex escapes. This guards that the shipped tput.js stays strict-mode-safe.
+describe('blessed Node 24 compatibility', () => {
+  it('lib/tput.js parses under strict mode', () => {
+    const source = readFileSync(require.resolve('blessed/lib/tput.js'), 'utf8')
+    // Compiles (does not execute) the module in strict mode via the Function
+    // constructor, surfacing octal-escape syntax errors the same way Node 24
+    // does at load time.
+    expect(() => Function(`"use strict";\n${source}`)).not.toThrow()
+  })
+})


### PR DESCRIPTION
Node 24 rejects octal escape sequences in strict mode. The vendored `blessed` `lib/tput.js` uses `'\200'`, `'\016'`, and `'\017'`, which threw `SyntaxError: Octal escape sequences are not allowed in strict mode` on startup — the CLI could not run at all on Node 24 (users had to downgrade to Node 22).

This extends the existing `blessed` pnpm patch to use the byte-equivalent hex escapes (`'\x80'`, `'\x0e'`, `'\x0f'`).

Verified: the patched `lib/tput.js` now parses under strict mode (reproduced the original crash on the unpatched file first).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Byte-equivalent escape and numeric literal rewrites in a vendored TUI dependency; no app auth, data, or API surface changes.
> 
> **Overview**
> **Fixes startup on Node 24** by extending the existing `blessed@0.1.81` pnpm patch so vendored terminal code no longer uses octal *string* escapes that strict mode rejects.
> 
> In `lib/tput.js` and `lib/program.js`, legacy sequences like `'\200'`, `'\016'`, and `'\017'` are swapped for hex equivalents (`'\x80'`, `'\x0e'`, `'\x0f'`). Terminfo parsing comparisons move from `0377` to `0o377`, and default char fallbacks from `0200` to `0o200`, preserving behavior while satisfying the parser. The lockfile records the updated patch hash for `blessed`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de7f7a3a718de969aa36b831612a7e69a23f5e6d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->