### PR TITLE
feat(manifest): case-sensitive config-name globs with character classes (REA-621)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,24 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [1.1.136](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.136) - 2026-07-02
 
 ### Changed
-- `socket manifest gradle --facts` no longer silently skips a Gradle
-  configuration it can't resolve. Such configurations are now reported and stop
-  the run unless you pass `--ignore-unresolved`, so an incomplete scan can't slip
-  by unnoticed. Benign variant-selection ambiguity stays a one-line notice.
-- `--include-configs` / `--exclude-configs` patterns for `socket manifest
-  gradle`, `kotlin`, `scala`, and `maven` are now matched case-sensitively (as
-  documented) and support `[...]` character classes — e.g. `*[Tt]est*` matches
-  both `testCompileClasspath` and `androidTestCompileClasspath`.
+- `socket manifest gradle --facts` now reports Gradle configurations it can't resolve instead of silently skipping them, failing the run unless you pass `--ignore-unresolved` so an incomplete scan can't slip by. Benign variant-selection ambiguity stays a one-line notice.
+- Config filters (`--include-configs` / `--exclude-configs`) for `socket manifest gradle`, `kotlin`, `scala`, and `maven` are now case-sensitive, as documented, and support `[...]` character classes — e.g. `*[Tt]est*` matches both `testCompileClasspath` and `androidTestCompileClasspath`.
 
 ### Fixed
-- `socket manifest auto` and `scan create --auto-manifest` now detect a Gradle
-  project by its build files (`build.gradle`/`.kts` or `settings.gradle`/`.kts`)
-  instead of requiring a `gradlew` wrapper, so a project that builds with
-  `gradle` on your PATH — including a settings-only multi-module root — is no
-  longer skipped.
+- `socket manifest auto` and `socket scan create --auto-manifest` now detect a Gradle project by its build files (`build.gradle`/`.kts` or `settings.gradle`/`.kts`) instead of requiring a `gradlew` wrapper, so wrapper-less projects — including settings-only multi-module roots — are no longer skipped.
 
 ## [1.1.135](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.135) - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the run unless you pass `--ignore-unresolved`, so an incomplete scan can't slip
   by unnoticed. Benign variant-selection ambiguity stays a one-line notice.
 - `--include-configs` / `--exclude-configs` patterns for `socket manifest
-  gradle`, `kotlin`, `sbt`, and `maven` are now matched case-sensitively (as
+  gradle`, `kotlin`, `scala`, and `maven` are now matched case-sensitively (as
   documented) and support `[...]` character classes — e.g. `*[Tt]est*` matches
   both `testCompileClasspath` and `androidTestCompileClasspath`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+- `--include-configs` / `--exclude-configs` patterns for `socket manifest
+  gradle`, `kotlin`, `sbt`, and `maven` are now matched case-sensitively (as
+  documented) and support `[...]` character classes — e.g. `*[Tt]est*` matches
+  both `testCompileClasspath` and `androidTestCompileClasspath`.
+
 ## [1.1.135](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.135) - 2026-07-01
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.135",
+  "version": "1.1.136",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT",

--- a/src/commands/manifest/cmd-manifest-gradle.mts
+++ b/src/commands/manifest/cmd-manifest-gradle.mts
@@ -45,7 +45,7 @@ const config: CliCommandConfig = {
     includeConfigs: {
       type: 'string',
       description:
-        'When generating facts: comma-separated glob patterns matched against Gradle configuration names (case-sensitive, `*` and `?` wildcards). Only configurations matching at least one pattern are resolved. e.g. `*CompileClasspath,*RuntimeClasspath`. Default: every resolvable configuration except AGP instrumented-test classpaths',
+        'When generating facts: comma-separated glob patterns matched against Gradle configuration names (case-sensitive; `*`, `?`, and `[...]` wildcards). Only configurations matching at least one pattern are resolved. e.g. `*CompileClasspath,*RuntimeClasspath`. Default: every resolvable configuration except AGP instrumented-test classpaths',
     },
     excludeConfigs: {
       type: 'string',

--- a/src/commands/manifest/cmd-manifest-gradle.test.mts
+++ b/src/commands/manifest/cmd-manifest-gradle.test.mts
@@ -28,7 +28,7 @@ describe('socket manifest gradle', async () => {
             --facts             Emit a Socket facts JSON file (\`.socket.facts.json\`) describing the resolved dependency graph. This is the default; pass \`--pom\` to generate \`pom.xml\` files instead
             --gradle-opts       Additional options to pass on to ./gradlew, see \`./gradlew --help\`
             --ignore-unresolved  When generating facts: warn on unresolved dependencies instead of failing the run (unresolved deps are not emitted to the facts file)
-            --include-configs   When generating facts: comma-separated glob patterns matched against Gradle configuration names (case-sensitive, \`*\` and \`?\` wildcards). Only configurations matching at least one pattern are resolved. e.g. \`*CompileClasspath,*RuntimeClasspath\`. Default: every resolvable configuration except AGP instrumented-test classpaths
+            --include-configs   When generating facts: comma-separated glob patterns matched against Gradle configuration names (case-sensitive; \`*\`, \`?\`, and \`[...]\` wildcards). Only configurations matching at least one pattern are resolved. e.g. \`*CompileClasspath,*RuntimeClasspath\`. Default: every resolvable configuration except AGP instrumented-test classpaths
             --pom               Generate \`pom.xml\` manifest file(s) instead of the default Socket facts file (\`.socket.facts.json\`)
             --verbose           Print debug messages
 

--- a/src/commands/manifest/cmd-manifest-kotlin.mts
+++ b/src/commands/manifest/cmd-manifest-kotlin.mts
@@ -50,7 +50,7 @@ const config: CliCommandConfig = {
     includeConfigs: {
       type: 'string',
       description:
-        'When generating facts: comma-separated glob patterns matched against Gradle configuration names (case-sensitive, `*` and `?` wildcards). Only configurations matching at least one pattern are resolved. e.g. `*CompileClasspath,*RuntimeClasspath`. Default: every resolvable configuration except AGP instrumented-test classpaths',
+        'When generating facts: comma-separated glob patterns matched against Gradle configuration names (case-sensitive; `*`, `?`, and `[...]` wildcards). Only configurations matching at least one pattern are resolved. e.g. `*CompileClasspath,*RuntimeClasspath`. Default: every resolvable configuration except AGP instrumented-test classpaths',
     },
     excludeConfigs: {
       type: 'string',

--- a/src/commands/manifest/cmd-manifest-kotlin.test.mts
+++ b/src/commands/manifest/cmd-manifest-kotlin.test.mts
@@ -28,7 +28,7 @@ describe('socket manifest kotlin', async () => {
             --facts             Emit a Socket facts JSON file (\`.socket.facts.json\`) describing the resolved dependency graph. This is the default; pass \`--pom\` to generate \`pom.xml\` files instead
             --gradle-opts       Additional options to pass on to ./gradlew, see \`./gradlew --help\`
             --ignore-unresolved  When generating facts: warn on unresolved dependencies instead of failing the run (unresolved deps are not emitted to the facts file)
-            --include-configs   When generating facts: comma-separated glob patterns matched against Gradle configuration names (case-sensitive, \`*\` and \`?\` wildcards). Only configurations matching at least one pattern are resolved. e.g. \`*CompileClasspath,*RuntimeClasspath\`. Default: every resolvable configuration except AGP instrumented-test classpaths
+            --include-configs   When generating facts: comma-separated glob patterns matched against Gradle configuration names (case-sensitive; \`*\`, \`?\`, and \`[...]\` wildcards). Only configurations matching at least one pattern are resolved. e.g. \`*CompileClasspath,*RuntimeClasspath\`. Default: every resolvable configuration except AGP instrumented-test classpaths
             --pom               Generate \`pom.xml\` manifest file(s) instead of the default Socket facts file (\`.socket.facts.json\`)
             --verbose           Print debug messages
 

--- a/src/commands/manifest/cmd-manifest-maven.mts
+++ b/src/commands/manifest/cmd-manifest-maven.mts
@@ -34,7 +34,7 @@ const config: CliCommandConfig = {
     includeConfigs: {
       type: 'string',
       description:
-        'Comma-separated glob patterns matched against Maven dependency scopes (case-sensitive, `*` and `?` wildcards). Only scopes matching at least one pattern are resolved. e.g. `compile,runtime`. Default: every scope',
+        'Comma-separated glob patterns matched against Maven dependency scopes (case-sensitive; `*`, `?`, and `[...]` wildcards). Only scopes matching at least one pattern are resolved. e.g. `compile,runtime`. Default: every scope',
     },
     excludeConfigs: {
       type: 'string',

--- a/src/commands/manifest/cmd-manifest-maven.test.mts
+++ b/src/commands/manifest/cmd-manifest-maven.test.mts
@@ -25,7 +25,7 @@ describe('socket manifest maven', async () => {
             --bin               Location of the maven binary to use, default: ./mvnw if present, else mvn on PATH
             --exclude-configs   Comma-separated glob patterns; Maven scopes matching any pattern are skipped (applied after --include-configs)
             --ignore-unresolved  Warn on unresolved dependencies instead of failing the run (unresolved deps are not emitted to the facts file)
-            --include-configs   Comma-separated glob patterns matched against Maven dependency scopes (case-sensitive, \`*\` and \`?\` wildcards). Only scopes matching at least one pattern are resolved. e.g. \`compile,runtime\`. Default: every scope
+            --include-configs   Comma-separated glob patterns matched against Maven dependency scopes (case-sensitive; \`*\`, \`?\`, and \`[...]\` wildcards). Only scopes matching at least one pattern are resolved. e.g. \`compile,runtime\`. Default: every scope
             --maven-opts        Additional options to pass on to maven, e.g. \`-P <profile> -s <settings.xml>\`
             --verbose           Print debug messages
 

--- a/src/commands/manifest/cmd-manifest-scala.mts
+++ b/src/commands/manifest/cmd-manifest-scala.mts
@@ -43,7 +43,7 @@ const config: CliCommandConfig = {
     includeConfigs: {
       type: 'string',
       description:
-        'When generating facts: comma-separated glob patterns matched against sbt configuration names (case-sensitive, `*` and `?` wildcards). Only configurations matching at least one pattern are resolved. e.g. `compile,test`. Default: compile,optional,provided,runtime,test',
+        'When generating facts: comma-separated glob patterns matched against sbt configuration names (case-sensitive; `*`, `?`, and `[...]` wildcards). Only configurations matching at least one pattern are resolved. e.g. `compile,test`. Default: compile,optional,provided,runtime,test',
     },
     excludeConfigs: {
       type: 'string',

--- a/src/commands/manifest/cmd-manifest-scala.test.mts
+++ b/src/commands/manifest/cmd-manifest-scala.test.mts
@@ -27,7 +27,7 @@ describe('socket manifest scala', async () => {
             --exclude-configs   When generating facts: comma-separated glob patterns; sbt configurations matching any pattern are skipped (applied after --include-configs)
             --facts             Emit a Socket facts JSON file (\`.socket.facts.json\`) describing the resolved dependency graph. This is the default; pass \`--pom\` to generate \`pom.xml\` files instead
             --ignore-unresolved  When generating facts: warn on unresolved dependencies instead of failing the run (unresolved deps are not emitted to the facts file)
-            --include-configs   When generating facts: comma-separated glob patterns matched against sbt configuration names (case-sensitive, \`*\` and \`?\` wildcards). Only configurations matching at least one pattern are resolved. e.g. \`compile,test\`. Default: compile,optional,provided,runtime,test
+            --include-configs   When generating facts: comma-separated glob patterns matched against sbt configuration names (case-sensitive; \`*\`, \`?\`, and \`[...]\` wildcards). Only configurations matching at least one pattern are resolved. e.g. \`compile,test\`. Default: compile,optional,provided,runtime,test
             --out               Only with --pom: path of the output \`pom.xml\`, see also --stdout. Does not apply when generating Socket facts (always written to the project root as \`.socket.facts.json\`)
             --pom               Generate \`pom.xml\` manifest file(s) instead of the default Socket facts file (\`.socket.facts.json\`)
             --sbt-opts          Additional options to pass on to sbt, as per \`sbt --help\`

--- a/src/commands/manifest/scripts/maven-extension/src/main/java/tech/coana/socket/SocketSupport.java
+++ b/src/commands/manifest/scripts/maven-extension/src/main/java/tech/coana/socket/SocketSupport.java
@@ -42,7 +42,7 @@ public final class SocketSupport {
   /**
    * Translate a config-name glob to a case-sensitive regex. Supports {@code *}, {@code ?}, and
    * {@code [...]} character classes: enumerations ({@code [cC]}), ranges ({@code [a-z]}), and
-   * {@code [!..]} negation. A malformed glob falls back to a literal match rather than throwing.
+   * {@code [!..]}/{@code [^..]} negation. A malformed glob falls back to a literal match, never throws.
    */
   public static Pattern globToRegex(String glob) {
     StringBuilder sb = new StringBuilder();

--- a/src/commands/manifest/scripts/maven-extension/src/main/java/tech/coana/socket/SocketSupport.java
+++ b/src/commands/manifest/scripts/maven-extension/src/main/java/tech/coana/socket/SocketSupport.java
@@ -39,25 +39,44 @@ public final class SocketSupport {
     return coordId(groupId, artifactId, null, null, version);
   }
 
-  /** Translate a config-name glob ({@code *}/{@code ?}) to a case-insensitive regex. */
+  /**
+   * Translate a config-name glob to a case-sensitive regex. Supports {@code *}, {@code ?}, and
+   * {@code [...]} character classes: enumerations ({@code [cC]}), ranges ({@code [a-z]}), and
+   * {@code [!..]} negation. A malformed glob falls back to a literal match rather than throwing.
+   */
   public static Pattern globToRegex(String glob) {
     StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < glob.length(); i++) {
+    int i = 0;
+    int n = glob.length();
+    while (i < n) {
       char c = glob.charAt(i);
-      switch (c) {
-        case '*': sb.append(".*"); break;
-        case '?': sb.append('.'); break;
-        case '\\': case '.': case '^': case '$': case '|':
-        case '+': case '(': case ')':
-        case '[': case ']': case '{': case '}':
-          sb.append('\\').append(c); break;
-        default: sb.append(c);
-      }
+      if (c == '*') { sb.append(".*"); i++; }
+      else if (c == '?') { sb.append('.'); i++; }
+      else if (c == '[') {
+        int j = glob.indexOf(']', i + 1);
+        // Treat as a class only with a non-empty body; else a literal '['.
+        if (j <= i + 1) { sb.append("\\["); i++; }
+        else {
+          String body = glob.substring(i + 1, j);
+          boolean neg = body.startsWith("!");
+          if (neg) body = body.substring(1);
+          // Only literal chars and '-' ranges are meaningful; neutralize regex-class tricks.
+          body = body.replace("\\", "\\\\").replace("[", "\\[").replace("&", "\\&");
+          sb.append('[').append(neg ? "^" : "").append(body).append(']');
+          i = j + 1;
+        }
+      } else if ("\\.^$|+(){}]".indexOf(c) >= 0) {
+        sb.append('\\').append(c); i++;
+      } else { sb.append(c); i++; }
     }
-    return Pattern.compile(sb.toString(), Pattern.CASE_INSENSITIVE);
+    try {
+      return Pattern.compile(sb.toString());
+    } catch (java.util.regex.PatternSyntaxException e) {
+      return Pattern.compile(Pattern.quote(glob));
+    }
   }
 
-  /** Parse a comma-separated list of globs into case-insensitive patterns. */
+  /** Parse a comma-separated list of globs into case-sensitive patterns. */
   public static List<Pattern> parsePatterns(String csv) {
     List<Pattern> out = new ArrayList<>();
     if (csv == null || csv.trim().isEmpty()) return out;

--- a/src/commands/manifest/scripts/socket-facts.init.gradle
+++ b/src/commands/manifest/scripts/socket-facts.init.gradle
@@ -286,7 +286,7 @@ allprojects { project ->
 
       // Config-name glob to a case-SENSITIVE regex (matching is documented as case-sensitive).
       // Supports `*`, `?`, and `[...]` character classes: enumerations (`[cC]`), ranges (`[a-z]`),
-      // and `[!..]` negation. A malformed glob falls back to a literal match rather than throwing.
+      // and `[!..]`/`[^..]` negation. A malformed glob falls back to a literal match, never throws.
       def globToRegex = { String glob ->
         def sb = new StringBuilder()
         int i = 0

--- a/src/commands/manifest/scripts/socket-facts.init.gradle
+++ b/src/commands/manifest/scripts/socket-facts.init.gradle
@@ -284,22 +284,39 @@ allprojects { project ->
         n.contains('classpath') || n == 'compile' || n == 'runtime'
       }
 
-      // Config-name glob (`*`/`?` only) to a case-INSENSITIVE regex — Gradle config names are
-      // camelCase, so a case-sensitive `*Classpath` would miss the base `compileClasspath`.
+      // Config-name glob to a case-SENSITIVE regex (matching is documented as case-sensitive).
+      // Supports `*`, `?`, and `[...]` character classes: enumerations (`[cC]`), ranges (`[a-z]`),
+      // and `[!..]` negation. A malformed glob falls back to a literal match rather than throwing.
       def globToRegex = { String glob ->
         def sb = new StringBuilder()
-        glob.each { String ch ->
-          switch (ch) {
-            case '*': sb << '.*'; break
-            case '?': sb << '.'; break
-            case '.': case '\\': case '^': case '$': case '|':
-            case '+': case '(': case ')':
-            case '[': case ']': case '{': case '}':
-              sb << '\\' << ch; break
-            default: sb << ch
+        int i = 0
+        int n = glob.length()
+        while (i < n) {
+          def ch = glob[i]
+          if (ch == '*') { sb << '.*'; i++ }
+          else if (ch == '?') { sb << '.'; i++ }
+          else if (ch == '[') {
+            int j = glob.indexOf(']', i + 1)
+            // Treat as a class only with a non-empty body; else a literal `[`.
+            if (j <= i + 1) { sb << '\\['; i++ }
+            else {
+              def body = glob.substring(i + 1, j)
+              boolean neg = body.startsWith('!')
+              if (neg) { body = body.substring(1) }
+              // Only literal chars and `-` ranges are meaningful; neutralize regex-class tricks.
+              body = body.replace('\\', '\\\\').replace('[', '\\[').replace('&', '\\&')
+              sb << '[' << (neg ? '^' : '') << body << ']'
+              i = j + 1
+            }
           }
+          else if ('.\\^$|+(){}]'.contains(ch)) { sb << '\\' << ch; i++ }
+          else { sb << ch; i++ }
         }
-        java.util.regex.Pattern.compile(sb.toString(), java.util.regex.Pattern.CASE_INSENSITIVE)
+        try {
+          java.util.regex.Pattern.compile(sb.toString())
+        } catch (java.util.regex.PatternSyntaxException e) {
+          java.util.regex.Pattern.compile(java.util.regex.Pattern.quote(glob))
+        }
       }
 
       // `-Psocket.includeConfigs`/`-Psocket.excludeConfigs`: comma-separated config-name globs. A

--- a/src/commands/manifest/scripts/socket-facts.plugin.scala
+++ b/src/commands/manifest/scripts/socket-facts.plugin.scala
@@ -336,16 +336,39 @@ object SocketFactsPlugin extends AutoPlugin {
     }
   }
 
+  // Case-SENSITIVE (matching is documented as case-sensitive). Supports `*`, `?`, and `[...]`
+  // character classes: enumerations (`[cC]`), ranges (`[a-z]`), and `[!..]` negation. A malformed
+  // glob falls back to a literal match rather than throwing.
   private def globToRegex(glob: String): java.util.regex.Pattern = {
     val sb = new StringBuilder
-    glob.foreach {
-      case '*' => sb.append(".*")
-      case '?' => sb.append('.')
-      case c if "\\.^$|+()[]{}".indexOf(c.toInt) >= 0 =>
-        sb.append('\\').append(c)
-      case c => sb.append(c)
+    var i = 0
+    val n = glob.length
+    while (i < n) {
+      val c = glob.charAt(i)
+      if (c == '*') { sb.append(".*"); i += 1 }
+      else if (c == '?') { sb.append('.'); i += 1 }
+      else if (c == '[') {
+        val j = glob.indexOf(']', i + 1)
+        // Treat as a class only with a non-empty body; else a literal `[`.
+        if (j <= i + 1) { sb.append("\\["); i += 1 }
+        else {
+          var body = glob.substring(i + 1, j)
+          val neg = body.startsWith("!")
+          if (neg) body = body.substring(1)
+          // Only literal chars and `-` ranges are meaningful; neutralize regex-class tricks.
+          body = body.replace("\\", "\\\\").replace("[", "\\[").replace("&", "\\&")
+          sb.append('[').append(if (neg) "^" else "").append(body).append(']')
+          i = j + 1
+        }
+      } else if ("\\.^$|+(){}]".indexOf(c.toInt) >= 0) {
+        sb.append('\\').append(c); i += 1
+      } else { sb.append(c); i += 1 }
     }
-    java.util.regex.Pattern.compile(sb.toString, java.util.regex.Pattern.CASE_INSENSITIVE)
+    try java.util.regex.Pattern.compile(sb.toString)
+    catch {
+      case _: java.util.regex.PatternSyntaxException =>
+        java.util.regex.Pattern.compile(java.util.regex.Pattern.quote(glob))
+    }
   }
 
   // ConfigurationReport.configuration is a String on sbt 0.13, a ConfigRef on 1.x: read `.name` reflectively.

--- a/src/commands/manifest/scripts/socket-facts.plugin.scala
+++ b/src/commands/manifest/scripts/socket-facts.plugin.scala
@@ -337,8 +337,8 @@ object SocketFactsPlugin extends AutoPlugin {
   }
 
   // Case-SENSITIVE (matching is documented as case-sensitive). Supports `*`, `?`, and `[...]`
-  // character classes: enumerations (`[cC]`), ranges (`[a-z]`), and `[!..]` negation. A malformed
-  // glob falls back to a literal match rather than throwing.
+  // character classes: enumerations (`[cC]`), ranges (`[a-z]`), and `[!..]`/`[^..]` negation. A
+  // malformed glob falls back to a literal match, never throws.
   private def globToRegex(glob: String): java.util.regex.Pattern = {
     val sb = new StringBuilder
     var i = 0


### PR DESCRIPTION
## Problem

The `--include-configs` / `--exclude-configs` glob matchers in all three JVM facts producers — the Gradle init script (Groovy), the sbt plugin (Scala), and the Maven extension (Java) — compiled their patterns with `Pattern.CASE_INSENSITIVE`. That contradicts the CLI help ("case-sensitive") and the capitalized examples (`*CompileClasspath,*RuntimeClasspath`). Confirmed: `--include-configs '*classpath'` (lowercase) matched `compileClasspath` etc.

## Changes

1. **Case-sensitive matching** — dropped `CASE_INSENSITIVE` in all three `globToRegex` implementations, matching the documented behavior. (The old code even had a comment justifying the insensitivity on a false premise — `*Classpath` matches camelCase `compileClasspath` case-sensitively just fine.)
2. **Character-class support** — `[...]` now works: enumerations (`[cC]`), ranges (`[a-z]`), and `[!..]` negation. Under case-sensitive matching this lets a pattern span the camelCase boundary, e.g. `*[Tt]est*` matches both `testCompileClasspath` and `androidTestCompileClasspath` — impossible with `*`/`?` alone.
3. **Robustness** — the class body is hardened (escape `\`/`[`/`&`) so exotic input (POSIX classes, `&&` intersection) degrades to a literal match, and `Pattern.compile` is wrapped so a malformed glob (e.g. reversed range `[z-a]`) falls back to a literal match instead of throwing and failing the build.
4. Help text for gradle/kotlin/sbt/maven mentions `[...]`; fixed a stale "case-insensitive" javadoc on `SocketSupport.parsePatterns`.

## Why a custom converter (not a library / `PathMatcher`)

Considered `java.nio.file.PathMatcher` `glob:` and TS-side conversion (picomatch). Both were rejected:
- **`PathMatcher`** is case-sensitive on Unix but **case-insensitive on Windows** (JDK `Globs.toWindowsRegexPattern` adds `CASE_INSENSITIVE`), and `Path.of` is **Java 11+** — this code must run on **Java 8→newest, Gradle 1→newest, sbt 0.13→newest, Maven 3.3→newest**. `java.util.regex.Pattern` + string ops are stable since Java 1.4 and behave identically across that whole matrix.
- **picomatch/micromatch** emit **JS-flavored, path-oriented** regex (dotfile guards, `[^/]`, trailing `/?`) and even mangle `[Tt]` into `(?:\[Tt\]|[Tt])` — not portable to Java's regex engine, and passing a regex would change the producers' glob contract and add escaping fragility.

An independent review agent reached the same conclusion (custom converter), flagging the hardening/compile-guard and stale comment fixed here.

## Testing

- End-to-end against a real Gradle project: `*classpath` (lowercase) now matches nothing; `*Classpath` matches all four classpath configs; `*[Tt]est*` matches only the test configs; malformed `[z-a]` exits 0 (literal fallback, no crash).
- Maven extension jar rebuilds from source (gitignored, built in CI).
- Help snapshots updated; `pnpm check:tsc` clean; 12/12 manifest help tests pass.

**Follow-up (noted, not in this PR):** a shared cross-language conformance fixture would guard against the three hand-written converters drifting.

Closes REA-621. Part of the same Unreleased version as PRs #1398 (REA-519) and #1399 (REA-622). Note: the gradle/kotlin `--include-configs` help line also conflicts trivially with #1398 (which removes stale AGP text from the same string) — resolve by keeping both edits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Matching semantics change which build configurations/scopes are resolved into facts/SBOMs; users with lowercase or case-loose patterns may see different dependency coverage until patterns are fixed.
> 
> **Overview**
> **`--include-configs` / `--exclude-configs`** on JVM manifest commands now match configuration/scope names **case-sensitively**, aligning runtime behavior with the documented CLI help. Patterns that relied on case folding (e.g. `*classpath` matching `compileClasspath`) will stop matching unless updated.
> 
> The Gradle init script, sbt facts plugin, and Maven extension **`globToRegex`** implementations are updated in parallel: they drop `CASE_INSENSITIVE`, add **`[...]`** glob classes (including `[!…]` negation), harden class bodies against regex tricks, and **fall back to a literal match** when compilation fails so bad patterns do not crash the build.
> 
> CLI flag descriptions and help snapshots for **`socket manifest gradle`**, **`kotlin`**, **`scala`**, and **`maven`** now mention `[...]` wildcards; **CHANGELOG** records the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33850b408521573ac2b51c12e5c3b2fb0be976a6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->