### PR TITLE
fix(scan): scope --reach-ecosystems to reachability-supported ecosystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.144](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.144) - 2026-07-23
+
+### Fixed
+- `--reach-ecosystems` now rejects ecosystems the reachability engine cannot analyze, failing fast at the CLI with a clear message listing the supported ecosystems instead of erroring partway through a scan.
+
 ## [1.1.143](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.143) - 2026-07-10
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.143",
+  "version": "1.1.144",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT",

--- a/src/commands/scan/cmd-scan-create.mts
+++ b/src/commands/scan/cmd-scan-create.mts
@@ -1,7 +1,6 @@
 import { existsSync } from 'node:fs'
 import path from 'node:path'
 
-import { joinAnd } from '@socketsecurity/registry/lib/arrays'
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { assertValidExcludePaths } from './exclude-paths.mts'
@@ -20,7 +19,7 @@ import { commonFlags, outputFlags } from '../../flags.mts'
 import { checkCommandInput } from '../../utils/check-input.mts'
 import { cmdFlagValueToArray } from '../../utils/cmd.mts'
 import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
-import { getEcosystemChoicesForMeow } from '../../utils/ecosystem.mts'
+import { parseReachEcosystems } from '../../utils/ecosystem.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import {
   detectDefaultBranch,
@@ -39,7 +38,6 @@ import { detectManifestActions } from '../manifest/detect-manifest-actions.mts'
 
 import type { REPORT_LEVEL } from './types.mts'
 import type { MeowFlags } from '../../flags.mts'
-import type { PURL_Type } from '../../utils/ecosystem.mts'
 import type {
   CliCommandConfig,
   CliCommandContext,
@@ -308,18 +306,10 @@ async function run(
     reachVersion: string | undefined
   }
 
-  // Validate ecosystem values.
-  const reachEcosystems: PURL_Type[] = []
-  const reachEcosystemsRaw = cmdFlagValueToArray(cli.flags['reachEcosystems'])
-  const validEcosystems = getEcosystemChoicesForMeow()
-  for (const ecosystem of reachEcosystemsRaw) {
-    if (!validEcosystems.includes(ecosystem)) {
-      throw new Error(
-        `Invalid ecosystem: "${ecosystem}". Valid values are: ${joinAnd(validEcosystems)}`,
-      )
-    }
-    reachEcosystems.push(ecosystem as PURL_Type)
-  }
+  // Validate ecosystem values against the reachability-supported set.
+  const reachEcosystems = parseReachEcosystems(
+    cmdFlagValueToArray(cli.flags['reachEcosystems']),
+  )
 
   const dryRun = !!cli.flags['dryRun']
 

--- a/src/commands/scan/cmd-scan-create.test.mts
+++ b/src/commands/scan/cmd-scan-create.test.mts
@@ -67,7 +67,7 @@ describe('socket scan create', async () => {
             --reach-detailed-analysis-log-file  A log file with detailed analysis logs is written to root of each analyzed workspace.
             --reach-disable-analytics  Disable reachability analytics sharing with Socket. Also disables caching-based optimizations.
             --reach-disable-external-tool-checks  Disable external tool checks during reachability analysis.
-            --reach-ecosystems  List of ecosystems to conduct reachability analysis on, as either a comma separated value or as multiple flags. Defaults to all ecosystems.
+            --reach-ecosystems  List of ecosystems to conduct reachability analysis on, as either a comma separated value or as multiple flags. Supported: cargo, composer, gem, golang, maven, npm, nuget, pypi. Defaults to all supported ecosystems.
             --reach-enable-analysis-splitting  Allow the reachability analysis to partition CVEs into buckets that are processed in separate analysis runs. May improve accuracy, but not recommended by default.
             --reach-retain-facts-file  Keep the \`.socket.facts.json\` reachability report that the analysis writes to the scan directory instead of deleting it after a successful scan. IMPORTANT: you must delete this file before running a fresh full application reachability scan. A stale \`.socket.facts.json\` left in place is picked up as a pre-generated input and silently overrides fresh analysis, so the new scan results will not be reliable.
             --reach-skip-cache  Skip caching-based optimizations. By default, the reachability analysis will use cached configurations from previous runs to speed up the analysis.

--- a/src/commands/scan/cmd-scan-reach.mts
+++ b/src/commands/scan/cmd-scan-reach.mts
@@ -1,6 +1,5 @@
 import path from 'node:path'
 
-import { joinAnd } from '@socketsecurity/registry/lib/arrays'
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { assertValidExcludePaths } from './exclude-paths.mts'
@@ -13,7 +12,7 @@ import { commonFlags, outputFlags } from '../../flags.mts'
 import { checkCommandInput } from '../../utils/check-input.mts'
 import { cmdFlagValueToArray } from '../../utils/cmd.mts'
 import { determineOrgSlug } from '../../utils/determine-org-slug.mts'
-import { getEcosystemChoicesForMeow } from '../../utils/ecosystem.mts'
+import { parseReachEcosystems } from '../../utils/ecosystem.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import {
@@ -23,7 +22,6 @@ import {
 import { hasDefaultApiToken } from '../../utils/sdk.mts'
 
 import type { MeowFlags } from '../../flags.mts'
-import type { PURL_Type } from '../../utils/ecosystem.mts'
 import type {
   CliCommandConfig,
   CliCommandContext,
@@ -176,17 +174,8 @@ async function run(
   const reachExcludePaths = cmdFlagValueToArray(cli.flags['reachExcludePaths'])
   assertValidExcludePaths(excludePaths)
 
-  // Validate ecosystem values.
-  const reachEcosystems: PURL_Type[] = []
-  const validEcosystems = getEcosystemChoicesForMeow()
-  for (const ecosystem of reachEcosystemsRaw) {
-    if (!validEcosystems.includes(ecosystem)) {
-      throw new Error(
-        `Invalid ecosystem: "${ecosystem}". Valid values are: ${joinAnd(validEcosystems)}`,
-      )
-    }
-    reachEcosystems.push(ecosystem as PURL_Type)
-  }
+  // Validate ecosystem values against the reachability-supported set.
+  const reachEcosystems = parseReachEcosystems(reachEcosystemsRaw)
 
   const processCwd = process.cwd()
   const cwd =

--- a/src/commands/scan/cmd-scan-reach.test.mts
+++ b/src/commands/scan/cmd-scan-reach.test.mts
@@ -49,7 +49,7 @@ describe('socket scan reach', async () => {
             --reach-detailed-analysis-log-file  A log file with detailed analysis logs is written to root of each analyzed workspace.
             --reach-disable-analytics  Disable reachability analytics sharing with Socket. Also disables caching-based optimizations.
             --reach-disable-external-tool-checks  Disable external tool checks during reachability analysis.
-            --reach-ecosystems  List of ecosystems to conduct reachability analysis on, as either a comma separated value or as multiple flags. Defaults to all ecosystems.
+            --reach-ecosystems  List of ecosystems to conduct reachability analysis on, as either a comma separated value or as multiple flags. Supported: cargo, composer, gem, golang, maven, npm, nuget, pypi. Defaults to all supported ecosystems.
             --reach-enable-analysis-splitting  Allow the reachability analysis to partition CVEs into buckets that are processed in separate analysis runs. May improve accuracy, but not recommended by default.
             --reach-retain-facts-file  Keep the \`.socket.facts.json\` reachability report that the analysis writes to the scan directory instead of deleting it after a successful scan. IMPORTANT: you must delete this file before running a fresh full application reachability scan. A stale \`.socket.facts.json\` left in place is picked up as a pre-generated input and silently overrides fresh analysis, so the new scan results will not be reliable.
             --reach-skip-cache  Skip caching-based optimizations. By default, the reachability analysis will use cached configurations from previous runs to speed up the analysis.
@@ -287,6 +287,27 @@ describe('socket scan reach', async () => {
       const { code, stderr, stdout } = await spawnSocketCli(binCliPath, cmd)
       const output = stdout + stderr
       expect(output).toContain('Invalid ecosystem: "invalid-ecosystem"')
+      expect(code, 'should exit with non-zero code').not.toBe(0)
+    },
+  )
+
+  cmdit(
+    [
+      'scan',
+      'reach',
+      '--reach-ecosystems',
+      'conda',
+      '--org',
+      'fakeOrg',
+      FLAG_CONFIG,
+      '{"apiToken":"fakeToken"}',
+    ],
+    'should reject a purl type that lacks reachability support',
+    async cmd => {
+      const { code, stderr, stdout } = await spawnSocketCli(binCliPath, cmd)
+      const output = stdout + stderr
+      expect(output).toContain('Invalid ecosystem: "conda"')
+      expect(output).toContain('maven')
       expect(code, 'should exit with non-zero code').not.toBe(0)
     },
   )

--- a/src/commands/scan/reachability-flags.mts
+++ b/src/commands/scan/reachability-flags.mts
@@ -1,4 +1,5 @@
 import constants from '../../constants.mts'
+import { getReachabilityEcosystemChoices } from '../../utils/ecosystem.mts'
 
 import type { MeowFlags } from '../../flags.mts'
 
@@ -88,8 +89,7 @@ export const reachabilityFlags: MeowFlags = {
   reachEcosystems: {
     type: 'string',
     isMultiple: true,
-    description:
-      'List of ecosystems to conduct reachability analysis on, as either a comma separated value or as multiple flags. Defaults to all ecosystems.',
+    description: `List of ecosystems to conduct reachability analysis on, as either a comma separated value or as multiple flags. Supported: ${getReachabilityEcosystemChoices().join(', ')}. Defaults to all supported ecosystems.`,
   },
   reachExcludePaths: {
     type: 'string',

--- a/src/utils/ecosystem.mts
+++ b/src/utils/ecosystem.mts
@@ -22,7 +22,10 @@
  * - Ensures type safety for ecosystem operations
  */
 
+import { joinAnd } from '@socketsecurity/registry/lib/arrays'
+
 import { NPM } from '../constants.mts'
+import { InputError } from './errors.mts'
 
 import type { EcosystemString } from '@socketsecurity/registry'
 import type { components } from '@socketsecurity/sdk/types/api'
@@ -87,8 +90,27 @@ export type _Check_ALL_ECOSYSTEMS_has_no_extras =
 
 export const ALL_SUPPORTED_ECOSYSTEMS = new Set<string>(ALL_ECOSYSTEMS)
 
+// Purl types accepted by Coana's reachability `--purl-types` gate
+// (@coana-tech/cli `getAdvisoryEcosystemFromPurlType`), narrower than
+// ALL_ECOSYSTEMS. Values outside this set are rejected by the engine at scan
+// time, so we validate up front. Keep in sync when bumping @coana-tech/cli.
+export const REACHABILITY_SUPPORTED_ECOSYSTEMS = [
+  'cargo',
+  'composer',
+  'gem',
+  'golang',
+  'maven',
+  NPM,
+  'nuget',
+  'pypi',
+] as const satisfies readonly PURL_Type[]
+
 export function getEcosystemChoicesForMeow(): string[] {
   return [...ALL_ECOSYSTEMS]
+}
+
+export function getReachabilityEcosystemChoices(): string[] {
+  return [...REACHABILITY_SUPPORTED_ECOSYSTEMS]
 }
 
 export function isValidEcosystem(value: string): value is PURL_Type {
@@ -107,4 +129,18 @@ export function parseEcosystems(
       : value.map(v => String(v).toLowerCase())
 
   return values.filter(isValidEcosystem)
+}
+
+export function parseReachEcosystems(raw: readonly string[]): PURL_Type[] {
+  const choices = getReachabilityEcosystemChoices()
+  const result: PURL_Type[] = []
+  for (const ecosystem of raw) {
+    if (!choices.includes(ecosystem)) {
+      throw new InputError(
+        `Invalid ecosystem: "${ecosystem}". Valid values are: ${joinAnd(choices)}`,
+      )
+    }
+    result.push(ecosystem as PURL_Type)
+  }
+  return result
 }


### PR DESCRIPTION
## Problem

`socket scan create --reach --reach-ecosystems <values>` (and `socket scan reach`) validated the `--reach-ecosystems` values against the full purl-type list (`ALL_ECOSYSTEMS`, 32 entries), which is far broader than what the Coana reachability engine accepts. As a result, ecosystems the engine cannot analyze — e.g. `conda` — passed CLI validation and only failed partway through the scan with an opaque engine-level error:

```
Invalid purl type: conda. Supported purl types are: npm, maven, pypi, golang, composer, nuget
```

The CLI's validation list and the engine's accepted list disagreed, so bad input surfaced late and confusingly instead of failing fast at the CLI.

## Fix

Scope `--reach-ecosystems` validation to the set the Coana engine's `--purl-types` gate actually accepts, and share it between both commands:

- New `REACHABILITY_SUPPORTED_ECOSYSTEMS` constant + `getReachabilityEcosystemChoices()` in `src/utils/ecosystem.mts`: `cargo, composer, gem, golang, maven, npm, nuget, pypi`.
- New shared `parseReachEcosystems()` validator (throws `InputError`) replaces the two duplicated inline validation loops in `cmd-scan-create.mts` and `cmd-scan-reach.mts`.
- `ALL_ECOSYSTEMS` / `getEcosystemChoicesForMeow()` are left untouched — the `fix` command still validates its `--ecosystems` against the full purl-type list.
- The `--reach-ecosystems` help text now lists the supported ecosystems, generated from the constant so it cannot drift.

### Why this set

The set was verified against the bundled `@coana-tech/cli` 15.8.8 source. Its `--purl-types` validation gate (`getAdvisoryEcosystemFromPurlType`) accepts exactly these 8 purl types, and each one maps to a dedicated reachability analyzer that ships in the engine:

| purl type | Coana reachability analyzer |
|-----------|-----------------------------|
| npm       | JS Reachability Analyzer    |
| maven     | Java Reachability Analyzer  |
| pypi      | Python Reachability Analyzer|
| nuget     | .NET Reachability Analyzer  |
| golang    | Go Reachability Analyzer    |
| composer  | PHP Reachability Analyzer   |
| cargo     | Rust Reachability Analyzer  |
| gem       | Ruby Reachability Analyzer  |

So all 8 are genuinely reachability-supported: validating against them means the CLI accepts everything the engine can analyze and fails fast on everything else.

## Release

This PR bumps the patch version `1.1.143 → 1.1.144` and adds the dated `1.1.144` CHANGELOG entry, so merging it stages a new patch release. The actual npm publish is the manual `Publish to npm registry` workflow (`.github/workflows/provenance.yml`, `workflow_dispatch`), which publishes the `package.json` version at HEAD and tags `v1.1.144`.

## Testing

- `pnpm check` (lint + tsc) passes.
- `cmd-scan-create.test.mts` and `cmd-scan-reach.test.mts` pass, including a new regression test asserting a valid-but-unsupported purl type (`conda`) is rejected.
- Manual e2e (dry run): `--reach-ecosystems maven,pypi,conda` now errors immediately at the CLI; `maven,pypi` and `cargo,gem` pass validation.

## Out of scope / follow-ups

- Coana's own runtime error message under-reports its supported set: it lists only 6 purl types (`npm, maven, pypi, golang, composer, nuget`) and omits `cargo`/`gem`, even though the engine ships Rust and Ruby reachability analyzers and its `--purl-types` gate accepts them. That misleading message is a Coana-engine issue, tracked separately under REA.
- The v2.0.0 / `main` line (monorepo `packages/cli/src/...` layout) has the identical CLI bug and needs a parallel port.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI input validation only; narrows accepted values and fails fast with clearer errors, with no changes to scan execution or auth paths beyond earlier rejection of bad flags.
> 
> **Overview**
> **`--reach-ecosystems`** on `socket scan create` (with `--reach`) and `socket scan reach` no longer validates against the full purl-type list. It now checks only the eight ecosystems the Coana reachability engine accepts (`cargo`, `composer`, `gem`, `golang`, `maven`, `npm`, `nuget`, `pypi`), so values like `conda` fail immediately with a clear error instead of dying mid-scan.
> 
> Shared **`REACHABILITY_SUPPORTED_ECOSYSTEMS`**, **`parseReachEcosystems()`**, and help text driven by **`getReachabilityEcosystemChoices()`** replace duplicated inline loops in both scan commands. **`socket fix --ecosystems`** still uses the full **`ALL_ECOSYSTEMS`** list.
> 
> Patch release **1.1.144** with a CHANGELOG entry; regression test covers rejecting `conda` on `scan reach`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8578ffcaa466d8875bb6a2e8500237a75ce16215. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->