### PR TITLE
ci(npm-publish): rename to npm-publish.yml + env npm-publish, OIDC trusted publishing + dry-run gate + auto GitHub release (v1.x)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -49,6 +49,34 @@ jobs:
       id-token: write # NPM trusted publishing via OIDC
 
     steps:
+      # npm trusted publishing authorizes on repository + workflow filename +
+      # GitHub environment. It does NOT pin a branch, and the `npm-publish`
+      # environment has no deployment-branch policy (verified 2026-07-28:
+      # `deployment_branch_policy: null`, zero protection rules). So a
+      # `workflow_dispatch` from ANY ref that can reach this workflow mints a
+      # valid publish token, and `dist-tag` defaults to `latest` — a dispatch
+      # from an old release branch or an attacker-pushed branch could
+      # overwrite `socket@latest` with whatever that ref builds.
+      #
+      # This is the in-repo half of the mitigation: `latest` may only be
+      # published from the default branch. Any other ref must pick an explicit
+      # non-latest tag (next, beta, canary, backport, ...), which is how the
+      # v1.x line should publish anyway. Setting a deployment-branch policy on
+      # the environment is the other half and is worth doing too — this guard
+      # does not depend on it.
+      - name: Guard the latest dist-tag to the default branch
+        if: ${{ inputs.dist-tag == 'latest' }}
+        env:
+          REF: ${{ github.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          if [ "$REF" != "refs/heads/$DEFAULT_BRANCH" ]; then
+            echo "Refusing to publish dist-tag 'latest' from $REF." >&2
+            echo "Only refs/heads/$DEFAULT_BRANCH may publish 'latest'." >&2
+            echo "Re-dispatch from the default branch, or pick a non-latest dist-tag." >&2
+            exit 1
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 (2026-05-20)
         with:
           persist-credentials: false
@@ -254,7 +282,6 @@ jobs:
         id: publish_socket
         if: ${{ inputs.dry-run == false }}
         run: npm publish --provenance --access public --tag "${NPM_DIST_TAG}"
-        continue-on-error: true
         env:
           NPM_DIST_TAG: ${{ inputs.dist-tag }}
           SOCKET_CLI_DEBUG: ${{ inputs.debug }}
@@ -264,7 +291,6 @@ jobs:
       - name: Publish @socketsecurity/cli (legacy)
         if: ${{ inputs.dry-run == false }}
         run: npm publish --provenance --access public --tag "${NPM_DIST_TAG}"
-        continue-on-error: true
         env:
           NPM_DIST_TAG: ${{ inputs.dist-tag }}
           SOCKET_CLI_DEBUG: ${{ inputs.debug }}
@@ -274,7 +300,6 @@ jobs:
       - name: Publish @socketsecurity/cli-with-sentry
         if: ${{ inputs.dry-run == false }}
         run: npm publish --provenance --access public --tag "${NPM_DIST_TAG}"
-        continue-on-error: true
         env:
           NPM_DIST_TAG: ${{ inputs.dist-tag }}
           SOCKET_CLI_DEBUG: ${{ inputs.debug }}
@@ -287,8 +312,14 @@ jobs:
       #   - existing tag at different SHA → hard-fail (operator recovery
       #     required)
       # Gated on the first publish step (publish_socket — the `socket` npm
-      # package) actually succeeding; the cli / cli-with-sentry publishes
-      # use `continue-on-error: true` and don't gate the tag.
+      # package) actually succeeding.
+      #
+      # None of the three publishes carries `continue-on-error: true`. They
+      # used to, which made a 1-of-3 release look green: if `socket` landed
+      # and either of the other two failed, this step still ran and cut a
+      # v<version> tag plus an IMMUTABLE GitHub Release describing artifacts
+      # that were never published. Recovery from that is a version burn, so a
+      # failed publish now fails the job and no tag or release is created.
       #
       # Uses gh api (not `git push`) so the token only lives in this step's
       # env, never written to `.git/config` by an earlier `actions/checkout`

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,22 +8,37 @@ on:
         required: false
         default: 'latest'
         type: string
+      dry-run:
+        description: 'Build everything but do NOT publish, tag, or cut a release. Defaults to true so an accidental dispatch never reaches the registry — set to false for a real release.'
+        required: false
+        default: true
+        type: boolean
       debug:
         description: 'Enable debug output'
         required: false
         default: '0'
         type: string
-        options:
-          - '0'
-          - '1'
 
 permissions:
   contents: read
+
+# Serialize publishes per dist-tag. Two concurrent dispatches with the same
+# tag would race on `npm publish` (one wins, the other 409s). Don't cancel an
+# in-flight publish — a half-published release is worse than a queued one.
+concurrency:
+  group: publish-${{ inputs.dist-tag }}
+  cancel-in-progress: false
 
 jobs:
   build:
     name: Build and Publish
     runs-on: ubuntu-latest
+    # npm's trusted-publisher config pins this GitHub environment name (npm TP
+    # is PER-PACKAGE, not per-branch: the socket / @socketsecurity/cli /
+    # @socketsecurity/cli-with-sentry entries point at npm-publish.yml + the
+    # npm-publish environment). The OIDC token exchange 404s if this job runs
+    # outside it — so v1.x publishes from the same workflow filename + env as main.
+    environment: npm-publish
 
     permissions:
       # `contents: write` needed to create the v<version> tag via gh api
@@ -57,6 +72,7 @@ jobs:
           if [ ! -x "$PNPM_BIN" ]; then
             mkdir -p "$PNPM_DIR"
             curl -fsSL -o "$PNPM_BIN" "https://github.com/pnpm/pnpm/releases/download/v${PNPM_VERSION}/${ASSET}"
+            # shellcheck disable=SC1003 # `tr -d '\\'` strips the leading backslash GNU coreutils prepends to a checksum line when the path has a backslash (Windows RUNNER_TEMP).
             ACTUAL_SHA256="$( (sha256sum "$PNPM_BIN" 2>/dev/null || shasum -a 256 "$PNPM_BIN") | cut -d' ' -f1 | tr -d '\\')"
             if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
               echo "Checksum mismatch for ${ASSET}!" >&2
@@ -131,6 +147,7 @@ jobs:
               exit 1
             fi
             curl -fsSL -o "$SFW_BIN" "$DOWNLOAD_URL"
+            # shellcheck disable=SC1003 # `tr -d '\\'` strips the leading backslash GNU coreutils prepends to a checksum line when the path has a backslash (Windows RUNNER_TEMP).
             ACTUAL_SHA256="$( (sha256sum "$SFW_BIN" 2>/dev/null || shasum -a 256 "$SFW_BIN") | cut -d' ' -f1 | tr -d '\\')"
             if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
               echo "Checksum mismatch for ${ASSET} (${REPO}@v${SFW_VERSION})!" >&2
@@ -220,32 +237,46 @@ jobs:
           fi
           bash src/commands/manifest/scripts/maven-extension/build-jar.sh
 
+      # All three publishes use npm trusted publishing (OIDC): no long-lived
+      # NPM_TOKEN is set, so npm mints a short-lived registry token from the
+      # `id-token: write` OIDC token at publish time and attaches provenance.
+      # Each package (`socket`, `@socketsecurity/cli`,
+      # `@socketsecurity/cli-with-sentry`) must have a matching trusted
+      # publisher configured on npm for SocketDev/socket-cli + this workflow
+      # file + the v1.x branch, or the publish 404s on the token exchange.
+      #
+      # The publish steps are skipped entirely on a dry run (inputs.dry-run
+      # defaults to true), so an accidental dispatch builds but never reaches
+      # the registry. When skipped, publish_socket.outcome is not 'success',
+      # so the tag + release steps below also skip.
       - run: INLINED_SOCKET_CLI_PUBLISHED_BUILD=1 pnpm run build:dist
       - name: Publish socket
         id: publish_socket
+        if: ${{ inputs.dry-run == false }}
         run: npm publish --provenance --access public --tag "${NPM_DIST_TAG}"
         continue-on-error: true
         env:
           NPM_DIST_TAG: ${{ inputs.dist-tag }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # zizmor: ignore[secrets-outside-env]
           SOCKET_CLI_DEBUG: ${{ inputs.debug }}
       - run: INLINED_SOCKET_CLI_PUBLISHED_BUILD=1 INLINED_SOCKET_CLI_LEGACY_BUILD=1 pnpm run build:dist
         env:
           SOCKET_CLI_DEBUG: ${{ inputs.debug }}
-      - run: npm publish --provenance --access public --tag "${NPM_DIST_TAG}"
+      - name: Publish @socketsecurity/cli (legacy)
+        if: ${{ inputs.dry-run == false }}
+        run: npm publish --provenance --access public --tag "${NPM_DIST_TAG}"
         continue-on-error: true
         env:
           NPM_DIST_TAG: ${{ inputs.dist-tag }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # zizmor: ignore[secrets-outside-env]
           SOCKET_CLI_DEBUG: ${{ inputs.debug }}
       - run: INLINED_SOCKET_CLI_PUBLISHED_BUILD=1 INLINED_SOCKET_CLI_SENTRY_BUILD=1 pnpm run build:dist
         env:
           SOCKET_CLI_DEBUG: ${{ inputs.debug }}
-      - run: npm publish --provenance --access public --tag "${NPM_DIST_TAG}"
+      - name: Publish @socketsecurity/cli-with-sentry
+        if: ${{ inputs.dry-run == false }}
+        run: npm publish --provenance --access public --tag "${NPM_DIST_TAG}"
         continue-on-error: true
         env:
           NPM_DIST_TAG: ${{ inputs.dist-tag }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # zizmor: ignore[secrets-outside-env]
           SOCKET_CLI_DEBUG: ${{ inputs.debug }}
 
       # Create v<version> git tag at the published commit SHA after a
@@ -264,6 +295,7 @@ jobs:
       # with persist-credentials: true (which would leak it to every later
       # step including `pnpm install` postinstall scripts).
       - name: Tag release (idempotent)
+        id: tag
         if: steps.publish_socket.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -272,6 +304,10 @@ jobs:
           PUBLISHED_SHA=$(git rev-parse HEAD)
           PUBLISHED_VERSION=$(node -p "require('./package.json').version")
           TAG="v$PUBLISHED_VERSION"
+          # Emit the tag before any early exit so the release step below can
+          # consume it on every non-error path (fresh tag AND the same-SHA
+          # no-op).
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
           # Look up any existing tag ref. gh api exits non-zero on 404 (tag
           # absent) and writes the error body to stdout, so branch on the
@@ -307,3 +343,32 @@ jobs:
             -f "ref=refs/tags/$TAG" \
             -f "sha=$PUBLISHED_SHA"
           echo "Created tag $TAG at $PUBLISHED_SHA"
+
+      # Cut the immutable GitHub Release for the tag, idempotently. ORDER
+      # RULE: the tag + GH release are the FINAL markers of a release — they
+      # only exist AFTER the npm publish is confirmed live (this step is gated
+      # on the same publish_socket success as the tag step, and runs after
+      # it). Uses gh release (gh api under the hood) so GH_TOKEN only lives in
+      # this step's env, never written to `.git/config`. Skips cleanly if a
+      # release already exists for the tag so re-runs are safe.
+      - name: Cut GitHub release (idempotent)
+        if: steps.publish_socket.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — no-op."
+            exit 0
+          fi
+          # --verify-tag: refuse to create if the tag ref is somehow missing
+          # (the tag step above creates it; this guards against a race).
+          # --generate-notes: auto-populate notes from commits since the last
+          # release.
+          gh release create "$TAG" \
+            --repo "$REPO" \
+            --title "$TAG" \
+            --verify-tag \
+            --generate-notes
+          echo "Created GitHub release $TAG"


### PR DESCRIPTION
> [!IMPORTANT]
> **Update (adds commit `1bfae126c`):** the workflow is renamed `provenance.yml` → **`npm-publish.yml`** and its job now binds **`environment: npm-publish`**.
>
> npm trusted publishing is **per-package, not per-branch**. main now publishes `socket` / `@socketsecurity/cli` / `@socketsecurity/cli-with-sentry` from `npm-publish.yml` + the `npm-publish` environment, and their TP entries pin that filename + environment. v1.x must publish those same packages from the same filename + environment or the OIDC token exchange 404s — so this PR conforms NAME + ENV (previously `Environment: none`). v1.x's own 3-variant build/publish flow is otherwise unchanged; OIDC (`id-token: write`, no `NPM_TOKEN`) is unchanged.

## What this does

The v1.x publish workflow (`.github/workflows/npm-publish.yml`) is a standalone, inlined workflow that builds and publishes the three CLI packages to npm. This PR finishes the SURF-726 goal of making tag and release creation automatic in the release process, and removes the last long-lived npm secret from the release path.

Three changes:

1. **npm trusted publishing (OIDC) instead of a stored `NPM_TOKEN`.** All three `npm publish` steps drop `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`. The job already has `id-token: write`, so npm mints a short-lived registry token from the OIDC token at publish time and attaches provenance. No npm secret lives in the repo anymore.
2. **A `dry-run` input that defaults to the safe mode.** It defaults to `true`, so a stray dispatch builds everything but does not touch the registry. A real release requires a deliberate dispatch with `dry-run: false`.
3. **An automatic GitHub Release.** After a successful publish and the existing `v<version>` tag creation, the workflow cuts the immutable GitHub Release for that tag, idempotently.

Links: SURF-726. Modeled on socket-sdk-js [#639](https://github.com/SocketDev/socket-sdk-js/pull/639) (inlined standalone publish + idempotent auto-tag with a `dry-run` input), adapted to socket-cli v1.x's real build (Socket Firewall shims, the Maven manifest jar, and the three package variants), which was already inlined by #1322.

<details>
<summary>How the publish path works</summary>

The workflow runs on manual dispatch only. In order, the single `build` job:

1. Checks out with `persist-credentials: false` (no git token in `.git/config`).
2. Installs a pinned, checksum-verified pnpm and Node 25.9.0.
3. Downloads Socket Firewall and creates shims so `pnpm install` is scanned.
4. Installs dependencies and builds the Maven manifest extension jar.
5. Builds and publishes each of the three packages in turn: `socket`, `@socketsecurity/cli` (legacy), and `@socketsecurity/cli-with-sentry`.

Each publish uses `npm publish --provenance --access public --tag <dist-tag>`. The three variants differ only in the build env vars (`INLINED_SOCKET_CLI_LEGACY_BUILD`, `INLINED_SOCKET_CLI_SENTRY_BUILD`) that rename the package and adjust its bins before publish. None of that changed here; only the auth mechanism, the dry-run gate, and the release step are new.
</details>

<details>
<summary>OIDC / trusted-publisher setup (what needs configuring on npm)</summary>

npm trusted publishing means npm trusts a specific GitHub workflow to publish a package, with no shared secret. Each package must have a trusted-publisher entry on npm pointing at:

- Repository: `SocketDev/socket-cli`
- Workflow file: `.github/workflows/npm-publish.yml`
- Branch/ref: `v1.x`
- Environment: `npm-publish`

Packages that need the entry (this workflow publishes all three):

- `socket`
- `@socketsecurity/cli`
- `@socketsecurity/cli-with-sentry`

Until each entry exists on npm, that package's publish step will fail at the OIDC token exchange. This is why the token was removed here and configured on npm separately.
</details>

<details>
<summary>Dry-run gate</summary>

The `dry-run` input is a boolean, default `true`. Every publish step carries `if: ${{ inputs.dry-run == false }}`, so on a dry run they are skipped and only the build runs. Because the tag and release steps are gated on `steps.publish_socket.outcome == 'success'`, a skipped publish also skips the tag and the release. A real release is a deliberate dispatch with `dry-run: false`.

A `concurrency` group keyed on the dist-tag serializes concurrent dispatches so two runs can't race on the same `npm publish` (one would 409); an in-flight publish is never cancelled.
</details>

<details>
<summary>Token scoping and the order rule</summary>

The tag and release steps talk to GitHub through `gh` (`gh api` / `gh release`), with `GH_TOKEN` set only in each step's `env` block. The token is never written to `.git/config`, so it can't leak into an earlier `pnpm install`'s postinstall scripts. Checkout keeps `persist-credentials: false` for the same reason.

Order rule: the `v<version>` tag and the immutable GitHub Release are the final markers of a release. They are created only after the `socket` publish is confirmed live (`publish_socket.outcome == 'success'`), and the release step runs after the tag step. Tag creation is idempotent — an existing tag at the same commit is a no-op, and an existing tag at a different commit hard-fails with operator-recovery instructions (release immutability makes moving a tag unsafe). The release step is likewise idempotent: it no-ops if a release for the tag already exists.
</details>

## Validation

- `actionlint` on `.github/workflows/npm-publish.yml`: zero findings (exit 0). This PR also fixes a pre-existing actionlint error on v1.x — the `debug` input had an `options:` list that is only valid for `choice`-typed inputs.
- `zizmor` (v1.25.2): no findings (the two suppressed items are the pre-existing, intentional `github-env` ignores on the pnpm/Socket Firewall download scripts).
- No secret is written to `.git/config` (checkout uses `persist-credentials: false`) or exposed to `pnpm install` (the `gh` token lives only in the tag/release step env).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the release path to OIDC publishing and automatic immutable GitHub releases; misconfiguration or a dispatch with dry-run false can block or incorrectly gate production npm/GitHub artifacts.
> 
> **Overview**
> Hardens the v1.x **manual npm publish** workflow so accidental runs build only, publishes use **OIDC trusted publishing** instead of a repo secret, and a successful `socket` publish can **auto-tag and cut a GitHub Release**.
> 
> A new **`dry-run` input defaults to `true`**, so dispatch still runs the full build but **skips all three `npm publish` steps** unless `dry-run: false`. Tag and release steps stay gated on `publish_socket` succeeding, so dry runs never touch the registry or GitHub release markers. **`concurrency`** serializes runs per `dist-tag` without cancelling in-flight publishes.
> 
> **`NODE_AUTH_TOKEN` / `NPM_TOKEN` is removed** from every publish step; publishing relies on existing **`id-token: write`** and npm trusted-publisher config for `socket`, `@socketsecurity/cli`, and `@socketsecurity/cli-with-sentry`. Legacy and Sentry publishes get explicit step names; behavior is unchanged aside from auth and the dry-run gate.
> 
> After a successful primary publish, the **tag step** now exports **`tag` to step outputs** (including same-SHA no-op) for a new **idempotent `gh release create`** step (`--verify-tag`, `--generate-notes`). Minor workflow fixes: invalid **`debug` input `options`**, and **shellcheck notes** on checksum `tr` for Windows paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 651ad81b4a151ce03c057b86ffe55935092242b8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
