### PR TITLE
fix(package): correct mislabeled header in deep score markdown

### DIFF
--- a/packages/cli/src/commands/package/output-purls-deep-score.mts
+++ b/packages/cli/src/commands/package/output-purls-deep-score.mts
@@ -133,7 +133,7 @@ export function createMarkdownReport(data: PurlDataResponse): string {
     o.push(`- Vulnerability: ${score.vulnerability}`)
     o.push(`- License: ${score.license}`)
     o.push('')
-    o.push('### Capabilities')
+    o.push('### Lowest Scoring Package Per Category')
     o.push('')
     o.push(
       'These are the packages with the lowest recorded score. If there is more than one with the lowest score, just one is shown here. This may help you figure out the source of low scores.',

--- a/packages/cli/test/unit/commands/package/output-purls-deep-score-nuget-maven-python.test.mts
+++ b/packages/cli/test/unit/commands/package/output-purls-deep-score-nuget-maven-python.test.mts
@@ -71,7 +71,7 @@ describe('package score output', async () => {
         - Vulnerability: 84
         - License: 100
 
-        ### Capabilities
+        ### Lowest Scoring Package Per Category
 
         These are the packages with the lowest recorded score. If there is more than one with the lowest score, just one is shown here. This may help you figure out the source of low scores.
 
@@ -163,7 +163,7 @@ describe('package score output', async () => {
         - Vulnerability: 25
         - License: 50
 
-        ### Capabilities
+        ### Lowest Scoring Package Per Category
 
         These are the packages with the lowest recorded score. If there is more than one with the lowest score, just one is shown here. This may help you figure out the source of low scores.
 
@@ -268,7 +268,7 @@ describe('package score output', async () => {
         - Vulnerability: 100
         - License: 70
 
-        ### Capabilities
+        ### Lowest Scoring Package Per Category
 
         These are the packages with the lowest recorded score. If there is more than one with the lowest score, just one is shown here. This may help you figure out the source of low scores.
 

--- a/packages/cli/test/unit/commands/package/output-purls-deep-score.test.mts
+++ b/packages/cli/test/unit/commands/package/output-purls-deep-score.test.mts
@@ -106,7 +106,7 @@ describe('package score output', async () => {
         - Vulnerability: 25
         - License: 80
 
-        ### Capabilities
+        ### Lowest Scoring Package Per Category
 
         These are the packages with the lowest recorded score. If there is more than one with the lowest score, just one is shown here. This may help you figure out the source of low scores.
 
@@ -212,7 +212,7 @@ describe('package score output', async () => {
         - Vulnerability: 84
         - License: 70
 
-        ### Capabilities
+        ### Lowest Scoring Package Per Category
 
         These are the packages with the lowest recorded score. If there is more than one with the lowest score, just one is shown here. This may help you figure out the source of low scores.
 
@@ -311,7 +311,7 @@ describe('package score output', async () => {
         - Vulnerability: 72
         - License: 70
 
-        ### Capabilities
+        ### Lowest Scoring Package Per Category
 
         These are the packages with the lowest recorded score. If there is more than one with the lowest score, just one is shown here. This may help you figure out the source of low scores.
 


### PR DESCRIPTION
## What

`socket package score --markdown` printed `### Capabilities` twice in the **Transitive Package Results** section, back to back. The first one was mislabeled — its body is the *lowest-scoring package per score category*, not capabilities.

This renames that first header to `### Lowest Scoring Package Per Category`, so the two sections are distinct and each header matches its body.

Fixes #1356.

## Why

The duplicated heading is confusing in the rendered report (and produces duplicate anchors). The mislabel also means the report claimed a "Capabilities" section that actually described low-scoring packages.

## Change

<details>
<summary>Before / after (transitive section)</summary>

Before:

```
### Deep Score
...
### Capabilities          ← wrong label
These are the packages with the lowest recorded score. ...
- Overall: npm/shell-quote@0.0.1
...
### Capabilities          ← real capabilities
These are the capabilities detected in at least one package:
...
```

After:

```
### Deep Score
...
### Lowest Scoring Package Per Category
These are the packages with the lowest recorded score. ...
- Overall: npm/shell-quote@0.0.1
...
### Capabilities
These are the capabilities detected in at least one package:
...
```

</details>

- `src/commands/package/output-purls-deep-score.mts` — rename the header string.
- Updated the affected inline snapshots in the two deep-score output tests (npm/go/ruby + nuget/maven/python), which assert on the exact markdown.

## Testing

- `vitest run test/unit/commands/package/` — 144 passed.
- `pnpm run lint <file>` — passed.
- `tsc -p tsconfig.json --noEmit` — no errors in the changed file.

One unrelated pre-existing failure (`test/unit/constants.test.mts > has correct path properties`) is present on a clean `origin/main` too (environment-dependent path assertion); not touched by this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only markdown heading change with snapshot test updates; no scoring or API behavior changes.
> 
> **Overview**
> Fixes duplicate **`### Capabilities`** headings in the transitive section of `socket package score --markdown` output.
> 
> The block that lists **lowest-scoring packages per score category** (after **Deep Score**) is now titled **`### Lowest Scoring Package Per Category`**, so it no longer shares a heading with the real capabilities list. Unit test inline snapshots were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c25647afbc86f881058578e1f5c6cde5193f01a6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->