### PR TITLE
fix(package): include namespace in shallow score purl output

### DIFF
--- a/packages/cli/src/commands/package/output-purls-shallow-score.mts
+++ b/packages/cli/src/commands/package/output-purls-shallow-score.mts
@@ -29,7 +29,7 @@ export function formatReportCard(
     debug(`miss: artifact ecosystem ${JSON.stringify(artifact)}`)
   }
   /* c8 ignore stop */
-  const purl = `pkg:${artifact.ecosystem}/${artifact.name}${artifact.version ? `@${artifact.version}` : ''}`
+  const purl = `pkg:${artifact.ecosystem}/${artifact.namespace ? `${artifact.namespace}/` : ''}${artifact.name}${artifact.version ? `@${artifact.version}` : ''}`
 
   // Calculate proper padding based on longest label.
   const maxLabelLength = Math.max(

--- a/packages/cli/test/unit/commands/package/output-purls-shallow-score.test.mts
+++ b/packages/cli/test/unit/commands/package/output-purls-shallow-score.test.mts
@@ -34,12 +34,54 @@ import npmShallow from '../../../../src/commands/package/fixtures/npm_shallow.js
 import nugetShallow from '../../../../src/commands/package/fixtures/nuget_shallow.json' with { type: 'json' }
 import rubyShallow from '../../../../src/commands/package/fixtures/ruby_shallow.json' with { type: 'json' }
 import {
+  formatReportCard,
   generateMarkdownReport,
   generateTextReport,
   preProcess,
 } from '../../../../src/commands/package/output-purls-shallow-score.mts'
 
+import type { DedupedArtifact } from '../../../../src/commands/package/output-purls-shallow-score.mts'
+
 describe('package score output', async () => {
+  describe('namespaced packages in shallow report purl', () => {
+    function makeArtifact(
+      overrides: Partial<DedupedArtifact>,
+    ): DedupedArtifact {
+      return {
+        ecosystem: 'npm',
+        namespace: '',
+        name: 'react',
+        version: '4.11.0',
+        score: {
+          supplyChain: 99,
+          maintenance: 95,
+          quality: 100,
+          vulnerability: 100,
+          license: 70,
+        },
+        alerts: new Map(),
+        ...overrides,
+      }
+    }
+
+    it('should include the npm namespace in the reported purl', () => {
+      const card = formatReportCard(makeArtifact({ namespace: '@axe-core' }), {
+        colorize: false,
+      })
+      // Regression: the namespace was dropped, so the card reported
+      // `pkg:npm/react@4.11.0` instead of `pkg:npm/@axe-core/react@4.11.0`.
+      expect(card).toContain('Package: pkg:npm/@axe-core/react@4.11.0')
+      expect(card).not.toContain('Package: pkg:npm/react@4.11.0')
+    })
+
+    it('should omit the namespace segment when there is none', () => {
+      const card = formatReportCard(makeArtifact({ name: 'express' }), {
+        colorize: false,
+      })
+      expect(card).toContain('Package: pkg:npm/express@4.11.0')
+    })
+  })
+
   describe('npm', () => {
     it('should report shallow as text', () => {
       const { missing, rows } = preProcess(npmShallow.data, [])
@@ -101,7 +143,7 @@ describe('package score output', async () => {
                      reflect the scores of any dependencies, transitive or otherwise.
 
 
-        Package: [1mpkg:golang/tlsproxy@v0.0.0-20250304082521-29051ed19c60[22m
+        Package: [1mpkg:golang/github.com/steelpoor/tlsproxy@v0.0.0-20250304082521-29051ed19c60[22m
 
         - Supply Chain Risk:  [31m 39[39m
         - Maintenance:       [32m100[39m
@@ -126,7 +168,7 @@ describe('package score output', async () => {
 
 
 
-        ## Package: pkg:golang/tlsproxy@v0.0.0-20250304082521-29051ed19c60
+        ## Package: pkg:golang/github.com/steelpoor/tlsproxy@v0.0.0-20250304082521-29051ed19c60
 
         - Supply Chain Risk:   39
         - Maintenance:       100
@@ -248,7 +290,7 @@ describe('package score output', async () => {
                      reflect the scores of any dependencies, transitive or otherwise.
 
 
-        Package: [1mpkg:maven/beam-runners-flink-1.15-job-server@2.58.0[22m
+        Package: [1mpkg:maven/org.apache.beam/beam-runners-flink-1.15-job-server@2.58.0[22m
 
         - Supply Chain Risk:  [33m 67[39m
         - Maintenance:       [32m100[39m
@@ -273,7 +315,7 @@ describe('package score output', async () => {
 
 
 
-        ## Package: pkg:maven/beam-runners-flink-1.15-job-server@2.58.0
+        ## Package: pkg:maven/org.apache.beam/beam-runners-flink-1.15-job-server@2.58.0
 
         - Supply Chain Risk:   67
         - Maintenance:       100


### PR DESCRIPTION
## What

`socket package shallow` dropped the package **namespace** from the purl it printed in the report card. A scoped npm package like `@axe-core/react` was rendered as:

```
Package: pkg:npm/react@4.11.0
```

instead of `pkg:npm/@axe-core/react@4.11.0`. The informational log line (`Requesting shallow score data for ... pkg:npm/@axe-core/react`) already showed the correct purl, so the mismatch was confusing.

Fixes #971.

## Root cause

`formatReportCard()` in `output-purls-shallow-score.mts` rebuilt the purl from `ecosystem` / `name` / `version` but skipped the `namespace` segment:

```js
const purl = `pkg:${artifact.ecosystem}/${artifact.name}${artifact.version ? `@${artifact.version}` : ''}`
```

`preProcess()` already tracks `namespace` on the deduped artifact (and the deep-score renderer includes it), so only the report-card purl was affected.

## Change

- `src/commands/package/output-purls-shallow-score.mts` — add the namespace segment to the report-card purl, matching how `preProcess()` and the deep-score renderer build purls.

```diff
-const purl = `pkg:${artifact.ecosystem}/${artifact.name}${artifact.version ? `@${artifact.version}` : ''}`
+const purl = `pkg:${artifact.ecosystem}/${artifact.namespace ? `${artifact.namespace}/` : ''}${artifact.name}${artifact.version ? `@${artifact.version}` : ''}`
```

## Testing

- Added a focused regression test (`namespaced packages (issue #971)`) asserting the scoped-npm purl and the no-namespace case, calling `formatReportCard` directly.
- Updated the Go shallow snapshots, which now correctly show the module namespace (`pkg:golang/github.com/steelpoor/tlsproxy@...`) — this is the same bug for Go modules.
- `vitest run test/unit/commands/package/` — 146 passed.
- `pnpm run lint <files>` — passed.

<details>
<summary>Before / after (Go shallow report, showing the same bug for module namespaces)</summary>

Before: `Package: pkg:golang/tlsproxy@v0.0.0-...`
After: `Package: pkg:golang/github.com/steelpoor/tlsproxy@v0.0.0-...`

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display-only purl formatting fix with targeted unit tests; no API or scoring logic changes.
> 
> **Overview**
> Fixes **#971** by including the `namespace` segment when `formatReportCard` builds the purl for shallow package score text and markdown output, aligned with `preProcess()` and the deep-score renderer.
> 
> Scoped npm packages (e.g. `@axe-core/react`) and other namespaced ecosystems (Go modules, Maven coordinates) now show canonical purls such as `pkg:npm/@axe-core/react@…` instead of dropping the namespace and showing only the bare name.
> 
> Adds direct `formatReportCard` regression tests for scoped vs non-scoped npm and updates Go/Maven fixture snapshots to expect the corrected purls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 402cea18d21723fe160bd8616f6813c60691673c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->