### PR TITLE
docs(readme): clarify install-time protection covers npm, pnpm, and yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,16 @@ socket package npm/express@4.18.0
 # Scan your project's dependencies
 socket scan create
 
-# Audit an install before it runs
+# Audit an install before it runs (npm, pnpm, or yarn)
 socket npm install
+socket pnpm install
+socket yarn add <package>
 ```
+
+`socket npm`, `socket pnpm`, and `socket yarn` each run the underlying
+package manager through [Socket Firewall](https://docs.socket.dev), which
+blocks known-malicious packages before they are installed. Install-time
+protection is no longer npm-only.
 
 See [the Socket docs](https://docs.socket.dev) for the full command reference.
 


### PR DESCRIPTION
## What

Resolves the documentation inconsistency reported in #999: the [safe-npm FAQ](https://docs.socket.dev/docs/safe-npm-faq) says install-time protection is npm-only, while older READMEs mentioned wrapping pnpm and yarn. A reader can't tell which is current.

This updates the README Usage section to state plainly that `socket npm`, `socket pnpm`, and `socket yarn` all run the underlying package manager through Socket Firewall.

Refs #999.

## Why this is accurate

Verified against the current command definitions — all three forward to Socket Firewall (`sfw`):

- `src/commands/npm/cmd-npm.mts` — "Run npm with Socket Firewall security"
- `src/commands/pnpm/cmd-pnpm.mts` — "Run pnpm with Socket Firewall security"
- `src/commands/yarn/cmd-yarn.mts` — "Run yarn with Socket Firewall security"

So install-time protection is no longer npm-only; the FAQ's "npm only" statement is the stale one.

## Change

- `README.md` — expand the "Audit an install before it runs" example to cover npm/pnpm/yarn and add a one-paragraph note about Socket Firewall.

## Scope / follow-up

- This PR fixes the **README** side only. The [FAQ page](https://docs.socket.dev/docs/safe-npm-faq) lives in the separate `SocketDev/docs` repo and still needs a matching update — flagged for a docs-repo follow-up.
- `socket pnpm` / `socket yarn` are functional but hidden from top-level `--help` (npm is the primary documented entry point); documenting them here is intentional so their existence is discoverable.

## Testing

Docs-only. `markdownlint-cli2` reports no errors in `README.md` (the 5 findings in the run are pre-existing, in unrelated `docs/agents.md/fleet/*.md` files).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to README.md with no runtime or security behavior impact.
> 
> **Overview**
> Updates the **Usage** section so install-time auditing is described for **npm, pnpm, and yarn**, not only npm.
> 
> The "Audit an install before it runs" example now includes `socket pnpm install` and `socket yarn add`, and a short note explains that `socket npm`, `socket pnpm`, and `socket yarn` all delegate to **Socket Firewall** so malicious packages can be blocked before install—explicitly stating that protection is **no longer npm-only**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f15c7c68cd26030befc3bc4437f1bfafb4b3669e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->