### PR TITLE
fix(npm): merge NODE_OPTIONS and drop quotes in shadow --node-options

### DIFF
--- a/src/shadow/npm-base.mts
+++ b/src/shadow/npm-base.mts
@@ -37,6 +37,42 @@ export type ShadowBinResult = {
   spawnPromise: SpawnResult<string, SpawnExtra | undefined>
 }
 
+// Length of the '--node-options=' prefix, used to slice the value out of an
+// npm '--node-options=<value>' argument.
+const NODE_OPTIONS_FLAG_PREFIX_LENGTH = '--node-options='.length
+
+/**
+ * Build the '--node-options=<value>' argument passed to npm so its lifecycle
+ * scripts run with our Node permission flags.
+ *
+ * npm assigns this value to NODE_OPTIONS for the scripts it runs, REPLACING any
+ * inherited NODE_OPTIONS. To avoid clobbering the user's configuration we merge,
+ * in order, the caller's existing process.env.NODE_OPTIONS and any
+ * '--node-options=<value>' npm argument ahead of our permission flags (issue
+ * #1036).
+ *
+ * The value is intentionally NOT wrapped in quotes. shadowNpmBase spawns npm
+ * without a shell, so any quotes would be passed literally to npm and become
+ * part of the NODE_OPTIONS value. Consumers that re-tokenize NODE_OPTIONS on
+ * whitespace (e.g. Next.js) then strip the leading quote off '--permission',
+ * dropping it while keeping the '--allow-*' flags, which crashes Node >= 24
+ * with ERR_MISSING_OPTION (issue #1160).
+ */
+export function buildNpmNodeOptionsArg(
+  envNodeOptions: string | undefined,
+  nodeOptionsArg: string | undefined,
+  permArgs: string[] | readonly string[],
+): string {
+  const value = [
+    envNodeOptions,
+    nodeOptionsArg ? nodeOptionsArg.slice(NODE_OPTIONS_FLAG_PREFIX_LENGTH) : '',
+    cmdFlagsToString(permArgs),
+  ]
+    .filter(Boolean)
+    .join(' ')
+  return `--node-options=${value}`
+}
+
 export default async function shadowNpmBase(
   binName: typeof NPM | typeof NPX,
   args: string[] | readonly string[] = process.argv.slice(2),
@@ -113,7 +149,11 @@ export default async function shadowNpmBase(
       ...noAuditArgs,
       ...(useNodeOptions
         ? [
-            `--node-options='${nodeOptionsArg ? nodeOptionsArg.slice(15) : ''}${cmdFlagsToString(permArgs)}'`,
+            buildNpmNodeOptionsArg(
+              process.env['NODE_OPTIONS'],
+              nodeOptionsArg,
+              permArgs,
+            ),
           ]
         : []),
       '--no-fund',

--- a/src/shadow/npm-base.test.mts
+++ b/src/shadow/npm-base.test.mts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildNpmNodeOptionsArg } from './npm-base.mts'
+
+// The permission flags shadowNpmBase injects on Node versions that support
+// --permission. Mirrors the array built in npm-base.mts.
+const permArgs = [
+  '--permission',
+  '--allow-child-process',
+  '--allow-fs-read=*',
+  '--allow-fs-write=/project/*',
+]
+
+describe('buildNpmNodeOptionsArg', () => {
+  it('does not wrap the value in quotes (issue #1160)', () => {
+    // Literal quotes survive spawn() (no shell) and get re-tokenized by
+    // consumers like Next.js, which strips the leading quote off --permission
+    // and crashes Node >= 24 with ERR_MISSING_OPTION.
+    const result = buildNpmNodeOptionsArg(undefined, undefined, permArgs)
+
+    expect(result).not.toContain("'")
+    expect(result).not.toContain('"')
+    expect(result).toBe(
+      '--node-options=--permission --allow-child-process --allow-fs-read=* --allow-fs-write=/project/*',
+    )
+    // The NODE_OPTIONS value must keep --permission as a clean, standalone
+    // token so a whitespace re-tokenizer (Next.js) doesn't orphan the
+    // --allow-* flags.
+    const value = result.slice('--node-options='.length)
+    expect(value.split(' ')).toContain('--permission')
+  })
+
+  it('merges an inherited NODE_OPTIONS env value ahead of perm flags (issue #1036)', () => {
+    const result = buildNpmNodeOptionsArg(
+      '--max-old-space-size=4096',
+      undefined,
+      permArgs,
+    )
+
+    expect(result).toBe(
+      '--node-options=--max-old-space-size=4096 --permission --allow-child-process --allow-fs-read=* --allow-fs-write=/project/*',
+    )
+  })
+
+  it('preserves the inherited NODE_OPTIONS even when there are no perm flags', () => {
+    const result = buildNpmNodeOptionsArg('--enable-source-maps', undefined, [])
+
+    expect(result).toBe('--node-options=--enable-source-maps')
+  })
+
+  it('strips the --node-options= prefix from an npm --node-options arg', () => {
+    const result = buildNpmNodeOptionsArg(
+      undefined,
+      '--node-options=--trace-warnings',
+      permArgs,
+    )
+
+    expect(result).toBe(
+      '--node-options=--trace-warnings --permission --allow-child-process --allow-fs-read=* --allow-fs-write=/project/*',
+    )
+  })
+
+  it('merges env NODE_OPTIONS, the npm --node-options arg, and perm flags in order', () => {
+    const result = buildNpmNodeOptionsArg(
+      '--enable-source-maps',
+      '--node-options=--trace-warnings',
+      permArgs,
+    )
+
+    expect(result).toBe(
+      '--node-options=--enable-source-maps --trace-warnings --permission --allow-child-process --allow-fs-read=* --allow-fs-write=/project/*',
+    )
+  })
+
+  it('emits an empty value when nothing is provided', () => {
+    const result = buildNpmNodeOptionsArg(undefined, undefined, [])
+
+    expect(result).toBe('--node-options=')
+  })
+
+  it('drops an empty-string env NODE_OPTIONS instead of adding a stray space', () => {
+    const result = buildNpmNodeOptionsArg('', undefined, permArgs)
+
+    expect(result).toBe(
+      '--node-options=--permission --allow-child-process --allow-fs-read=* --allow-fs-write=/project/*',
+    )
+  })
+})


### PR DESCRIPTION
Two things go wrong today when you run `socket npm run build` on Node 24 or newer.

**It crashes.** Node throws `TypeError [ERR_MISSING_OPTION]: --permission is required` and the build dies. Nothing you did caused it — `socket npm` mangles its own flags on the way in.

**It silently discards your `NODE_OPTIONS`.** If you had `NODE_OPTIONS=--max-old-space-size=4096` set globally, running your build through `socket npm` throws it away. Builds that need the extra heap just fail, with no message saying why.

Both come from one line in `src/shadow/npm-base.mts`, and this PR fixes both. Fixes #1160 and #1036.

<details>

<summary><b>Bug 1</b> — the quotes were never needed, and Next.js chokes on them (#1160)</summary>

The old line wrapped the value in literal single quotes:

```js
`--node-options='${nodeOptionsArg ? nodeOptionsArg.slice(15) : ''}${cmdFlagsToString(permArgs)}'`
```

`shadowNpmBase` spawns npm **without a shell**, so nothing ever interprets those quotes. They become part of the value npm assigns to `NODE_OPTIONS` for lifecycle scripts:

```
NODE_OPTIONS='--permission --allow-child-process --allow-fs-read=* ...'
```

Node itself tolerates the garbled tokens. Consumers that re-tokenize `NODE_OPTIONS` on whitespace and only honour `"` do not — Next.js's TypeScript build worker is the one users hit. It drops `'--permission` (it has a leading quote glued to it) while keeping the valid `--allow-*` flags. Node 24 then throws, because the allow-list flags are orphaned:

```
TypeError [ERR_MISSING_OPTION]: --permission is required
```

Removing the quotes keeps `--permission` a clean, standalone token.

</details>

<details>

<summary><b>Bug 2</b> — npm's <code>--node-options</code> replaces the inherited value, so ours clobbered the user's (#1036)</summary>

The old value merged in a `--node-options=` npm argument if one was present, but never the caller's existing `process.env.NODE_OPTIONS`. Since npm's `--node-options` config **replaces** the inherited `NODE_OPTIONS` for scripts, a globally-configured `NODE_OPTIONS` was silently dropped:

```
$ NODE_OPTIONS=test socket npm run echo   # echoes socket's flags, not "test"
```

The value now merges three sources, in this order:

| Order | Source |
| --- | --- |
| 1 | `process.env.NODE_OPTIONS` — whatever the caller already had |
| 2 | any `--node-options=` npm argument, with its prefix stripped |
| 3 | Socket's own permission flags |

</details>

<details>

<summary><b>The change</b> — one pure exported helper, so both behaviours are testable without spawning</summary>

The construction moved out of the template literal and into a pure, exported `buildNpmNodeOptionsArg(envNodeOptions, nodeOptionsArg, permArgs)`, and the call site now uses it. Empty and falsy inputs are filtered out so the merge never leaves a stray separator.

Concretely, for `NODE_OPTIONS=--max-old-space-size=4096 socket npm run build` on Node 24:

- **Before:** `--node-options='--permission --allow-child-process ...'` → `--permission` dropped downstream → crash, and `--max-old-space-size` lost.
- **After:** `--node-options=--max-old-space-size=4096 --permission --allow-child-process --allow-fs-read=* ...` → all tokens clean, user value preserved.

</details>

<details>

<summary><b>What I checked</b> — 7 new unit tests, plus typecheck and lint on the changed files</summary>

New `src/shadow/npm-base.test.mts` covers:

- the value is never quoted and `--permission` stays a standalone token (#1160)
- inherited `process.env.NODE_OPTIONS` is merged ahead of the permission flags (#1036)
- the inherited value survives even when there are no permission flags
- a `--node-options=` npm arg has its prefix stripped and is preserved
- env + npm-arg + perm-flags merge in that order
- empty / falsy inputs do not leave stray separators

**Ran:**

- `pnpm exec vitest run src/shadow/npm-base.test.mts` — 7/7 pass
- `pnpm run check:tsc` — clean
- `oxlint` on changed files — 0 errors (only pre-existing `no-named-as-default-member` warnings on unchanged lines)

</details>

<details>

<summary><b>Branch scope</b> — this targets <code>v1.x</code>; <code>main</code> does not have the bug</summary>

Targets `v1.x`, the branch where the shadow-npm wrapper lives. The issues reproduce on v1.1.78.

On `main`, `socket npm` hands off to Socket Firewall and no longer builds this argument, so `main` is unaffected and needs no companion PR.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes NODE_OPTIONS passed into npm lifecycle scripts (build/run), which can affect all downstream script processes, but the logic is isolated, well-tested, and targets known production bugs.
> 
> **Overview**
> Fixes how `socket npm` builds the `--node-options` flag for npm lifecycle scripts by replacing inline string templating with **`buildNpmNodeOptionsArg`**.
> 
> The value is no longer wrapped in single quotes, so `--permission` stays a real token when tools re-split `NODE_OPTIONS` on whitespace (fixes Node ≥ 24 `ERR_MISSING_OPTION` on builds like Next.js, #1160). The helper also merges **`process.env.NODE_OPTIONS`**, any existing npm `--node-options=…` arg, and Socket’s permission flags in that order, because npm’s flag replaces inherited `NODE_OPTIONS` for scripts (#1036).
> 
> Adds **`npm-base.test.mts`** with seven unit tests for quoting, merge order, prefix stripping, and empty inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f272fbb406700e69b3ce80241a168f518ee944b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
