### PR TITLE
test(cli): make cmd-ci dry-run snapshot branch-agnostic

### DIFF
--- a/packages/cli/test/integration/cli/cmd-ci.test.mts
+++ b/packages/cli/test/integration/cli/cmd-ci.test.mts
@@ -97,7 +97,7 @@ describe('socket ci', async () => {
 
           Details:
             autoManifest: false
-            branchName: "main"
+            branchName: "[BRANCH]"
             cwd: "[PROJECT]"
             organizationSlug: "(from API token)"
             repoName: "socket-cli"

--- a/packages/cli/test/util/scrub-snapshot-data.mts
+++ b/packages/cli/test/util/scrub-snapshot-data.mts
@@ -31,6 +31,10 @@ interface ScrubOptions {
    */
   ipAddresses?: boolean | undefined
   /**
+   * Scrub git branch names in dry-run details (default: true).
+   */
+  branches?: boolean | undefined
+  /**
    * Scrub email addresses (default: false - usually stable in mocks).
    */
   emails?: boolean | undefined
@@ -56,6 +60,7 @@ export function scrubSnapshotData(
   options: ScrubOptions = {},
 ): string {
   const {
+    branches = true,
     custom = [],
     emails = false,
     ids = true,
@@ -149,7 +154,26 @@ export function scrubSnapshotData(
     )
   }
 
-  // Phase 7: Custom patterns.
+  // Phase 7: Git branch names in dry-run details.
+  if (branches) {
+    // The CLI resolves the branch from the ambient git checkout
+    // (`git symbolic-ref`) or the CI env (GITHUB_HEAD_REF / GITHUB_REF_NAME),
+    // so the rendered `branchName: "…"` is whatever branch the test happens to
+    // run on — "main" on a main push, the PR head branch on a PR build, the
+    // local feature branch when run from a worktree, or a short commit hash on
+    // a detached HEAD with no CI env. Pin it so the snapshot is branch-agnostic
+    // (this test failed on every non-main PR before). The branch-resolution
+    // logic itself stays covered by the unit tests that mock `gitBranch`
+    // (handle-ci / cmd-ci unit specs). Only matches the human-readable details
+    // form (`branchName: "…"`, space after the unquoted key), not JSON output
+    // (`"branchName":"…"`).
+    scrubbed = scrubbed.replace(
+      /branchName: "[^"]*"/g,
+      'branchName: "[BRANCH]"',
+    )
+  }
+
+  // Phase 8: Custom patterns.
   for (const { pattern, replacement } of custom) {
     scrubbed = scrubbed.replace(pattern, replacement)
   }

--- a/packages/cli/test/util/scrub-snapshot-data.test.mts
+++ b/packages/cli/test/util/scrub-snapshot-data.test.mts
@@ -173,6 +173,38 @@ describe('scrubSnapshotData', () => {
     })
   })
 
+  describe('git branch names', () => {
+    it('should scrub the auto-detected branch name in dry-run details', () => {
+      const input = '  branchName: "main"'
+      const result = scrubSnapshotData(input)
+      expect(result).toBe('  branchName: "[BRANCH]"')
+    })
+
+    it('should scrub a feature branch name with slashes', () => {
+      const input = '  branchName: "fix/cmd-ci-branch-snapshot"'
+      const result = scrubSnapshotData(input)
+      expect(result).toBe('  branchName: "[BRANCH]"')
+    })
+
+    it('should scrub a detached-HEAD commit-hash fallback', () => {
+      const input = '  branchName: "a0211c9"'
+      const result = scrubSnapshotData(input)
+      expect(result).toBe('  branchName: "[BRANCH]"')
+    })
+
+    it('should not scrub JSON-form branchName (quoted key)', () => {
+      const input = '"branchName":"develop"'
+      const result = scrubSnapshotData(input)
+      expect(result).toBe('"branchName":"develop"')
+    })
+
+    it('should preserve branch names when disabled', () => {
+      const input = '  branchName: "main"'
+      const result = scrubSnapshotData(input, { branches: false })
+      expect(result).toBe('  branchName: "main"')
+    })
+  })
+
   describe('custom patterns', () => {
     it('should apply custom scrubbing patterns', () => {
       const input = 'API key: abc-123-def and token: xyz-456-uvw'


### PR DESCRIPTION
## What

The `socket ci` integration test (`packages/cli/test/integration/cli/cmd-ci.test.mts`) hardcoded `branchName: "main"` in its dry-run inline snapshot. That value is environment-dependent, so the test passed only on a `main` push and **failed on every non-main PR** — reddening the `🧪 Test` check across the whole open-PR fleet (I hit it on an unrelated workflow PR, #1429).

## Root cause

The CLI resolves the branch at runtime (`packages/cli/src/util/git/git-remote-info.mts` → `gitBranch`):
1. `git symbolic-ref --short HEAD` — the current branch when on one (local / worktree runs).
2. On detached HEAD (CI checkouts): `GITHUB_HEAD_REF` (PR head branch), else `GITHUB_REF_NAME` when the ref is a branch.
3. Fallback: short commit hash.

So the dry-run details print whatever branch the test runs on — `"main"` on a main push, the PR head branch on a PR build, the local feature branch from a worktree. The snapshot only matched case 1-on-main.

<details>
<summary>Before/after proof (run on a non-main branch)</summary>

On branch `fix/cmd-ci-branch-snapshot`, the raw built CLI emits the feature branch (would fail the old `"main"` snapshot):

```
$ node dist/cli.js ci --dry-run --config '{"apiToken":"fakeToken"}'
    branchName: "fix/cmd-ci-branch-snapshot"
```

With the scrub in place, the integration test passes on that same non-main branch:

```
$ pnpm exec vitest run --config vitest.integration.config.mts test/integration/cli/cmd-ci.test.mts
 ✓ test/integration/cli/cmd-ci.test.mts (2 tests)
     ✓ should support --help
     ✓ should require args with just dry-run
 Test Files  1 passed (1)
```

</details>

## Fix

Handled at the snapshot-scrubber boundary (`packages/cli/test/util/scrub-snapshot-data.mts`), alongside the existing `[PROJECT]` / `[TIMESTAMP]` / `[UUID]` / `[IP]` normalizations — the same place volatile, environment-specific values are already pinned:

- `scrubSnapshotData` now replaces the human-readable `branchName: "…"` details line with `branchName: "[BRANCH]"` (new `branches` option, default `true`). The regex only matches the details form (unquoted key + `: "`), **not** JSON output (`"branchName":"…"`), so machine-readable snapshots are untouched.
- Updated the one snapshot that pinned it (`branchName: "[BRANCH]"`).

**No real coverage lost:** branch-resolution behavior stays asserted by the unit specs that mock `gitBranch` (`handle-ci` / `cmd-ci` unit tests assert `develop` / `feature-branch` / `(default)` with deterministic inputs). This test only verifies the dry-run details block renders — which it still does.

## Testing

- Added 5 scrubber unit tests (main / slashed feature branch / detached-HEAD hash / JSON-form left intact / disabled). `scrub-snapshot-data.test.mts`: **35/35 pass**.
- `cmd-ci` integration test: **2/2 pass on a non-main branch** (was red before — see proof above).
- oxlint clean on all changed files; `tsgo --noEmit` reports zero errors in changed files (the pre-existing TS4111 errors in `output-purls-shallow-score.mts` are on `main`, untouched here).

## Impact

Unblocks the `🧪 Test` check for all non-main socket-cli PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to snapshot scrubbing; no CLI runtime or branch-resolution logic is modified.
> 
> **Overview**
> Fixes flaky **`socket ci`** integration snapshots that assumed `branchName: "main"` while the CLI prints the ambient git/CI branch.
> 
> **`scrubSnapshotData`** now normalizes human-readable dry-run details lines (`branchName: "…"`) to `branchName: "[BRANCH]"` via a new **`branches`** option (default **on**). JSON-style `"branchName":"…"` output is left unchanged. The **`cmd-ci`** dry-run inline snapshot expects **`[BRANCH]`**, and five scrubber unit tests cover main, feature branches, detached HEAD hashes, JSON passthrough, and opt-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46b82fe51b573954a674accfe86be06d4ad24e75. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->