### PR TITLE
fix(scripts): drop unnecessary type assertions in stage-publish runner (unblocks Check)

### DIFF
--- a/scripts/repo/stage-publish-cli-exe.mts
+++ b/scripts/repo/stage-publish-cli-exe.mts
@@ -100,7 +100,7 @@ function resolveTriplets(spec: string): readonly CliExeTriplet[] | undefined {
   const parts = spec.split(',').map(part => part.trim())
   const triplets: CliExeTriplet[] = []
   for (let i = 0, { length } = parts; i < length; i += 1) {
-    const part = parts[i]!
+    const part = parts[i]
     if (!isCliExeTriplet(part)) {
       logger.error(
         `Unknown triplet "${part}" — expected one of: ${CLI_EXE_TRIPLETS.join(', ')}, or all/buildable`,
@@ -190,9 +190,7 @@ async function stageTarget(
   } catch (e) {
     // Non-zero exits reject; the error carries the exit code.
     const errCode =
-      e && typeof e === 'object' && 'code' in e
-        ? (e as { code: unknown }).code
-        : undefined
+      e && typeof e === 'object' && 'code' in e ? e.code : undefined
     code = typeof errCode === 'number' ? errCode : 1
   }
   if (code !== 0) {
@@ -267,7 +265,7 @@ async function main(): Promise<void> {
 
   let ok = true
   for (let i = 0, { length } = targets; i < length; i += 1) {
-    const target = targets[i]!
+    const target = targets[i]
     ok = guardTarget(target, version) && ok
   }
   if (!ok) {
@@ -282,14 +280,14 @@ async function main(): Promise<void> {
       `Plan (${dryRun ? 'dry-run' : 'PUBLISH'}, tag=${tag}, version=${version}):`,
     )
     for (let i = 0, { length } = targets; i < length; i += 1) {
-      const target = targets[i]!
+      const target = targets[i]
       logger.log(`  ${target.name}@${version}  <- ${target.dir}`)
     }
     return
   }
 
   for (let i = 0, { length } = targets; i < length; i += 1) {
-    const target = targets[i]!
+    const target = targets[i]
     // eslint-disable-next-line no-await-in-loop
     const staged = await stageTarget(target, { dryRun, tag })
     if (!staged) {


### PR DESCRIPTION
## What

The **🔎 Check** CI job (`pnpm run check --all`) is red on `main` — and therefore on every open socket-cli PR — because the type-aware oxlint gate flags five unnecessary type assertions in `scripts/repo/stage-publish-cli-exe.mts`:

```
##[error]This assertion is unnecessary since it does not change the type of the expression.  (×5)
Found 0 warnings and 5 errors.
```

This removes those five assertions. No rule was disabled and no `oxlint-disable` was added — the code is fixed so the type-aware rule passes on its own.

## Why unblocking this matters

`Check` gates the whole PR fleet. While it's red on `main`, every PR inherits a red `Check` regardless of its contents, which hides real regressions. Fixing the root cause greens `Check` for all socket-cli PRs (same fleet-wide win as the `cmd-ci` snapshot fix).

## The findings (all type-aware `no-unnecessary-type-assertion`)

- **4× `arr[i]!`** in indexed `for` loops (lines ~103, ~270, ~285, ~292). The tsconfig does not enable `noUncheckedIndexedAccess`, so `arr[i]` is already the non-nullable element type — the `!` changes nothing. Dropped the `!`.
- **1× `(e as { code: unknown }).code`** (line ~193) inside an `e && typeof e === 'object' && 'code' in e` branch. After that narrowing, `e.code` is already accessible as `unknown` — the cast changes nothing. Replaced with `e.code`.

Removing an assertion the type-checker itself deems redundant is type-safe by definition (the assertion did not alter the type).

## Verification (proof)

`scripts/repo/stage-publish-cli-exe.mts` is a build/release script with no unit tests; the type-aware lint gate is the relevant check.

- **Before (this file, on `main`):** the type-aware pass reports 5 errors — see the `Check` job on the latest `main` run.
- **After (this branch):** `pnpm run lint:all` (the same whole-tree gate that runs the `--type-aware` oxlint leg) passes clean:

```
$ pnpm run lint:all
Lint scope: all
Running oxlint on all files…
Formatting all files…
Checking formatting...
All matched files use the correct format.
Finished in 3711ms on 1387 files using 14 threads.
Lint passed
# exit 0
```

<details>
<summary>Note on the other red checks</summary>

The `🧪 Test` job still fails on the unrelated `cmd-ci.test.mts` branch-name banner snapshot, which fails on every non-`main` PR (tracked separately). This PR only addresses the `🔎 Check` failure.
</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only cleanup in a release script; assertions were provably redundant and runtime behavior is unchanged.
> 
> **Overview**
> Clears **five type-aware oxlint `no-unnecessary-type-assertion` errors** in `scripts/repo/stage-publish-cli-exe.mts` so the **Check** CI job can pass again.
> 
> In indexed `for` loops over `parts` and `targets`, **`arr[i]!` becomes `arr[i]`** because the indexed element type is already non-nullable under the script’s tsconfig. In the `spawn` error handler, **`(e as { code: unknown }).code` becomes `e.code`** after the existing `typeof` / `'code' in e` narrowing.
> 
> **No publish or staging behavior changes**—only redundant assertions removed so `pnpm run lint:all` / `check` stays green.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c63d5564b4fd6f814640eda9d8c0c5f79bf01e40. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->