### PR TITLE
fix(fix): propagate Coana discovery failures + consume structured discovery result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.150](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.150) - 2026-07-29
+
+### Changed
+- Updated the Coana CLI to v `15.9.7`.
+- `socket fix` vulnerability discovery now reads Coana's structured `--output-file` JSON result instead of parsing stdout, and warns when the Socket backend resolved 0 artifacts so an incomplete server-side resolve is surfaced instead of silently reporting "Finished!".
+
+### Fixed
+- `socket fix` no longer reports success when the Coana vulnerability-discovery step fails — Coana errors and unreadable discovery output now exit non-zero with the underlying reason instead of printing "Finished!" with nothing fixed.
+
 ## [1.1.149](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.149) - 2026-07-29
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.149",
+  "version": "1.1.150",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT",
@@ -97,7 +97,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "15.9.6",
+    "@coana-tech/cli": "15.9.7",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,8 +132,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 15.9.6
-        version: 15.9.6
+        specifier: 15.9.7
+        version: 15.9.7
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -806,8 +806,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@15.9.6':
-    resolution: {integrity: sha512-c4bTWc+fgKuyKVc9p2qxly6JNqwzF0L/UrDctMSTupbKeoELkL6nZw4TCdaAUr8Xd28AW46UxucMFOd4QevXUA==}
+  '@coana-tech/cli@15.9.7':
+    resolution: {integrity: sha512-1CGis51nRr3Sl3uKYLd7/c4L+vEtYlJUiGYh1TL58WtD4Ojd+qaticSFDa+mywbKLRBXpAPwPWBOes0OQZNP1g==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5509,7 +5509,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@15.9.6': {}
+  '@coana-tech/cli@15.9.7': {}
 
   '@colors/colors@1.5.0':
     optional: true

--- a/src/commands/fix/cmd-fix.e2e.test.mts
+++ b/src/commands/fix/cmd-fix.e2e.test.mts
@@ -196,9 +196,9 @@ describe('socket fix (E2E tests)', async () => {
             `\nSuccessfully upgraded lodash from ${beforeVersion} to ${afterVersion}`,
           )
         } catch (e) {
-          if (code !== 0) {
-            logCommandOutput(code, stdout, stderr)
-          }
+          // Log output on any failure — including exit-0 runs whose later
+          // assertions fail (e.g. a silent no-op upgrade).
+          logCommandOutput(code, stdout, stderr)
           throw e
         } finally {
           await tempFixture.cleanup()
@@ -276,9 +276,9 @@ describe('socket fix (E2E tests)', async () => {
             `\nSuccessfully upgraded lodash from ${beforeVersion} to ${afterVersion} and wrote output file`,
           )
         } catch (e) {
-          if (code !== 0) {
-            logCommandOutput(code, stdout, stderr)
-          }
+          // Log output on any failure — including exit-0 runs whose later
+          // assertions fail (e.g. a silent no-op upgrade).
+          logCommandOutput(code, stdout, stderr)
           throw e
         } finally {
           await tempFixture.cleanup()
@@ -334,9 +334,9 @@ describe('socket fix (E2E tests)', async () => {
             `\nSuccessfully fixed GHSA-35jh-r3h4-6jhm by upgrading lodash from ${beforeVersion} to ${afterVersion}`,
           )
         } catch (e) {
-          if (code !== 0) {
-            logCommandOutput(code, stdout, stderr)
-          }
+          // Log output on any failure — including exit-0 runs whose later
+          // assertions fail (e.g. a silent no-op upgrade).
+          logCommandOutput(code, stdout, stderr)
           throw e
         } finally {
           await tempFixture.cleanup()
@@ -392,9 +392,9 @@ describe('socket fix (E2E tests)', async () => {
             `\nSuccessfully converted CVE-2021-23337 to GHSA and fixed by upgrading lodash from ${beforeVersion} to ${afterVersion}`,
           )
         } catch (e) {
-          if (code !== 0) {
-            logCommandOutput(code, stdout, stderr)
-          }
+          // Log output on any failure — including exit-0 runs whose later
+          // assertions fail (e.g. a silent no-op upgrade).
+          logCommandOutput(code, stdout, stderr)
           throw e
         } finally {
           await tempFixture.cleanup()
@@ -458,9 +458,9 @@ describe('socket fix (E2E tests)', async () => {
             '\nSuccessfully verified --silence --json outputs only JSON',
           )
         } catch (e) {
-          if (code !== 0) {
-            logCommandOutput(code, stdout, stderr)
-          }
+          // Log output on any failure — including exit-0 runs whose later
+          // assertions fail (e.g. a silent no-op upgrade).
+          logCommandOutput(code, stdout, stderr)
           throw e
         } finally {
           await tempFixture.cleanup()
@@ -525,9 +525,9 @@ describe('socket fix (E2E tests)', async () => {
             `\n--package-managers NPM upgraded npm-app lodash to ${afterLodash} and left pnpm-app axios untouched`,
           )
         } catch (e) {
-          if (code !== 0) {
-            logCommandOutput(code, stdout, stderr)
-          }
+          // Log output on any failure — including exit-0 runs whose later
+          // assertions fail (e.g. a silent no-op upgrade).
+          logCommandOutput(code, stdout, stderr)
           throw e
         } finally {
           await tempFixture.cleanup()
@@ -590,9 +590,9 @@ describe('socket fix (E2E tests)', async () => {
             `\n--package-managers PNPM upgraded pnpm-app axios to ${afterAxios} and left npm-app lodash untouched`,
           )
         } catch (e) {
-          if (code !== 0) {
-            logCommandOutput(code, stdout, stderr)
-          }
+          // Log output on any failure — including exit-0 runs whose later
+          // assertions fail (e.g. a silent no-op upgrade).
+          logCommandOutput(code, stdout, stderr)
           throw e
         } finally {
           await tempFixture.cleanup()
@@ -692,9 +692,9 @@ describe('socket fix (E2E tests)', async () => {
             `\nSuccessfully upgraded django from ${beforeVersion} to ${afterVersion}`,
           )
         } catch (e) {
-          if (code !== 0) {
-            logCommandOutput(code, stdout, stderr)
-          }
+          // Log output on any failure — including exit-0 runs whose later
+          // assertions fail (e.g. a silent no-op upgrade).
+          logCommandOutput(code, stdout, stderr)
           throw e
         } finally {
           await tempFixture.cleanup()

--- a/src/commands/fix/coana-fix.mts
+++ b/src/commands/fix/coana-fix.mts
@@ -72,7 +72,7 @@ async function discoverGhsaIds(
   orgSlug: string,
   tarHash: string,
   options?: DiscoverGhsaIdsOptions | undefined,
-): Promise<string[]> {
+): Promise<CResult<string[]>> {
   const {
     cwd = process.cwd(),
     ecosystems,
@@ -104,16 +104,43 @@ async function discoverGhsaIds(
     { stdio: 'pipe' },
   )
 
-  if (foundCResult.ok) {
-    try {
-      // Coana prints ghsaIds as json-formatted string on the final line of the output.
-      const ghsaIdsRaw = foundCResult.data.trim().split('\n').pop()
-      if (ghsaIdsRaw) {
-        return JSON.parse(ghsaIdsRaw)
-      }
-    } catch {}
+  if (!foundCResult.ok) {
+    return foundCResult
   }
-  return []
+
+  // Coana prints ghsaIds as json-formatted string on the final line of the output.
+  const lastLine = foundCResult.data.trim().split('\n').pop()
+  if (!lastLine) {
+    return {
+      ok: false,
+      message: 'Coana returned no output while discovering vulnerabilities',
+      cause:
+        'Expected a JSON array of GHSA IDs on the final line of `find-vulnerabilities` output.',
+    }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(lastLine)
+  } catch {
+    return {
+      ok: false,
+      message: 'Could not parse the vulnerability list returned by Coana',
+      cause:
+        'Expected a JSON array of GHSA IDs on the final line of `find-vulnerabilities` output, got:\n' +
+        `  ${lastLine}`,
+    }
+  }
+
+  if (!Array.isArray(parsed) || parsed.some(id => typeof id !== 'string')) {
+    return {
+      ok: false,
+      message: 'Coana returned an unexpected vulnerability list',
+      cause: `Expected a JSON array of GHSA ID strings, got:\n  ${lastLine}`,
+    }
+  }
+
+  return { ok: true, data: parsed }
 }
 
 export async function coanaFix(
@@ -267,16 +294,26 @@ export async function coanaFix(
     }
 
     // In local mode, process all discovered/provided IDs (no limit).
-    const ids: string[] = shouldDiscoverGhsaIds
-      ? await discoverGhsaIds(orgSlug, tarHash, {
-          coanaVersion,
-          cwd,
-          ecosystems,
-          packageManagers,
-          silence,
-          spinner,
-        })
-      : ghsas
+    let ids: string[]
+    if (shouldDiscoverGhsaIds) {
+      const discoverCResult = await discoverGhsaIds(orgSlug, tarHash, {
+        coanaVersion,
+        cwd,
+        ecosystems,
+        packageManagers,
+        silence,
+        spinner,
+      })
+      if (!discoverCResult.ok) {
+        if (!silence) {
+          spinner?.stop()
+        }
+        return discoverCResult
+      }
+      ids = discoverCResult.data
+    } else {
+      ids = ghsas
+    }
 
     if (ids.length === 0) {
       if (!silence) {
@@ -403,18 +440,25 @@ export async function coanaFix(
   let ids: string[] | undefined
 
   if (shouldSpawnCoana) {
-    ids = (
-      shouldDiscoverGhsaIds
-        ? await discoverGhsaIds(orgSlug, tarHash, {
-            coanaVersion,
-            cwd,
-            ecosystems,
-            packageManagers,
-            silence,
-            spinner,
-          })
-        : ghsas
-    ).slice(0, adjustedPrLimit)
+    if (shouldDiscoverGhsaIds) {
+      const discoverCResult = await discoverGhsaIds(orgSlug, tarHash, {
+        coanaVersion,
+        cwd,
+        ecosystems,
+        packageManagers,
+        silence,
+        spinner,
+      })
+      if (!discoverCResult.ok) {
+        if (!silence) {
+          spinner?.stop()
+        }
+        return discoverCResult
+      }
+      ids = discoverCResult.data.slice(0, adjustedPrLimit)
+    } else {
+      ids = ghsas.slice(0, adjustedPrLimit)
+    }
   }
 
   if (!ids?.length) {

--- a/src/commands/fix/coana-fix.mts
+++ b/src/commands/fix/coana-fix.mts
@@ -97,6 +97,14 @@ async function readStructuredDiscoveryResult(
     }
   }
 
+  if (parsed === null || typeof parsed !== 'object') {
+    return {
+      ok: false,
+      message: 'Coana wrote an unexpected vulnerability discovery result',
+      cause: `Expected a JSON object with a ghsaIds string array, got:\n  ${raw.slice(0, 500)}`,
+    }
+  }
+
   const { artifactCount, ghsaIds } = parsed as StructuredDiscoveryResult
   if (!Array.isArray(ghsaIds) || ghsaIds.some(id => typeof id !== 'string')) {
     return {
@@ -168,6 +176,7 @@ async function discoverGhsaIds(
   )
 
   if (!foundCResult.ok) {
+    await fs.rm(outputFile, { force: true }).catch(() => {})
     return foundCResult
   }
 

--- a/src/commands/fix/coana-fix.mts
+++ b/src/commands/fix/coana-fix.mts
@@ -2,6 +2,8 @@ import { promises as fs } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
+import semver from 'semver'
+
 import { joinAnd } from '@socketsecurity/registry/lib/arrays'
 import { debugDir, debugFn } from '@socketsecurity/registry/lib/debug'
 import { readJsonSync } from '@socketsecurity/registry/lib/fs'
@@ -64,6 +66,64 @@ type DiscoverGhsaIdsOptions = {
   spinner?: Spinner | undefined
 }
 
+// First Coana version with `find-vulnerabilities --output-file`, which writes
+// a structured JSON result ({ ghsaIds, artifactCount, filteredArtifactCount })
+// instead of relying on the final stdout line.
+const COANA_STRUCTURED_DISCOVERY_MIN_VERSION = '15.9.7'
+
+type StructuredDiscoveryResult = {
+  ghsaIds?: unknown
+  artifactCount?: unknown
+  filteredArtifactCount?: unknown
+}
+
+async function readStructuredDiscoveryResult(
+  outputFile: string,
+  silence: boolean,
+): Promise<CResult<string[]>> {
+  let raw: string
+  try {
+    raw = await fs.readFile(outputFile, 'utf8')
+  } catch {
+    return {
+      ok: false,
+      message: 'Coana did not write a vulnerability discovery result file',
+      cause: `Expected \`find-vulnerabilities --output-file\` to create ${outputFile}.`,
+    }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return {
+      ok: false,
+      message:
+        'Could not parse the vulnerability discovery result written by Coana',
+      cause: `Expected JSON in ${outputFile}, got:\n  ${raw.slice(0, 500)}`,
+    }
+  }
+
+  const { artifactCount, ghsaIds } = parsed as StructuredDiscoveryResult
+  if (!Array.isArray(ghsaIds) || ghsaIds.some(id => typeof id !== 'string')) {
+    return {
+      ok: false,
+      message: 'Coana wrote an unexpected vulnerability discovery result',
+      cause: `Expected a JSON object with a ghsaIds string array, got:\n  ${raw.slice(0, 500)}`,
+    }
+  }
+
+  // Zero artifacts means the backend resolved nothing — suspicious when
+  // manifests were uploaded, so warn even though discovery itself succeeded.
+  if (artifactCount === 0 && !silence) {
+    logger.warn(
+      'The Socket backend resolved 0 artifacts, so vulnerability discovery may be incomplete.',
+    )
+  }
+
+  return { ok: true, data: ghsaIds }
+}
+
 /**
  * Discovers GHSA IDs by running coana without applying fixes.
  * Returns a list of GHSA IDs, optionally limited.
@@ -84,12 +144,26 @@ async function discoverGhsaIds(
     ...options,
   } as DiscoverGhsaIdsOptions
 
+  const resolvedCoanaVersion =
+    options?.coanaVersion ??
+    process.env['INLINED_SOCKET_CLI_COANA_TECH_CLI_VERSION']
+  // Local Coana builds (SOCKET_CLI_COANA_LOCAL_PATH) are assumed current.
+  const useStructuredOutput =
+    !!process.env['SOCKET_CLI_COANA_LOCAL_PATH'] ||
+    (!!resolvedCoanaVersion &&
+      !!semver.valid(resolvedCoanaVersion) &&
+      semver.gte(resolvedCoanaVersion, COANA_STRUCTURED_DISCOVERY_MIN_VERSION))
+  const outputFile = useStructuredOutput
+    ? path.join(os.tmpdir(), `socket-fix-discovery-${Date.now()}.json`)
+    : undefined
+
   const foundCResult = await spawnCoanaDlx(
     [
       'find-vulnerabilities',
       cwd,
       '--manifests-tar-hash',
       tarHash,
+      ...(outputFile ? ['--output-file', outputFile] : []),
       ...(ecosystems?.length ? ['--purl-types', ...ecosystems] : []),
       ...(packageManagers?.length
         ? ['--package-managers', ...packageManagers]
@@ -106,6 +180,14 @@ async function discoverGhsaIds(
 
   if (!foundCResult.ok) {
     return foundCResult
+  }
+
+  if (outputFile) {
+    try {
+      return await readStructuredDiscoveryResult(outputFile, silence)
+    } finally {
+      await fs.rm(outputFile, { force: true }).catch(() => {})
+    }
   }
 
   // Coana prints ghsaIds as json-formatted string on the final line of the output.

--- a/src/commands/fix/coana-fix.mts
+++ b/src/commands/fix/coana-fix.mts
@@ -2,8 +2,6 @@ import { promises as fs } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import semver from 'semver'
-
 import { joinAnd } from '@socketsecurity/registry/lib/arrays'
 import { debugDir, debugFn } from '@socketsecurity/registry/lib/debug'
 import { readJsonSync } from '@socketsecurity/registry/lib/fs'
@@ -65,11 +63,6 @@ type DiscoverGhsaIdsOptions = {
   silence?: boolean | undefined
   spinner?: Spinner | undefined
 }
-
-// First Coana version with `find-vulnerabilities --output-file`, which writes
-// a structured JSON result ({ ghsaIds, artifactCount, filteredArtifactCount })
-// instead of relying on the final stdout line.
-const COANA_STRUCTURED_DISCOVERY_MIN_VERSION = '15.9.7'
 
 type StructuredDiscoveryResult = {
   ghsaIds?: unknown
@@ -144,18 +137,13 @@ async function discoverGhsaIds(
     ...options,
   } as DiscoverGhsaIdsOptions
 
-  const resolvedCoanaVersion =
-    options?.coanaVersion ??
-    process.env['INLINED_SOCKET_CLI_COANA_TECH_CLI_VERSION']
-  // Local Coana builds (SOCKET_CLI_COANA_LOCAL_PATH) are assumed current.
-  const useStructuredOutput =
-    !!process.env['SOCKET_CLI_COANA_LOCAL_PATH'] ||
-    (!!resolvedCoanaVersion &&
-      !!semver.valid(resolvedCoanaVersion) &&
-      semver.gte(resolvedCoanaVersion, COANA_STRUCTURED_DISCOVERY_MIN_VERSION))
-  const outputFile = useStructuredOutput
-    ? path.join(os.tmpdir(), `socket-fix-discovery-${Date.now()}.json`)
-    : undefined
+  // Coana writes a structured JSON result ({ ghsaIds, artifactCount,
+  // filteredArtifactCount }) via --output-file (available since coana 15.9.7,
+  // older than the pinned @coana-tech/cli version).
+  const outputFile = path.join(
+    os.tmpdir(),
+    `socket-fix-discovery-${Date.now()}.json`,
+  )
 
   const foundCResult = await spawnCoanaDlx(
     [
@@ -163,7 +151,8 @@ async function discoverGhsaIds(
       cwd,
       '--manifests-tar-hash',
       tarHash,
-      ...(outputFile ? ['--output-file', outputFile] : []),
+      '--output-file',
+      outputFile,
       ...(ecosystems?.length ? ['--purl-types', ...ecosystems] : []),
       ...(packageManagers?.length
         ? ['--package-managers', ...packageManagers]
@@ -182,47 +171,11 @@ async function discoverGhsaIds(
     return foundCResult
   }
 
-  if (outputFile) {
-    try {
-      return await readStructuredDiscoveryResult(outputFile, silence)
-    } finally {
-      await fs.rm(outputFile, { force: true }).catch(() => {})
-    }
-  }
-
-  // Coana prints ghsaIds as json-formatted string on the final line of the output.
-  const lastLine = foundCResult.data.trim().split('\n').pop()
-  if (!lastLine) {
-    return {
-      ok: false,
-      message: 'Coana returned no output while discovering vulnerabilities',
-      cause:
-        'Expected a JSON array of GHSA IDs on the final line of `find-vulnerabilities` output.',
-    }
-  }
-
-  let parsed: unknown
   try {
-    parsed = JSON.parse(lastLine)
-  } catch {
-    return {
-      ok: false,
-      message: 'Could not parse the vulnerability list returned by Coana',
-      cause:
-        'Expected a JSON array of GHSA IDs on the final line of `find-vulnerabilities` output, got:\n' +
-        `  ${lastLine}`,
-    }
+    return await readStructuredDiscoveryResult(outputFile, silence)
+  } finally {
+    await fs.rm(outputFile, { force: true }).catch(() => {})
   }
-
-  if (!Array.isArray(parsed) || parsed.some(id => typeof id !== 'string')) {
-    return {
-      ok: false,
-      message: 'Coana returned an unexpected vulnerability list',
-      cause: `Expected a JSON array of GHSA ID strings, got:\n  ${lastLine}`,
-    }
-  }
-
-  return { ok: true, data: parsed }
 }
 
 export async function coanaFix(

--- a/src/commands/fix/handle-fix-limit.test.mts
+++ b/src/commands/fix/handle-fix-limit.test.mts
@@ -497,6 +497,44 @@ describe('socket fix --pr-limit behavior verification', () => {
       expect(result.message).toMatch(/unexpected vulnerability discovery/i)
     })
 
+    it.each(['null', '[1, 2]', '42', '"text"'])(
+      'fails cleanly when the result file is %s instead of an object',
+      async body => {
+        mockSpawnCoanaDlx.mockImplementation(async (args: string[]) => {
+          const idx = args.indexOf('--output-file')
+          await fs.writeFile(args[idx + 1]!, body)
+          return { ok: true, data: '' }
+        })
+
+        const result = await coanaFix({
+          ...baseConfig,
+          ghsas: [],
+        })
+
+        expect(result.ok).toBe(false)
+        expect(result.message).toMatch(/unexpected vulnerability discovery/i)
+      },
+    )
+
+    it('removes the discovery temp file when the spawn fails', async () => {
+      let outputFile = ''
+      mockSpawnCoanaDlx.mockImplementation(async (args: string[]) => {
+        const idx = args.indexOf('--output-file')
+        outputFile = args[idx + 1]!
+        await fs.writeFile(outputFile, JSON.stringify({ ghsaIds: [] }))
+        return { ok: false, message: 'Coana exited with code 1' }
+      })
+
+      const result = await coanaFix({
+        ...baseConfig,
+        ghsas: [],
+      })
+
+      expect(result.ok).toBe(false)
+      expect(outputFile).not.toBe('')
+      await expect(fs.stat(outputFile)).rejects.toThrow()
+    })
+
     it('warns when the backend resolved zero artifacts', async () => {
       const warnSpy = vi.spyOn(logger, 'warn')
       mockDiscoveryEnvelope({

--- a/src/commands/fix/handle-fix-limit.test.mts
+++ b/src/commands/fix/handle-fix-limit.test.mts
@@ -1,4 +1,8 @@
+import { promises as fs } from 'node:fs'
+
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { coanaFix } from './coana-fix.mts'
 
@@ -514,6 +518,139 @@ describe('socket fix --pr-limit behavior verification', () => {
       expect(result.ok).toBe(false)
       expect(result.message).toBe('Coana exited with code 1')
       expect(mockSpawnCoanaDlx).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('structured discovery output (--output-file)', () => {
+    it('passes --output-file and reads the result file when Coana supports it', async () => {
+      mockSpawnCoanaDlx.mockImplementation(async (args: string[]) => {
+        if (args[0] === 'find-vulnerabilities') {
+          const idx = args.indexOf('--output-file')
+          expect(idx).toBeGreaterThan(-1)
+          await fs.writeFile(
+            args[idx + 1]!,
+            JSON.stringify({
+              ghsaIds: ['GHSA-aaaa-aaaa-aaaa'],
+              artifactCount: 3,
+              filteredArtifactCount: 3,
+            }),
+          )
+          return { ok: true, data: '' }
+        }
+        return { ok: true, data: 'fix applied' }
+      })
+
+      const result = await coanaFix({
+        ...baseConfig,
+        coanaVersion: '15.9.7',
+        ghsas: [],
+      })
+
+      expect(result.ok).toBe(true)
+      expect(mockSpawnCoanaDlx).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not pass --output-file to older Coana versions', async () => {
+      mockSpawnCoanaDlx.mockResolvedValueOnce({
+        ok: true,
+        data: JSON.stringify(['GHSA-aaaa-aaaa-aaaa']),
+      })
+      mockSpawnCoanaDlx.mockResolvedValueOnce({
+        ok: true,
+        data: 'fix applied',
+      })
+
+      const result = await coanaFix({
+        ...baseConfig,
+        coanaVersion: '15.9.6',
+        ghsas: [],
+      })
+
+      expect(result.ok).toBe(true)
+      const discoveryArgs = mockSpawnCoanaDlx.mock.calls[0]?.[0] as string[]
+      expect(discoveryArgs).not.toContain('--output-file')
+    })
+
+    it('fails when Coana does not write the result file', async () => {
+      mockSpawnCoanaDlx.mockResolvedValueOnce({ ok: true, data: '' })
+
+      const result = await coanaFix({
+        ...baseConfig,
+        coanaVersion: '15.9.7',
+        ghsas: [],
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toMatch(/did not write/i)
+      expect(mockSpawnCoanaDlx).toHaveBeenCalledTimes(1)
+    })
+
+    it('fails when the result file is not valid JSON', async () => {
+      mockSpawnCoanaDlx.mockImplementation(async (args: string[]) => {
+        const idx = args.indexOf('--output-file')
+        await fs.writeFile(args[idx + 1]!, 'not json')
+        return { ok: true, data: '' }
+      })
+
+      const result = await coanaFix({
+        ...baseConfig,
+        coanaVersion: '15.9.7',
+        ghsas: [],
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toMatch(/could not parse/i)
+    })
+
+    it('fails when ghsaIds in the result file is not a string array', async () => {
+      mockSpawnCoanaDlx.mockImplementation(async (args: string[]) => {
+        const idx = args.indexOf('--output-file')
+        await fs.writeFile(args[idx + 1]!, JSON.stringify({ ghsaIds: [123] }))
+        return { ok: true, data: '' }
+      })
+
+      const result = await coanaFix({
+        ...baseConfig,
+        coanaVersion: '15.9.7',
+        ghsas: [],
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toMatch(/unexpected vulnerability discovery/i)
+    })
+
+    it('warns when the backend resolved zero artifacts', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn')
+      mockSpawnCoanaDlx.mockImplementation(async (args: string[]) => {
+        const idx = args.indexOf('--output-file')
+        await fs.writeFile(
+          args[idx + 1]!,
+          JSON.stringify({
+            ghsaIds: [],
+            artifactCount: 0,
+            filteredArtifactCount: 0,
+          }),
+        )
+        return { ok: true, data: '' }
+      })
+
+      try {
+        const result = await coanaFix({
+          ...baseConfig,
+          coanaVersion: '15.9.7',
+          ghsas: [],
+        })
+
+        expect(result.ok).toBe(true)
+        expect(result.data?.fixedAll).toBe(false)
+        // Discovery succeeded with an empty list, so no fix call follows.
+        expect(mockSpawnCoanaDlx).toHaveBeenCalledTimes(1)
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringMatching(/0 artifacts/i),
+        )
+      } finally {
+        warnSpy.mockRestore()
+      }
     })
   })
 

--- a/src/commands/fix/handle-fix-limit.test.mts
+++ b/src/commands/fix/handle-fix-limit.test.mts
@@ -74,6 +74,32 @@ vi.mock('./branch-cleanup.mts', () => ({
   cleanupSuccessfulPrLocalBranch: vi.fn(),
 }))
 
+// Discovery always uses `find-vulnerabilities --output-file`: mock Coana by
+// writing the structured result file on the discovery call and succeeding on
+// the fix call.
+function mockDiscoveryEnvelope(envelope: {
+  ghsaIds: string[]
+  artifactCount?: number
+  filteredArtifactCount?: number
+}) {
+  mockSpawnCoanaDlx.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'find-vulnerabilities') {
+      const idx = args.indexOf('--output-file')
+      expect(idx).toBeGreaterThan(-1)
+      await fs.writeFile(
+        args[idx + 1]!,
+        JSON.stringify({
+          artifactCount: envelope.ghsaIds.length,
+          filteredArtifactCount: envelope.ghsaIds.length,
+          ...envelope,
+        }),
+      )
+      return { ok: true, data: '' }
+    }
+    return { ok: true, data: 'fix applied' }
+  })
+}
+
 describe('socket fix --pr-limit behavior verification', () => {
   const baseConfig: FixConfig = {
     all: false,
@@ -211,11 +237,7 @@ describe('socket fix --pr-limit behavior verification', () => {
     })
 
     it('should return early when no GHSAs are provided and none are discovered', async () => {
-      // Discovery returns empty array.
-      mockSpawnCoanaDlx.mockResolvedValueOnce({
-        ok: true,
-        data: JSON.stringify([]),
-      })
+      mockDiscoveryEnvelope({ ghsaIds: [] })
 
       const result = await coanaFix({
         ...baseConfig,
@@ -230,16 +252,8 @@ describe('socket fix --pr-limit behavior verification', () => {
     })
 
     it('should discover vulnerabilities when no GHSAs are provided', async () => {
-      // First call is for discovery (returns vulnerability IDs).
-      mockSpawnCoanaDlx.mockResolvedValueOnce({
-        ok: true,
-        data: JSON.stringify(['GHSA-aaaa-aaaa-aaaa', 'GHSA-bbbb-bbbb-bbbb']),
-      })
-
-      // Second call is to apply fixes to the discovered IDs.
-      mockSpawnCoanaDlx.mockResolvedValueOnce({
-        ok: true,
-        data: 'fix applied',
+      mockDiscoveryEnvelope({
+        ghsaIds: ['GHSA-aaaa-aaaa-aaaa', 'GHSA-bbbb-bbbb-bbbb'],
       })
 
       const result = await coanaFix({
@@ -284,23 +298,13 @@ describe('socket fix --pr-limit behavior verification', () => {
     })
 
     it('should process only N GHSAs when --pr-limit N is specified in PR mode', async () => {
-      const ghsas = [
-        'GHSA-aaaa-aaaa-aaaa',
-        'GHSA-bbbb-bbbb-bbbb',
-        'GHSA-cccc-cccc-cccc',
-        'GHSA-dddd-dddd-dddd',
-      ]
-
-      // First call discovers vulnerabilities.
-      mockSpawnCoanaDlx.mockResolvedValueOnce({
-        ok: true,
-        data: JSON.stringify(ghsas),
-      })
-
-      // Subsequent calls are for individual GHSA fixes.
-      mockSpawnCoanaDlx.mockResolvedValue({
-        ok: true,
-        data: 'fix applied',
+      mockDiscoveryEnvelope({
+        ghsaIds: [
+          'GHSA-aaaa-aaaa-aaaa',
+          'GHSA-bbbb-bbbb-bbbb',
+          'GHSA-cccc-cccc-cccc',
+          'GHSA-dddd-dddd-dddd',
+        ],
       })
 
       mockGitUnstagedModifiedFiles.mockResolvedValue({
@@ -321,12 +325,6 @@ describe('socket fix --pr-limit behavior verification', () => {
     })
 
     it('should adjust prLimit based on existing open PRs', async () => {
-      const ghsas = [
-        'GHSA-aaaa-aaaa-aaaa',
-        'GHSA-bbbb-bbbb-bbbb',
-        'GHSA-cccc-cccc-cccc',
-      ]
-
       // Mock 1 existing open PR.
       mockGetSocketFixPrs.mockResolvedValueOnce([
         { number: 123, state: 'OPEN' },
@@ -335,14 +333,12 @@ describe('socket fix --pr-limit behavior verification', () => {
       // Second call returns no open PRs for specific GHSAs.
       mockGetSocketFixPrs.mockResolvedValue([])
 
-      mockSpawnCoanaDlx.mockResolvedValueOnce({
-        ok: true,
-        data: JSON.stringify(ghsas),
-      })
-
-      mockSpawnCoanaDlx.mockResolvedValue({
-        ok: true,
-        data: 'fix applied',
+      mockDiscoveryEnvelope({
+        ghsaIds: [
+          'GHSA-aaaa-aaaa-aaaa',
+          'GHSA-bbbb-bbbb-bbbb',
+          'GHSA-cccc-cccc-cccc',
+        ],
       })
 
       mockGitUnstagedModifiedFiles.mockResolvedValue({
@@ -407,88 +403,6 @@ describe('socket fix --pr-limit behavior verification', () => {
       expect(mockSpawnCoanaDlx).toHaveBeenCalledTimes(1)
     })
 
-    it('fails when discovery returns no output', async () => {
-      mockSpawnCoanaDlx.mockResolvedValueOnce({
-        ok: true,
-        data: '',
-      })
-
-      const result = await coanaFix({
-        ...baseConfig,
-        ghsas: [],
-      })
-
-      expect(result.ok).toBe(false)
-      expect(result.message).toMatch(/no output/i)
-      expect(mockSpawnCoanaDlx).toHaveBeenCalledTimes(1)
-    })
-
-    it('fails when the final discovery output line is not JSON', async () => {
-      mockSpawnCoanaDlx.mockResolvedValueOnce({
-        ok: true,
-        data: '["GHSA-aaaa-aaaa-aaaa"]\nnpm notice: a new version is available',
-      })
-
-      const result = await coanaFix({
-        ...baseConfig,
-        ghsas: [],
-      })
-
-      expect(result.ok).toBe(false)
-      expect(result.message).toMatch(/could not parse/i)
-      expect(mockSpawnCoanaDlx).toHaveBeenCalledTimes(1)
-    })
-
-    it('fails when discovery output parses to a non-array', async () => {
-      mockSpawnCoanaDlx.mockResolvedValueOnce({
-        ok: true,
-        data: '{}',
-      })
-
-      const result = await coanaFix({
-        ...baseConfig,
-        ghsas: [],
-      })
-
-      expect(result.ok).toBe(false)
-      expect(result.message).toMatch(/unexpected vulnerability list/i)
-      expect(mockSpawnCoanaDlx).toHaveBeenCalledTimes(1)
-    })
-
-    it('fails when discovery output is an array of non-strings', async () => {
-      mockSpawnCoanaDlx.mockResolvedValueOnce({
-        ok: true,
-        data: '[123]',
-      })
-
-      const result = await coanaFix({
-        ...baseConfig,
-        ghsas: [],
-      })
-
-      expect(result.ok).toBe(false)
-      expect(result.message).toMatch(/unexpected vulnerability list/i)
-    })
-
-    it('still succeeds when warnings precede the JSON array on the final line', async () => {
-      mockSpawnCoanaDlx.mockResolvedValueOnce({
-        ok: true,
-        data: 'some warning\n["GHSA-aaaa-aaaa-aaaa"]',
-      })
-      mockSpawnCoanaDlx.mockResolvedValueOnce({
-        ok: true,
-        data: 'fix applied',
-      })
-
-      const result = await coanaFix({
-        ...baseConfig,
-        ghsas: [],
-      })
-
-      expect(result.ok).toBe(true)
-      expect(mockSpawnCoanaDlx).toHaveBeenCalledTimes(2)
-    })
-
     it('propagates discovery failures in PR mode', async () => {
       mockGetFixEnv.mockResolvedValue({
         baseBranch: 'main',
@@ -521,28 +435,16 @@ describe('socket fix --pr-limit behavior verification', () => {
     })
   })
 
-  describe('structured discovery output (--output-file)', () => {
-    it('passes --output-file and reads the result file when Coana supports it', async () => {
-      mockSpawnCoanaDlx.mockImplementation(async (args: string[]) => {
-        if (args[0] === 'find-vulnerabilities') {
-          const idx = args.indexOf('--output-file')
-          expect(idx).toBeGreaterThan(-1)
-          await fs.writeFile(
-            args[idx + 1]!,
-            JSON.stringify({
-              ghsaIds: ['GHSA-aaaa-aaaa-aaaa'],
-              artifactCount: 3,
-              filteredArtifactCount: 3,
-            }),
-          )
-          return { ok: true, data: '' }
-        }
-        return { ok: true, data: 'fix applied' }
+  describe('structured discovery result (--output-file)', () => {
+    it('reads discovered GHSA IDs from the result file', async () => {
+      mockDiscoveryEnvelope({
+        ghsaIds: ['GHSA-aaaa-aaaa-aaaa'],
+        artifactCount: 3,
+        filteredArtifactCount: 3,
       })
 
       const result = await coanaFix({
         ...baseConfig,
-        coanaVersion: '15.9.7',
         ghsas: [],
       })
 
@@ -550,33 +452,11 @@ describe('socket fix --pr-limit behavior verification', () => {
       expect(mockSpawnCoanaDlx).toHaveBeenCalledTimes(2)
     })
 
-    it('does not pass --output-file to older Coana versions', async () => {
-      mockSpawnCoanaDlx.mockResolvedValueOnce({
-        ok: true,
-        data: JSON.stringify(['GHSA-aaaa-aaaa-aaaa']),
-      })
-      mockSpawnCoanaDlx.mockResolvedValueOnce({
-        ok: true,
-        data: 'fix applied',
-      })
-
-      const result = await coanaFix({
-        ...baseConfig,
-        coanaVersion: '15.9.6',
-        ghsas: [],
-      })
-
-      expect(result.ok).toBe(true)
-      const discoveryArgs = mockSpawnCoanaDlx.mock.calls[0]?.[0] as string[]
-      expect(discoveryArgs).not.toContain('--output-file')
-    })
-
     it('fails when Coana does not write the result file', async () => {
       mockSpawnCoanaDlx.mockResolvedValueOnce({ ok: true, data: '' })
 
       const result = await coanaFix({
         ...baseConfig,
-        coanaVersion: '15.9.7',
         ghsas: [],
       })
 
@@ -594,7 +474,6 @@ describe('socket fix --pr-limit behavior verification', () => {
 
       const result = await coanaFix({
         ...baseConfig,
-        coanaVersion: '15.9.7',
         ghsas: [],
       })
 
@@ -611,7 +490,6 @@ describe('socket fix --pr-limit behavior verification', () => {
 
       const result = await coanaFix({
         ...baseConfig,
-        coanaVersion: '15.9.7',
         ghsas: [],
       })
 
@@ -621,23 +499,15 @@ describe('socket fix --pr-limit behavior verification', () => {
 
     it('warns when the backend resolved zero artifacts', async () => {
       const warnSpy = vi.spyOn(logger, 'warn')
-      mockSpawnCoanaDlx.mockImplementation(async (args: string[]) => {
-        const idx = args.indexOf('--output-file')
-        await fs.writeFile(
-          args[idx + 1]!,
-          JSON.stringify({
-            ghsaIds: [],
-            artifactCount: 0,
-            filteredArtifactCount: 0,
-          }),
-        )
-        return { ok: true, data: '' }
+      mockDiscoveryEnvelope({
+        ghsaIds: [],
+        artifactCount: 0,
+        filteredArtifactCount: 0,
       })
 
       try {
         const result = await coanaFix({
           ...baseConfig,
-          coanaVersion: '15.9.7',
           ghsas: [],
         })
 

--- a/src/commands/fix/handle-fix-limit.test.mts
+++ b/src/commands/fix/handle-fix-limit.test.mts
@@ -383,6 +383,140 @@ describe('socket fix --pr-limit behavior verification', () => {
     })
   })
 
+  describe('GHSA discovery failure propagation', () => {
+    it('propagates a failed discovery spawn instead of reporting success', async () => {
+      mockSpawnCoanaDlx.mockResolvedValueOnce({
+        ok: false,
+        message: 'Coana exited with code 1',
+        cause:
+          'Socket compute-artifacts failed: upstream timeout (code=timeout)',
+      })
+
+      const result = await coanaFix({
+        ...baseConfig,
+        ghsas: [],
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toBe('Coana exited with code 1')
+      // Discovery failed, so no fix call should follow.
+      expect(mockSpawnCoanaDlx).toHaveBeenCalledTimes(1)
+    })
+
+    it('fails when discovery returns no output', async () => {
+      mockSpawnCoanaDlx.mockResolvedValueOnce({
+        ok: true,
+        data: '',
+      })
+
+      const result = await coanaFix({
+        ...baseConfig,
+        ghsas: [],
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toMatch(/no output/i)
+      expect(mockSpawnCoanaDlx).toHaveBeenCalledTimes(1)
+    })
+
+    it('fails when the final discovery output line is not JSON', async () => {
+      mockSpawnCoanaDlx.mockResolvedValueOnce({
+        ok: true,
+        data: '["GHSA-aaaa-aaaa-aaaa"]\nnpm notice: a new version is available',
+      })
+
+      const result = await coanaFix({
+        ...baseConfig,
+        ghsas: [],
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toMatch(/could not parse/i)
+      expect(mockSpawnCoanaDlx).toHaveBeenCalledTimes(1)
+    })
+
+    it('fails when discovery output parses to a non-array', async () => {
+      mockSpawnCoanaDlx.mockResolvedValueOnce({
+        ok: true,
+        data: '{}',
+      })
+
+      const result = await coanaFix({
+        ...baseConfig,
+        ghsas: [],
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toMatch(/unexpected vulnerability list/i)
+      expect(mockSpawnCoanaDlx).toHaveBeenCalledTimes(1)
+    })
+
+    it('fails when discovery output is an array of non-strings', async () => {
+      mockSpawnCoanaDlx.mockResolvedValueOnce({
+        ok: true,
+        data: '[123]',
+      })
+
+      const result = await coanaFix({
+        ...baseConfig,
+        ghsas: [],
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toMatch(/unexpected vulnerability list/i)
+    })
+
+    it('still succeeds when warnings precede the JSON array on the final line', async () => {
+      mockSpawnCoanaDlx.mockResolvedValueOnce({
+        ok: true,
+        data: 'some warning\n["GHSA-aaaa-aaaa-aaaa"]',
+      })
+      mockSpawnCoanaDlx.mockResolvedValueOnce({
+        ok: true,
+        data: 'fix applied',
+      })
+
+      const result = await coanaFix({
+        ...baseConfig,
+        ghsas: [],
+      })
+
+      expect(result.ok).toBe(true)
+      expect(mockSpawnCoanaDlx).toHaveBeenCalledTimes(2)
+    })
+
+    it('propagates discovery failures in PR mode', async () => {
+      mockGetFixEnv.mockResolvedValue({
+        baseBranch: 'main',
+        githubToken: 'test-token',
+        gitEmail: 'test@example.com',
+        gitUser: 'test-user',
+        isCi: true,
+        repoInfo: {
+          defaultBranch: 'main',
+          owner: 'test-owner',
+          repo: 'test-repo',
+        },
+      })
+      mockGetSocketFixPrs.mockResolvedValue([])
+
+      mockSpawnCoanaDlx.mockResolvedValueOnce({
+        ok: false,
+        message: 'Coana exited with code 1',
+      })
+
+      const result = await coanaFix({
+        ...baseConfig,
+        ghsas: [],
+        prLimit: 2,
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toBe('Coana exited with code 1')
+      expect(mockSpawnCoanaDlx).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('--id filtering in local mode', () => {
     it('should process all provided GHSA IDs in local mode (prLimit ignored)', async () => {
       const ghsas = [


### PR DESCRIPTION
## Problem

`socket fix` silently reported success when its GHSA discovery step failed. `discoverGhsaIds` collapsed every failure mode to an empty list:

- Coana exiting non-zero (the error message was discarded)
- `npx`/`pnpm dlx` failing to fetch `@coana-tech/cli`
- empty stdout from Coana
- a non-JSON final stdout line (swallowed by a bare `catch {}`)

An empty id list then short-circuited `coanaFix` with `ok: true`, which `outputFixResult` renders as **"Finished!"** with exit code 0. A broken Coana in a customer's CI was indistinguishable from "nothing to fix" — and because the fix E2E tests only dump CLI output on non-zero exit, a silent no-op produced zero diagnostics (the flaky Python E2E test that exits 0 yet upgrades nothing).

A second, subtler hole: "backend resolved zero artifacts" and "genuinely nothing to fix" both surfaced as an empty list, with no way to tell them apart.

## Changes (5 commits)

**1. `fix(fix)`: propagate Coana discovery failures instead of reporting success**

`discoverGhsaIds` returns `CResult<string[]>`: a failed Coana spawn propagates its `CResult` as-is (exit code and stderr intact via `buildDlxErrorResult`); empty stdout, a non-JSON final line, or wrongly-shaped JSON each fail with a specific message. A genuine empty result still exits 0. Both call sites (local and CI/PR mode) propagate the failure, so the real reason reaches the user with a non-zero exit — and the E2E exit-code assertion failure now dumps CLI output, making the next occurrence self-diagnosing.

**2. `feat(fix)`: consume Coana's structured discovery result + **3. bump `@coana-tech/cli` to 15.9.7****

coana-tech/coana-package-manager#2327 (released as **coana 15.9.7**) adds `find-vulnerabilities --output-file <file>`, writing a structured result:

```json
{ "ghsaIds": ["GHSA-..."], "artifactCount": 137, "filteredArtifactCount": 42 }
```

Since the Coana version is pinned in this repo, discovery now **always** uses `--output-file` and reads that file — the brittle "JSON array on the final stdout line" parsing is gone entirely. A missing, unparseable, or wrongly-shaped result file fails the run with a specific message.

The artifact counts also close the second hole: when the backend resolved **0 artifacts**, an empty result is almost certainly a server-side resolve problem rather than "nothing to fix", so the CLI now warns (`The Socket backend resolved 0 artifacts…`) instead of only printing "Finished!".

**4. `fix(fix)`: plug discovery result edge cases (Cursor Bugbot)**

`readStructuredDiscoveryResult` no longer throws a `TypeError` on non-object JSON bodies (`null`, arrays, scalars) — they return the intended `ok: false`. The `--output-file` temp path is now also removed when the spawn fails (previously only cleaned up on success).

**5. `test(fix)`: log CLI output on any e2e failure, not just non-zero exits**

A silent no-op exits 0, so the `if (code !== 0)` guard hid all CLI output for exactly the failure class that is hardest to diagnose. The E2E catch blocks now log unconditionally, so the next flake occurrence shows what Coana and the backend actually reported — including the zero-artifact warning.

## Compatibility

- Coana 15.9.7 keeps the stdout output unchanged, but this CLI no longer consumes it. Users overriding `--coana-version` to something older than 15.9.7 will get a loud `unknown option '--output-file'` failure (propagated by commit 1) instead of a silent no-op — acceptable since the version is pinned.
- Failure contract unchanged: Coana prints errors to stderr and exits non-zero; `spawnCoanaDlx` maps that to `ok: false`, which now propagates.

## Tests

`handle-fix-limit.test.mts`: 24 tests, all passing; `tsgo`/`oxlint`/`eslint` clean. Discovery mocks now write the structured envelope the way coana 15.9.7 does.

- Failure propagation: spawn failure (local + PR mode).
- Structured result: envelope read + counts; missing file / invalid JSON / wrong shape (incl. non-object bodies) each fail with specific messages; temp file removed on spawn failure; zero-artifact warning emitted; genuine empty result still exits 0 (regression guard).
- Verified the published `@coana-tech/cli@15.9.7` exposes `-o, --output-file` (`find-vulnerabilities --help`).

## Behavior change (intended)

Automation parsing `socket fix --json` that relied on `ok: true` + empty `ghsaDetails` when Coana was broken now gets `ok: false` + message and a non-zero exit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `socket fix` success/failure semantics and JSON `ok` for discovery errors, which can break automation that treated failed Coana runs as success; core fix path behavior is otherwise localized to discovery.
> 
> **Overview**
> **`socket fix`** no longer treats a broken vulnerability-discovery step as “nothing to fix.” Discovery failures (Coana non-zero exit, missing/unreadable `--output-file` JSON) now return **`ok: false`** with a non-zero exit instead of **`Finished!`** with an empty result.
> 
> Discovery always runs Coana **`find-vulnerabilities`** with **`--output-file`** (Coana **15.9.7**) and reads **`ghsaIds`** plus **`artifactCount`** from that JSON, replacing parsing the last stdout line. When **`artifactCount` is 0**, the CLI **warns** that backend resolve may be incomplete rather than only showing an empty list.
> 
> **`@coana-tech/cli`** is bumped to **15.9.7** (version **1.1.150**). Tests mock the structured envelope and cover failure propagation and invalid discovery output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 645d428370ddea4bdf22d5d942a1b2aa5add4c23. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
