### PR TITLE
fix(scan): scope --reach-use-only-pregenerated-sboms to analysis input only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.147](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.147) - 2026-07-29
+
+### Fixed
+- `--reach-use-only-pregenerated-sboms` now only controls what reachability analysis uses as input. Previously it also narrowed the manifest files uploaded as part of the scan, which was not the intent of the option.
+
 ## [1.1.146](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.146) - 2026-07-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [1.1.147](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.147) - 2026-07-29
 
 ### Fixed
-- `--reach-use-only-pregenerated-sboms` now only controls what reachability analysis uses as input. Previously it also narrowed the manifest files uploaded as part of the scan, which was not the intent of the option.
+- `--reach-use-only-pregenerated-sboms` now only controls what reachability analysis uses as input. Previously it also narrowed the manifest files uploaded as part of the scan.
 
 ## [1.1.146](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.146) - 2026-07-24
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.146",
+  "version": "1.1.147",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT",

--- a/src/commands/scan/handle-create-new-scan.mts
+++ b/src/commands/scan/handle-create-new-scan.mts
@@ -1,8 +1,6 @@
 import { unlink } from 'node:fs/promises'
 import path from 'node:path'
 
-import micromatch from 'micromatch'
-
 import { debugDir, debugFn } from '@socketsecurity/registry/lib/debug'
 import { logger } from '@socketsecurity/registry/lib/logger'
 import { pluralize } from '@socketsecurity/registry/lib/words'
@@ -29,40 +27,6 @@ import type { REPORT_LEVEL } from './types.mts'
 import type { OutputKind } from '../../types.mts'
 import type { ResolvedPathsSidecar } from '../manifest/scripts/sidecar.mts'
 import type { Remap } from '@socketsecurity/registry/lib/objects'
-import type { SocketSdkSuccessResult } from '@socketsecurity/sdk'
-
-// Supported-files response keys whose files count as pre-generated SBOMs:
-// CycloneDX, SPDX, and Socket facts (`.socket.facts.json`, under `socket`).
-// Kept in sync with Coana's `--use-only-pregenerated-sboms` selection
-// (extractPregeneratedSbomPatterns), which matches the same three keys.
-const PREGENERATED_SBOM_KEYS = ['cdx', 'socket', 'spdx']
-
-function getPregeneratedSbomPatterns(
-  supportedFiles: SocketSdkSuccessResult<'getReportSupportedFiles'>['data'],
-): string[] {
-  const patterns: string[] = []
-  for (const key of PREGENERATED_SBOM_KEYS) {
-    const supported = supportedFiles[key]
-    if (supported) {
-      for (const entry of Object.values(supported)) {
-        patterns.push(`**/${entry.pattern}`)
-      }
-    }
-  }
-  return patterns
-}
-
-function filterToPregeneratedSboms(
-  filepaths: string[],
-  supportedFiles: SocketSdkSuccessResult<'getReportSupportedFiles'>['data'],
-): string[] {
-  const patterns = getPregeneratedSbomPatterns(supportedFiles)
-  // `dot: true` lets `*`-prefixed patterns match leading-dot filenames such as
-  // `.socket.facts.json` (advertised as `*.socket.facts.json`).
-  return filepaths.filter(filepath =>
-    micromatch.some(filepath, patterns, { dot: true, nocase: true }),
-  )
-}
 
 export type HandleCreateNewScanConfig = {
   autoManifest: boolean
@@ -269,16 +233,13 @@ export async function handleCreateNewScan({
 
     reachabilityReport = reachResult.data?.reachabilityReport
 
-    // When using only pre-generated SBOMs, build the scan from those inputs —
-    // CycloneDX, SPDX, and Socket facts (`.socket.facts.json`) — matching
-    // Coana's `--use-only-pregenerated-sboms` selection. Otherwise drop any
-    // stray `.socket.facts.json`; coana's fresh reachability report (appended
-    // below) is the authoritative facts file for the scan.
-    const pathsForScan = reach.reachUseOnlyPregeneratedSboms
-      ? filterToPregeneratedSboms(packagePaths, supportedFiles)
-      : packagePaths.filter(
-          p => path.basename(p) !== constants.DOT_SOCKET_DOT_FACTS_JSON,
-        )
+    // Drop any stray `.socket.facts.json`; coana's fresh reachability report
+    // (appended below) is the authoritative facts file for the scan.
+    // `reachUseOnlyPregeneratedSboms` only controls what coana analyzes
+    // (forwarded in performReachabilityAnalysis), not what gets uploaded here.
+    const pathsForScan = packagePaths.filter(
+      p => path.basename(p) !== constants.DOT_SOCKET_DOT_FACTS_JSON,
+    )
 
     // Append coana's reachability report, but not twice: a pre-generated facts
     // input can resolve to the same path coana wrote its report to.

--- a/src/commands/scan/reachability-flags.mts
+++ b/src/commands/scan/reachability-flags.mts
@@ -120,7 +120,7 @@ export const reachabilityFlags: MeowFlags = {
     type: 'boolean',
     default: false,
     description:
-      'When using this option, the scan is created based only on pre-generated CDX and SPDX files in your project.',
+      'When using this option, reachability analysis is performed using only pre-generated CDX, SPDX, and Socket facts files in your project instead of resolving dependencies itself.',
   },
 }
 


### PR DESCRIPTION
## Summary
- `--reach-use-only-pregenerated-sboms` was also filtering which manifest files get uploaded as part of the scan (restricting the upload to CDX/SPDX/Socket-facts files), in addition to controlling what Coana uses as input for reachability analysis.
- This wasn't the intent of the option: it should only control reachability analysis input. Removed the upload-side filtering (`filterToPregeneratedSboms`/`getPregeneratedSbomPatterns` in `handle-create-new-scan.mts`); the scan now always uploads all discovered package paths (minus a stray `.socket.facts.json`) regardless of this flag.
- The pass-through to Coana (`--use-only-pregenerated-sboms` in `perform-reachability-analysis.mts`) is unchanged.
- Updated the flag's help text to describe the corrected scope.

## Test plan
- [x] `pnpm build:dist:src`
- [x] `pnpm test:unit src/commands/scan/handle-create-new-scan.test.mts src/commands/scan/perform-reachability-analysis.test.mts` (18 tests pass)
- [x] `npx eslint` on both edited files (clean)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what files are sent on full scans when `--reach` and `--reach-use-only-pregenerated-sboms` are used together—broader uploads than before, which can affect scan scope and results for users who relied on the old behavior.
> 
> **Overview**
> **`--reach-use-only-pregenerated-sboms`** no longer limits which manifest files are uploaded with the scan. Uploads now always include all discovered package paths (still dropping a stray `.socket.facts.json` and appending Coana’s fresh reachability report), regardless of that flag.
> 
> The flag’s effect is limited to **reachability analysis input** (still passed through to Coana as `--use-only-pregenerated-sboms`). The upload-side filtering helpers (`filterToPregeneratedSboms`, `getPregeneratedSbomPatterns`, and the `micromatch` import) were removed from `handle-create-new-scan.mts`. Flag help text was updated to match.
> 
> Release **1.1.147** with a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5ccebc30a58bd7470de66ec00aca2a9b1efc170. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->