### PR TITLE
socket-cli: --dynamic-sbom-inference flag for per-workspace Maven reachability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.151](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.151) - 2026-07-30
+
+### Changed
+- Updated the Coana CLI to v `15.9.9`.
+
 ## [1.1.150](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.150) - 2026-07-29
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.150",
+  "version": "1.1.151",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT",
@@ -97,7 +97,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "15.9.7",
+    "@coana-tech/cli": "15.9.9",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,8 +132,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 15.9.7
-        version: 15.9.7
+        specifier: 15.9.9
+        version: 15.9.9
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -806,8 +806,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@15.9.7':
-    resolution: {integrity: sha512-1CGis51nRr3Sl3uKYLd7/c4L+vEtYlJUiGYh1TL58WtD4Ojd+qaticSFDa+mywbKLRBXpAPwPWBOes0OQZNP1g==}
+  '@coana-tech/cli@15.9.9':
+    resolution: {integrity: sha512-LfJSd0CagP/Jvu+OKodH+fSwf74sEVr3N6m4dYvr+jrRyOrhutrWMN6g517PwL6eioAGKTT39F0SWlQO/t0crg==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5509,7 +5509,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@15.9.7': {}
+  '@coana-tech/cli@15.9.9': {}
 
   '@colors/colors@1.5.0':
     optional: true

--- a/src/commands/ci/handle-ci.mts
+++ b/src/commands/ci/handle-ci.mts
@@ -51,6 +51,7 @@ export async function handleCi(autoManifest: boolean): Promise<void> {
     pendingHead: true,
     pullRequest: 0,
     reach: {
+      dynamicSbomInference: false,
       excludePaths: [],
       reachAnalysisMemoryLimit: '',
       reachAnalysisTimeout: '',

--- a/src/commands/manifest/scripts/assemble.mts
+++ b/src/commands/manifest/scripts/assemble.mts
@@ -379,8 +379,8 @@ function buildArtifactPaths(
     }
     coords.add(coordKey)
     const pi = projectsByGav.get(gav(c.group, c.name, c.version ?? ''))
-    const sources = (pi?.sources ?? []).filter(fileExists)
-    const targets = [...new Set([...fn.targets, ...(pi?.targets ?? [])])]
+    const sources = (pi?.sources ?? []).filter(fileExists).sort()
+    const targets = [...new Set(pi ? pi.targets : fn.targets)]
       .filter(fileExists)
       .sort()
     if (sources.length) {

--- a/src/commands/scan/cmd-scan-create.mts
+++ b/src/commands/scan/cmd-scan-create.mts
@@ -241,6 +241,7 @@ async function run(
     committers,
     cwd: cwdOverride,
     defaultBranch,
+    dynamicSbomInference,
     interactive = true,
     json,
     markdown,
@@ -275,6 +276,7 @@ async function run(
     committers: string
     cwd: string
     defaultBranch: boolean
+    dynamicSbomInference: boolean
     interactive: boolean
     json: boolean
     markdown: boolean
@@ -352,6 +354,11 @@ async function run(
     } else {
       autoManifest = false
     }
+  }
+  // --dynamic-sbom-inference requires auto-manifest to generate the
+  // per-workspace facts it feeds to Coana.
+  if (dynamicSbomInference) {
+    autoManifest = true
   }
   if (!branchName) {
     if (sockJson.defaults?.scan?.create?.branch) {
@@ -505,6 +512,7 @@ async function run(
     reachVersion !== reachabilityFlags['reachVersion']?.default
 
   const isUsingAnyReachabilityFlags =
+    dynamicSbomInference ||
     hasReachEcosystems ||
     hasReachExcludePaths ||
     isUsingNonDefaultAnalytics ||
@@ -625,6 +633,7 @@ async function run(
     pendingHead: Boolean(pendingHead),
     pullRequest: Number(pullRequest),
     reach: {
+      dynamicSbomInference: Boolean(dynamicSbomInference),
       excludePaths,
       reachAnalysisMemoryLimit,
       reachAnalysisTimeout,

--- a/src/commands/scan/cmd-scan-reach.mts
+++ b/src/commands/scan/cmd-scan-reach.mts
@@ -116,7 +116,6 @@ async function run(
 
   const {
     cwd: cwdOverride,
-    dynamicSbomInference,
     interactive = true,
     json,
     markdown,
@@ -142,7 +141,6 @@ async function run(
     reachVersion,
   } = cli.flags as {
     cwd: string
-    dynamicSbomInference: boolean
     interactive: boolean
     json: boolean
     markdown: boolean
@@ -269,7 +267,9 @@ async function run(
     outputKind,
     outputPath: outputPath || '',
     reachabilityOptions: {
-      dynamicSbomInference: Boolean(dynamicSbomInference),
+      // Not exposed here: it relies on --auto-manifest generating per-workspace
+      // Socket facts first, which `socket scan reach` never runs.
+      dynamicSbomInference: false,
       excludePaths,
       reachAnalysisMemoryLimit,
       reachAnalysisTimeout,

--- a/src/commands/scan/cmd-scan-reach.mts
+++ b/src/commands/scan/cmd-scan-reach.mts
@@ -116,6 +116,7 @@ async function run(
 
   const {
     cwd: cwdOverride,
+    dynamicSbomInference,
     interactive = true,
     json,
     markdown,
@@ -141,6 +142,7 @@ async function run(
     reachVersion,
   } = cli.flags as {
     cwd: string
+    dynamicSbomInference: boolean
     interactive: boolean
     json: boolean
     markdown: boolean
@@ -267,6 +269,7 @@ async function run(
     outputKind,
     outputPath: outputPath || '',
     reachabilityOptions: {
+      dynamicSbomInference: Boolean(dynamicSbomInference),
       excludePaths,
       reachAnalysisMemoryLimit,
       reachAnalysisTimeout,

--- a/src/commands/scan/create-scan-from-github.mts
+++ b/src/commands/scan/create-scan-from-github.mts
@@ -253,6 +253,7 @@ async function scanOneRepo(
     pendingHead: true,
     pullRequest: 0,
     reach: {
+      dynamicSbomInference: false,
       excludePaths: [],
       reachAnalysisMemoryLimit: '',
       reachAnalysisTimeout: '',

--- a/src/commands/scan/exclude-paths.test.mts
+++ b/src/commands/scan/exclude-paths.test.mts
@@ -14,6 +14,7 @@ function makeReachOptions(
   overrides: Partial<ReachabilityOptions> = {},
 ): ReachabilityOptions {
   return {
+    dynamicSbomInference: false,
     excludePaths: [],
     reachAnalysisMemoryLimit: '8192',
     reachAnalysisTimeout: '',

--- a/src/commands/scan/handle-create-new-scan.test.mts
+++ b/src/commands/scan/handle-create-new-scan.test.mts
@@ -86,6 +86,7 @@ function createConfig(
     pendingHead: false,
     pullRequest: 0,
     reach: {
+      dynamicSbomInference: false,
       excludePaths: [],
       reachAnalysisMemoryLimit: '8192',
       reachAnalysisTimeout: '',
@@ -198,6 +199,7 @@ describe('handleCreateNewScan excludePaths', () => {
       pendingHead: false,
       pullRequest: 0,
       reach: {
+        dynamicSbomInference: false,
         excludePaths: ['tests', 'packages/*'],
         reachAnalysisMemoryLimit: '8192',
         reachAnalysisTimeout: '',
@@ -261,6 +263,7 @@ describe('handleCreateNewScan excludePaths', () => {
       pendingHead: false,
       pullRequest: 0,
       reach: {
+        dynamicSbomInference: false,
         excludePaths: ['apps/api/tests', '**/dist'],
         reachAnalysisMemoryLimit: '8192',
         reachAnalysisTimeout: '',
@@ -330,6 +333,7 @@ describe('handleCreateNewScan excludePaths', () => {
       pendingHead: false,
       pullRequest: 0,
       reach: {
+        dynamicSbomInference: false,
         excludePaths: ['tests'],
         reachAnalysisMemoryLimit: '8192',
         reachAnalysisTimeout: '',
@@ -389,6 +393,7 @@ describe('handleCreateNewScan excludePaths', () => {
       pendingHead: false,
       pullRequest: 0,
       reach: {
+        dynamicSbomInference: false,
         excludePaths: ['apps/api'],
         reachAnalysisMemoryLimit: '8192',
         reachAnalysisTimeout: '',
@@ -448,6 +453,7 @@ describe('handleCreateNewScan excludePaths', () => {
       pendingHead: false,
       pullRequest: 0,
       reach: {
+        dynamicSbomInference: false,
         excludePaths: ['tests'],
         reachAnalysisMemoryLimit: '8192',
         reachAnalysisTimeout: '',

--- a/src/commands/scan/handle-scan-reach.test.mts
+++ b/src/commands/scan/handle-scan-reach.test.mts
@@ -104,6 +104,7 @@ describe('handleScanReach', () => {
 
   it('applies excludePaths to manifest discovery and reachability analysis', async () => {
     const reachabilityOptions = {
+      dynamicSbomInference: false,
       excludePaths: ['tests', 'packages/*'],
       reachAnalysisMemoryLimit: '8192',
       reachAnalysisTimeout: '',
@@ -156,6 +157,7 @@ describe('handleScanReach', () => {
 
   it('translates excludePaths from the scan root for nested targets', async () => {
     const reachabilityOptions = {
+      dynamicSbomInference: false,
       excludePaths: ['apps/api/tests', '**/dist'],
       reachAnalysisMemoryLimit: '8192',
       reachAnalysisTimeout: '',
@@ -218,6 +220,7 @@ describe('handleScanReach', () => {
         checks.every(check => check.test),
     )
     const reachabilityOptions = {
+      dynamicSbomInference: false,
       excludePaths: ['apps/api'],
       reachAnalysisMemoryLimit: '8192',
       reachAnalysisTimeout: '',
@@ -266,6 +269,7 @@ describe('handleScanReach', () => {
     mockFindSocketYmlSync.mockReturnValueOnce({ ok: false })
 
     const reachabilityOptions = {
+      dynamicSbomInference: false,
       excludePaths: ['tests'],
       reachAnalysisMemoryLimit: '8192',
       reachAnalysisTimeout: '',
@@ -318,6 +322,7 @@ describe('handleScanReach', () => {
       },
     })
     const reachabilityOptions = {
+      dynamicSbomInference: false,
       excludePaths: [],
       reachAnalysisMemoryLimit: '8192',
       reachAnalysisTimeout: '',
@@ -355,6 +360,7 @@ describe('handleScanReach', () => {
 
   it('does not call finalize when Coana did not return a full application reachability scan id', async () => {
     const reachabilityOptions = {
+      dynamicSbomInference: false,
       excludePaths: [],
       reachAnalysisMemoryLimit: '8192',
       reachAnalysisTimeout: '',
@@ -405,6 +411,7 @@ describe('handleScanReach', () => {
       cause: 'Socket API server error (503)',
     })
     const reachabilityOptions = {
+      dynamicSbomInference: false,
       excludePaths: [],
       reachAnalysisMemoryLimit: '8192',
       reachAnalysisTimeout: '',

--- a/src/commands/scan/perform-reachability-analysis.mts
+++ b/src/commands/scan/perform-reachability-analysis.mts
@@ -22,6 +22,7 @@ import type { Spinner } from '@socketsecurity/registry/lib/spinner'
 import type { StdioOptions } from 'node:child_process'
 
 export type ReachabilityOptions = {
+  dynamicSbomInference: boolean
   excludePaths: string[]
   reachAnalysisMemoryLimit: string
   reachAnalysisTimeout: string
@@ -250,6 +251,9 @@ export async function performReachabilityAnalysis(
       : []),
     ...(reachabilityOptions.reachExcludePaths.length
       ? ['--exclude-dirs', ...reachabilityOptions.reachExcludePaths]
+      : []),
+    ...(reachabilityOptions.dynamicSbomInference
+      ? ['--maven-use-only-root-socket-facts']
       : []),
     ...(reachabilityOptions.reachLazyMode ? ['--lazy-mode'] : []),
     ...(reachabilityOptions.reachSkipCache ? ['--skip-cache-usage'] : []),

--- a/src/commands/scan/perform-reachability-analysis.test.mts
+++ b/src/commands/scan/perform-reachability-analysis.test.mts
@@ -75,6 +75,7 @@ vi.mock('@socketsecurity/registry/lib/logger', () => ({
 
 function makeReachabilityOptions(): ReachabilityOptions {
   return {
+    dynamicSbomInference: false,
     excludePaths: [],
     reachAnalysisMemoryLimit: '',
     reachAnalysisTimeout: '',

--- a/src/commands/scan/reachability-flags.mts
+++ b/src/commands/scan/reachability-flags.mts
@@ -4,6 +4,13 @@ import { getReachabilityEcosystemChoices } from '../../utils/ecosystem.mts'
 import type { MeowFlags } from '../../flags.mts'
 
 export const reachabilityFlags: MeowFlags = {
+  dynamicSbomInference: {
+    type: 'boolean',
+    default: false,
+    hidden: true,
+    description:
+      'Internal: enables dynamic SBOM inference for full application reachability analysis. Passes --maven-use-only-root-socket-facts to Coana and implies --auto-manifest.',
+  },
   reachVersion: {
     type: 'string',
     description: `Override the version of @coana-tech/cli used for reachability analysis. Default: ${constants.ENV.INLINED_SOCKET_CLI_COANA_TECH_CLI_VERSION}.`,


### PR DESCRIPTION
## Summary
- Adds a hidden `--dynamic-sbom-inference` flag to `socket scan create` (and `socket scan reach`) that forces `--auto-manifest` on and passes `--maven-use-only-root-socket-facts` through to the Coana CLI, so Coana consumes pre-generated per-workspace Socket facts instead of resolving the full Maven reactor itself.
- Fixes `assemble.mts` so a dependency edge that resolves to a first-party project reports that project's own build source/target roots instead of a classpath-resolved artifact path that may not exist if the module hasn't been built yet.

## Status: draft, not mergeable yet

This PR is blocked until the Coana CLI supports `--maven-use-only-root-socket-facts` and `@coana-tech/cli` is bumped + published in this repo. Until then it can only be exercised via a local Coana build (`SOCKET_CLI_COANA_LOCAL_PATH`).

Linear: REA-687

## Test plan
- [x] `pnpm check:tsc` / `pnpm check:lint` clean
- [x] `pnpm build` (rollup + tsgo) succeeds
- [x] Relevant unit tests pass (`perform-reachability-analysis`, `handle-scan-reach`, `handle-create-new-scan`, `exclude-paths`)
- [ ] End-to-end `--reach --dynamic-sbom-inference` smoke test once Coana CLI is published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Maven reachability inputs and Coana CLI wiring; wrong artifact paths could skew analysis, but the flag is hidden and defaults off.
> 
> **Overview**
> Adds a hidden **`--dynamic-sbom-inference`** flag on **`socket scan create`** and **`socket scan reach`**. When set (with **`--reach`**), it turns on **`--auto-manifest`** so per-workspace Socket facts are generated, and forwards **`--maven-use-only-root-socket-facts`** to Coana so Maven reachability uses those pre-generated facts instead of resolving the full reactor inside Coana.
> 
> **`assemble.mts`** now maps first-party Maven modules to **only** the project’s own build **targets** (not merged with classpath artifact paths from dependency nodes), and sorts **sources**—so reachability points at module source roots that exist before a local build.
> 
> Bumps **`@coana-tech/cli`** to **15.9.9** and releases **1.1.151**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d0c6928286a4079397e743ba10888548edba60a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->