### PR TITLE
fix(manifest): keep sbt's Scala toolchain jars alive for reachability sidecar paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.151](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.151) - 2026-07-30
+
+### Fixed
+- Fixed `--auto-manifest --reach` reachability scans on sbt/Scala projects sometimes failing to resolve the Scala standard library.
+
 ## [1.1.150](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.150) - 2026-07-29
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.150",
+  "version": "1.1.151",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT",

--- a/src/commands/manifest/cmd-manifest-auto.mts
+++ b/src/commands/manifest/cmd-manifest-auto.mts
@@ -8,6 +8,7 @@ import { generateAutoManifest } from './generate_auto_manifest.mts'
 import constants from '../../constants.mts'
 import { commonFlags } from '../../flags.mts'
 import { cmdFlagValueToArray } from '../../utils/cmd.mts'
+import { withTmpDir } from '../../utils/fs.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
@@ -124,13 +125,16 @@ async function run(
   const excludePaths = cmdFlagValueToArray(cli.flags['excludePaths'])
   assertValidExcludePaths(excludePaths)
 
-  await generateAutoManifest({
-    detected,
-    cwd,
-    excludePaths,
-    outputKind,
-    verbose,
-  })
+  await withTmpDir('socket-manifest-auto-', tmpDir =>
+    generateAutoManifest({
+      detected,
+      cwd,
+      excludePaths,
+      outputKind,
+      tmpDir,
+      verbose,
+    }),
+  )
 
   logger.success(
     `Finished. Should have attempted to generate manifest files for ${detected.count} targets.`,

--- a/src/commands/manifest/cmd-manifest-scala.mts
+++ b/src/commands/manifest/cmd-manifest-scala.mts
@@ -10,6 +10,7 @@ import constants, { REQUIREMENTS_TXT, SOCKET_JSON } from '../../constants.mts'
 import { commonFlags } from '../../flags.mts'
 import { checkCommandInput } from '../../utils/check-input.mts'
 import { cmdFlagValueToArray } from '../../utils/cmd.mts'
+import { withTmpDir } from '../../utils/fs.mts'
 import { getOutputKind } from '../../utils/get-output-kind.mts'
 import { meowOrExit } from '../../utils/meow-with-subcommands.mts'
 import { getFlagListOutput } from '../../utils/output-formatting.mts'
@@ -348,16 +349,19 @@ async function run(
   assertValidExcludePaths(excludePaths)
 
   if (facts) {
-    await convertSbtToFacts({
-      bin: String(bin),
-      cwd,
-      excludeConfigs: String(excludeConfigs || ''),
-      excludePaths,
-      ignoreUnresolved: Boolean(ignoreUnresolved),
-      includeConfigs: String(includeConfigs || ''),
-      sbtOpts: parsedSbtOpts,
-      verbose: Boolean(verbose),
-    })
+    await withTmpDir('socket-manifest-scala-', tmpDir =>
+      convertSbtToFacts({
+        bin: String(bin),
+        cwd,
+        excludeConfigs: String(excludeConfigs || ''),
+        excludePaths,
+        ignoreUnresolved: Boolean(ignoreUnresolved),
+        includeConfigs: String(includeConfigs || ''),
+        sbtOpts: parsedSbtOpts,
+        tmpDir,
+        verbose: Boolean(verbose),
+      }),
+    )
     return
   }
 

--- a/src/commands/manifest/convert-sbt-to-facts.mts
+++ b/src/commands/manifest/convert-sbt-to-facts.mts
@@ -14,6 +14,7 @@ export async function convertSbtToFacts({
   includeConfigs,
   sbtOpts,
   sidecarAcc,
+  tmpDir,
   verbose,
   withFiles,
 }: {
@@ -25,6 +26,8 @@ export async function convertSbtToFacts({
   includeConfigs: string
   sbtOpts: string[]
   sidecarAcc?: SidecarAccumulator | undefined
+  // Caller-owned; see ManifestScriptOptions.tmpDir.
+  tmpDir?: string | undefined
   verbose: boolean
   withFiles?: boolean | undefined
 }): Promise<void> {
@@ -38,6 +41,7 @@ export async function convertSbtToFacts({
     ignoreUnresolved,
     includeConfigs,
     sidecarAcc,
+    tmpDir,
     verbose,
     withFiles,
   })

--- a/src/commands/manifest/convert-sbt-to-facts.mts
+++ b/src/commands/manifest/convert-sbt-to-facts.mts
@@ -27,7 +27,7 @@ export async function convertSbtToFacts({
   sbtOpts: string[]
   sidecarAcc?: SidecarAccumulator | undefined
   // Caller-owned; see ManifestScriptOptions.tmpDir.
-  tmpDir?: string | undefined
+  tmpDir: string
   verbose: boolean
   withFiles?: boolean | undefined
 }): Promise<void> {

--- a/src/commands/manifest/generate_auto_manifest.mts
+++ b/src/commands/manifest/generate_auto_manifest.mts
@@ -63,10 +63,9 @@ export async function generateAutoManifest({
   // excluded source roots from the resolved-paths sidecar.
   excludePaths?: string[] | undefined
   outputKind: OutputKind
-  // sbt only, required when computeArtifactsSidecar is true; see
-  // ManifestScriptOptions.tmpDir. Caller creates it and deletes it once
-  // resolvedPathsSidecar's paths are no longer needed.
-  tmpDir?: string | undefined
+  // Caller-owned; see ManifestScriptOptions.tmpDir. Only sbt reads it, but
+  // required here so every caller allocates one via withTmpDir uniformly.
+  tmpDir: string
   verbose: boolean
 }): Promise<GenerateAutoManifestResult> {
   const sockJson = readOrDefaultSocketJson(cwd)

--- a/src/commands/manifest/generate_auto_manifest.mts
+++ b/src/commands/manifest/generate_auto_manifest.mts
@@ -52,6 +52,7 @@ export async function generateAutoManifest({
   detected,
   excludePaths,
   outputKind,
+  tmpDir,
   verbose,
 }: {
   // Reachability path: run build tools with files to emit the sidecar.
@@ -62,6 +63,10 @@ export async function generateAutoManifest({
   // excluded source roots from the resolved-paths sidecar.
   excludePaths?: string[] | undefined
   outputKind: OutputKind
+  // sbt only, required when computeArtifactsSidecar is true; see
+  // ManifestScriptOptions.tmpDir. Caller creates it and deletes it once
+  // resolvedPathsSidecar's paths are no longer needed.
+  tmpDir?: string | undefined
   verbose: boolean
 }): Promise<GenerateAutoManifestResult> {
   const sockJson = readOrDefaultSocketJson(cwd)
@@ -101,6 +106,7 @@ export async function generateAutoManifest({
         ),
         includeConfigs: sockJson.defaults?.manifest?.sbt?.includeConfigs ?? '',
         sidecarAcc,
+        tmpDir,
         withFiles: computeArtifactsSidecar,
       })
       abortManifestRunIfFailed('sbt', beforeExitCode)

--- a/src/commands/manifest/run-manifest-facts.mts
+++ b/src/commands/manifest/run-manifest-facts.mts
@@ -40,6 +40,7 @@ export async function runManifestFacts({
   ignoreUnresolved,
   includeConfigs,
   sidecarAcc,
+  tmpDir,
   verbose,
   withFiles,
 }: {
@@ -52,6 +53,8 @@ export async function runManifestFacts({
   ignoreUnresolved: boolean
   includeConfigs: string
   sidecarAcc?: SidecarAccumulator | undefined
+  // sbt only; see ManifestScriptOptions.tmpDir.
+  tmpDir?: string | undefined
   verbose: boolean
   withFiles?: boolean | undefined
 }): Promise<void> {
@@ -70,6 +73,7 @@ export async function runManifestFacts({
     // Stream the build tool's output only when asked; otherwise capture it and
     // show a spinner, surfacing the output only if the build crashes.
     stdio: verbose ? ('inherit' as const) : ('pipe' as const),
+    tmpDir,
     toolOpts: buildOpts,
     withFiles,
   }

--- a/src/commands/manifest/scripts/run.mts
+++ b/src/commands/manifest/scripts/run.mts
@@ -1,5 +1,4 @@
 import { existsSync, promises as fs } from 'node:fs'
-import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 import { spawn } from '@socketsecurity/registry/lib/spawn'
@@ -8,6 +7,7 @@ import { assembleFacts } from './assemble.mts'
 import { resolveBuildToolBin } from './build-tool.mts'
 import { parseRecords } from './records.mts'
 import constants from '../../../constants.mts'
+import { withTmpDir } from '../../../utils/fs.mts'
 
 import type { BuildTool } from './build-tool.mts'
 import type { ResolvedArtifactPaths, SocketFactsSbom } from './facts.mts'
@@ -19,6 +19,14 @@ export type ManifestScriptOptions = {
   bin?: string | undefined
   // Reachability-only: also materialize resolved artifact paths (artifactPaths).
   withFiles?: boolean | undefined
+  // sbt only: caller-supplied directory to use as sbt's isolated global base.
+  // sbt provisions the project's Scala toolchain (compiler/library/reflect)
+  // under `<global base>/boot`, which withFiles' artifactPaths point into, so
+  // the directory must outlive this call; the caller owns creating it and
+  // deleting it once those paths are no longer needed. Unset ⇒ an ephemeral
+  // dir is created and cleaned up before this call returns (the withFiles-less
+  // default, and the case for a standalone `socket manifest sbt --facts`).
+  tmpDir?: string | undefined
   // Newline-delimited GAV file scoping withFiles materialization; absent ⇒ all.
   populateFilesFor?: string | undefined
   includeConfigs?: string | undefined
@@ -94,18 +102,6 @@ async function runNeverThrow(
       }
     }
     throw e
-  }
-}
-
-async function withTmpDir<T>(
-  prefix: string,
-  fn: (tmpDir: string) => Promise<T>,
-): Promise<T> {
-  const tmpDir = await fs.mkdtemp(path.join(tmpdir(), prefix))
-  try {
-    return await fn(tmpDir)
-  } finally {
-    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {})
   }
 }
 
@@ -214,36 +210,50 @@ async function runGradle(
   })
 }
 
+async function runSbtIn(
+  globalBase: string,
+  opts: ManifestScriptOptions,
+): Promise<ManifestRunResult> {
+  await writeSbtPlugin(globalBase)
+  const recordsFile = path.join(globalBase, 'records.tsv')
+  const bin = resolveBuildToolBin('sbt', opts.projectDir, opts.bin)
+  // Fresh per-run global base (not ~/.sbt): sbt executes everything under
+  // plugins/, so a shared path is a code-injection surface. BSP off for this
+  // run. sbt also provisions the project's Scala toolchain under
+  // <global.base>/boot; when opts.tmpDir was supplied, the caller keeps this
+  // directory (and that toolchain) alive until it's done with withFiles'
+  // artifactPaths, so no special-casing is needed here.
+  const props = [
+    `-Dsbt.global.base=${globalBase}`,
+    '-Dsbt.server.autostart=false',
+    `-Dsocket.recordsFile=${recordsFile}`,
+    ...commonProps(opts, '-D'),
+  ]
+  // sbt's launcher doesn't always honor JAVA_HOME; never override a
+  // caller-supplied --java-home.
+  const javaHome = opts.env?.['JAVA_HOME'] ?? process.env['JAVA_HOME']
+  const javaHomeOpt =
+    javaHome && !(opts.toolOpts ?? []).includes('--java-home')
+      ? ['--java-home', javaHome]
+      : []
+  const args = [
+    ...javaHomeOpt,
+    ...props,
+    ...(opts.toolOpts ?? []),
+    '--batch',
+    FACTS_TASK,
+  ]
+  const out = await runNeverThrow(bin, args, opts)
+  return await assembleFromRecords(out, recordsFile)
+}
+
 async function runSbt(opts: ManifestScriptOptions): Promise<ManifestRunResult> {
-  return await withTmpDir('socket-sbt-facts-', async globalBase => {
-    await writeSbtPlugin(globalBase)
-    const recordsFile = path.join(globalBase, 'records.tsv')
-    const bin = resolveBuildToolBin('sbt', opts.projectDir, opts.bin)
-    // Fresh per-run global base (not ~/.sbt): sbt executes everything under
-    // plugins/, so a shared path is a code-injection surface. BSP off for this run.
-    const props = [
-      `-Dsbt.global.base=${globalBase}`,
-      '-Dsbt.server.autostart=false',
-      `-Dsocket.recordsFile=${recordsFile}`,
-      ...commonProps(opts, '-D'),
-    ]
-    // sbt's launcher doesn't always honor JAVA_HOME; never override a
-    // caller-supplied --java-home.
-    const javaHome = opts.env?.['JAVA_HOME'] ?? process.env['JAVA_HOME']
-    const javaHomeOpt =
-      javaHome && !(opts.toolOpts ?? []).includes('--java-home')
-        ? ['--java-home', javaHome]
-        : []
-    const args = [
-      ...javaHomeOpt,
-      ...props,
-      ...(opts.toolOpts ?? []),
-      '--batch',
-      FACTS_TASK,
-    ]
-    const out = await runNeverThrow(bin, args, opts)
-    return await assembleFromRecords(out, recordsFile)
-  })
+  if (opts.tmpDir) {
+    return await runSbtIn(opts.tmpDir, opts)
+  }
+  return await withTmpDir('socket-sbt-facts-', globalBase =>
+    runSbtIn(globalBase, opts),
+  )
 }
 
 async function runMaven(

--- a/src/commands/scan/handle-create-new-scan.mts
+++ b/src/commands/scan/handle-create-new-scan.mts
@@ -18,6 +18,7 @@ import constants from '../../constants.mts'
 import { checkCommandInput } from '../../utils/check-input.mts'
 import { compressSocketFactsForUpload } from '../../utils/coana.mts'
 import { findSocketYmlSync } from '../../utils/config.mts'
+import { withTmpDir } from '../../utils/fs.mts'
 import { getPackageFilesForScan } from '../../utils/path-resolve.mts'
 import { readOrDefaultSocketJson } from '../../utils/socket-json.mts'
 import { socketDocsLink } from '../../utils/terminal-link.mts'
@@ -139,276 +140,285 @@ export async function handleCreateNewScan({
 
   // Sidecar forwarded to reachability; populated only when reach runs.
   let resolvedPathsSidecar: ResolvedPathsSidecar | undefined
-  if (autoManifest) {
-    logger.info('Auto-generating manifest files ...')
-    debugFn('notice', 'Auto-manifest mode enabled')
-    const sockJson = readOrDefaultSocketJson(cwd)
-    const detected = await detectManifestActions(sockJson, cwd)
-    debugDir('inspect', { detected })
-    const autoManifestResult = await generateAutoManifest({
-      computeArtifactsSidecar: reach.runReachabilityAnalysis,
-      cwd,
-      detected,
-      excludePaths: reach.excludePaths,
-      outputKind,
-      verbose: false,
-    })
-    resolvedPathsSidecar = autoManifestResult.resolvedPathsSidecar
-    if (autoManifestResult.generatedFiles.length) {
-      scanTargets = Array.from(
-        new Set([...targets, ...autoManifestResult.generatedFiles]),
-      )
+
+  // sbt provisions its Scala toolchain under the directory passed as its
+  // isolated global base; withFiles' artifactPaths point into it, so it must
+  // stay on disk until the reachability analysis below has consumed those
+  // paths. Always allocated (even when unused) to keep this uniform rather
+  // than conditional on autoManifest/reach.
+  await withTmpDir('socket-auto-manifest-', async manifestTmpDir => {
+    if (autoManifest) {
+      logger.info('Auto-generating manifest files ...')
+      debugFn('notice', 'Auto-manifest mode enabled')
+      const sockJson = readOrDefaultSocketJson(cwd)
+      const detected = await detectManifestActions(sockJson, cwd)
+      debugDir('inspect', { detected })
+      const autoManifestResult = await generateAutoManifest({
+        computeArtifactsSidecar: reach.runReachabilityAnalysis,
+        cwd,
+        detected,
+        excludePaths: reach.excludePaths,
+        outputKind,
+        tmpDir: manifestTmpDir,
+        verbose: false,
+      })
+      resolvedPathsSidecar = autoManifestResult.resolvedPathsSidecar
+      if (autoManifestResult.generatedFiles.length) {
+        scanTargets = Array.from(
+          new Set([...targets, ...autoManifestResult.generatedFiles]),
+        )
+      }
+      logger.info('Auto-generation finished. Proceeding with Scan creation.')
     }
-    logger.info('Auto-generation finished. Proceeding with Scan creation.')
-  }
 
-  const { spinner } = constants
+    const { spinner } = constants
 
-  const supportedFilesCResult = await fetchSupportedScanFileNames({
-    orgSlug,
-    spinner,
-  })
-  if (!supportedFilesCResult.ok) {
-    debugFn('warn', 'Failed to fetch supported scan file names')
-    debugDir('inspect', { supportedFilesCResult })
-    await outputCreateNewScan(supportedFilesCResult, {
-      interactive,
-      outputKind,
-    })
-    return
-  }
-  debugFn(
-    'notice',
-    `Fetched ${supportedFilesCResult.data['size']} supported file types`,
-  )
-
-  spinner.start('Searching for local files to include in scan...')
-
-  const supportedFiles = supportedFilesCResult.data
-
-  // Load socket.yml to respect projectIgnorePaths when collecting files.
-  const socketYmlResult = findSocketYmlSync(cwd)
-  const socketConfig = socketYmlResult.ok
-    ? socketYmlResult.data?.parsed
-    : undefined
-
-  const { additionalScaIgnores, mergedReachabilityOptions } =
-    applyFullExcludePaths({
-      cwd,
-      reachabilityOptions: reach,
-      target: targets[0]!,
-    })
-
-  const packagePaths = await getPackageFilesForScan(
-    scanTargets,
-    supportedFiles,
-    {
-      additionalIgnores: additionalScaIgnores,
-      config: socketConfig,
-      cwd,
-    },
-  )
-
-  spinner.successAndStop(
-    `Found ${packagePaths.length} ${pluralize('file', packagePaths.length)} to include in scan.`,
-  )
-
-  const wasValidInput = checkCommandInput(outputKind, {
-    nook: true,
-    test: packagePaths.length > 0,
-    fail: `found no eligible files to scan. See supported manifest files at ${socketDocsLink('/docs/manifest-file-detection-in-socket', 'docs.socket.dev')}`,
-    message:
-      'TARGET (file/dir) must contain matching / supported file types for a scan',
-  })
-  if (!wasValidInput) {
-    debugFn('warn', 'No eligible files found to scan')
-    return
-  }
-
-  logger.success(
-    `Found ${packagePaths.length} local ${pluralize('file', packagePaths.length)}`,
-  )
-
-  debugDir('inspect', { packagePaths })
-
-  if (readOnly) {
-    logger.log('[ReadOnly] Bailing now')
-    debugFn('notice', 'Read-only mode, exiting early')
-    return
-  }
-
-  let scanPaths: string[] = packagePaths
-  let tier1ReachabilityScanId: string | undefined
-  let reachabilityReport: string | undefined
-
-  // If reachability is enabled, perform reachability analysis.
-  if (reach.runReachabilityAnalysis) {
-    logger.error('')
-    logger.info('Starting reachability analysis...')
-    debugFn('notice', 'Reachability analysis enabled')
-    debugDir('inspect', { reachabilityOptions: mergedReachabilityOptions })
-
-    spinner.start()
-
-    const reachResult = await performReachabilityAnalysis({
-      branchName,
-      cwd,
+    const supportedFilesCResult = await fetchSupportedScanFileNames({
       orgSlug,
-      outputKind,
-      packagePaths,
-      reachabilityOptions: mergedReachabilityOptions,
-      repoName,
-      resolvedPathsSidecar,
       spinner,
-      target: targets[0]!,
     })
+    if (!supportedFilesCResult.ok) {
+      debugFn('warn', 'Failed to fetch supported scan file names')
+      debugDir('inspect', { supportedFilesCResult })
+      await outputCreateNewScan(supportedFilesCResult, {
+        interactive,
+        outputKind,
+      })
+      return
+    }
+    debugFn(
+      'notice',
+      `Fetched ${supportedFilesCResult.data['size']} supported file types`,
+    )
 
-    spinner.stop()
+    spinner.start('Searching for local files to include in scan...')
 
-    if (!reachResult.ok) {
-      await outputCreateNewScan(reachResult, { interactive, outputKind })
+    const supportedFiles = supportedFilesCResult.data
+
+    // Load socket.yml to respect projectIgnorePaths when collecting files.
+    const socketYmlResult = findSocketYmlSync(cwd)
+    const socketConfig = socketYmlResult.ok
+      ? socketYmlResult.data?.parsed
+      : undefined
+
+    const { additionalScaIgnores, mergedReachabilityOptions } =
+      applyFullExcludePaths({
+        cwd,
+        reachabilityOptions: reach,
+        target: targets[0]!,
+      })
+
+    const packagePaths = await getPackageFilesForScan(
+      scanTargets,
+      supportedFiles,
+      {
+        additionalIgnores: additionalScaIgnores,
+        config: socketConfig,
+        cwd,
+      },
+    )
+
+    spinner.successAndStop(
+      `Found ${packagePaths.length} ${pluralize('file', packagePaths.length)} to include in scan.`,
+    )
+
+    const wasValidInput = checkCommandInput(outputKind, {
+      nook: true,
+      test: packagePaths.length > 0,
+      fail: `found no eligible files to scan. See supported manifest files at ${socketDocsLink('/docs/manifest-file-detection-in-socket', 'docs.socket.dev')}`,
+      message:
+        'TARGET (file/dir) must contain matching / supported file types for a scan',
+    })
+    if (!wasValidInput) {
+      debugFn('warn', 'No eligible files found to scan')
       return
     }
 
-    logger.success('Reachability analysis completed successfully')
-
-    reachabilityReport = reachResult.data?.reachabilityReport
-
-    // When using only pre-generated SBOMs, build the scan from those inputs —
-    // CycloneDX, SPDX, and Socket facts (`.socket.facts.json`) — matching
-    // Coana's `--use-only-pregenerated-sboms` selection. Otherwise drop any
-    // stray `.socket.facts.json`; coana's fresh reachability report (appended
-    // below) is the authoritative facts file for the scan.
-    const pathsForScan = reach.reachUseOnlyPregeneratedSboms
-      ? filterToPregeneratedSboms(packagePaths, supportedFiles)
-      : packagePaths.filter(
-          p => path.basename(p) !== constants.DOT_SOCKET_DOT_FACTS_JSON,
-        )
-
-    // Append coana's reachability report, but not twice: a pre-generated facts
-    // input can resolve to the same path coana wrote its report to.
-    const reportPath = reachabilityReport
-      ? path.resolve(cwd, reachabilityReport)
-      : undefined
-    scanPaths = [
-      ...pathsForScan.filter(p => path.resolve(cwd, p) !== reportPath),
-      ...(reachabilityReport ? [reachabilityReport] : []),
-    ]
-
-    tier1ReachabilityScanId = reachResult.data?.tier1ReachabilityScanId
-  }
-
-  // Brotli-compress any .socket.facts.json paths in scanPaths just before
-  // upload. depscan's api-v0 multipart boundary streams brotli decode based
-  // on the .br filename suffix. Coana keeps writing plain .socket.facts.json
-  // on disk, so the local read paths (extractTier1ReachabilityScanId,
-  // extractReachabilityErrors) stay correct. The cleanup() in the finally
-  // block removes the temp dirs whether the upload succeeded or threw.
-  const compressed = await compressSocketFactsForUpload(scanPaths)
-  let fullScanCResult: Awaited<ReturnType<typeof fetchCreateOrgFullScan>>
-  try {
-    fullScanCResult = await fetchCreateOrgFullScan(
-      compressed.paths,
-      orgSlug,
-      {
-        commitHash,
-        commitMessage,
-        committers,
-        pullRequest,
-        repoName,
-        branchName,
-        scanType: reach.runReachabilityAnalysis
-          ? constants.SCAN_TYPE_SOCKET_TIER1
-          : constants.SCAN_TYPE_SOCKET,
-        workspace,
-      },
-      {
-        cwd,
-        defaultBranch,
-        pendingHead,
-        tmp,
-      },
+    logger.success(
+      `Found ${packagePaths.length} local ${pluralize('file', packagePaths.length)}`,
     )
-  } finally {
-    await compressed.cleanup()
-  }
 
-  const scanId = fullScanCResult.ok ? fullScanCResult.data?.id : undefined
+    debugDir('inspect', { packagePaths })
 
-  if (reach && scanId && tier1ReachabilityScanId) {
-    await finalizeTier1Scan(tier1ReachabilityScanId, scanId)
-  } else if (
-    reach.runReachabilityAnalysis &&
-    scanId &&
-    !tier1ReachabilityScanId
-  ) {
-    // Reachability analysis ran and a scan was created, but no full
-    // application reachability scan id was extracted from the facts file.
-    // Surface this instead of silently skipping finalize — otherwise the
-    // reachability row stays stuck (e.g. at COANA_DONE) and the full scan is
-    // never linked to its reachability report.
-    logger.warn(
-      'Reachability analysis ran but no full application reachability scan ID was found; skipping reachability finalize. The scan was created but its reachability report was not linked.',
-    )
-  }
-
-  // On a successful scan, clean up the `.socket.facts.json` coana wrote at
-  // the path we instructed it to write to (via `--socket-mode`). Failed
-  // scans leave the file in place for debugging. Producer-written files
-  // (e.g. from `socket manifest gradle --facts`) are NOT touched here —
-  // those are user-owned input that the user can clean up themselves; in
-  // the --reach path coana overwrites that file with its enriched output
-  // anyway, so it's the same path that gets removed. `--reach-retain-facts-file`
-  // opts out of this cleanup so the report can be inspected; the user is then
-  // responsible for deleting it before the next full application reachability
-  // scan (a stale file is picked up as pre-generated input and would make those
-  // results unreliable).
-  if (
-    fullScanCResult.ok &&
-    scanId &&
-    reachabilityReport &&
-    !reach.reachRetainFactsFile
-  ) {
-    try {
-      await unlink(path.resolve(cwd, reachabilityReport))
-      debugFn(
-        'notice',
-        `[socket-facts] removed coana output after successful scan: ${reachabilityReport}`,
-      )
-    } catch {
-      // Best-effort — file may already be gone or unwritable.
+    if (readOnly) {
+      logger.log('[ReadOnly] Bailing now')
+      debugFn('notice', 'Read-only mode, exiting early')
+      return
     }
-  }
 
-  if (report && fullScanCResult.ok) {
-    if (scanId) {
-      await handleScanReport({
-        filepath: '-',
-        fold: constants.FOLD_SETTING_VERSION,
-        includeLicensePolicy: true,
+    let scanPaths: string[] = packagePaths
+    let tier1ReachabilityScanId: string | undefined
+    let reachabilityReport: string | undefined
+
+    // If reachability is enabled, perform reachability analysis.
+    if (reach.runReachabilityAnalysis) {
+      logger.error('')
+      logger.info('Starting reachability analysis...')
+      debugFn('notice', 'Reachability analysis enabled')
+      debugDir('inspect', { reachabilityOptions: mergedReachabilityOptions })
+
+      spinner.start()
+
+      const reachResult = await performReachabilityAnalysis({
+        branchName,
+        cwd,
         orgSlug,
         outputKind,
-        reportLevel,
-        scanId,
-        short: false,
+        packagePaths,
+        reachabilityOptions: mergedReachabilityOptions,
+        repoName,
+        resolvedPathsSidecar,
+        spinner,
+        target: targets[0]!,
       })
-    } else {
-      await outputCreateNewScan(
+
+      spinner.stop()
+
+      if (!reachResult.ok) {
+        await outputCreateNewScan(reachResult, { interactive, outputKind })
+        return
+      }
+
+      logger.success('Reachability analysis completed successfully')
+
+      reachabilityReport = reachResult.data?.reachabilityReport
+
+      // When using only pre-generated SBOMs, build the scan from those inputs —
+      // CycloneDX, SPDX, and Socket facts (`.socket.facts.json`) — matching
+      // Coana's `--use-only-pregenerated-sboms` selection. Otherwise drop any
+      // stray `.socket.facts.json`; coana's fresh reachability report (appended
+      // below) is the authoritative facts file for the scan.
+      const pathsForScan = reach.reachUseOnlyPregeneratedSboms
+        ? filterToPregeneratedSboms(packagePaths, supportedFiles)
+        : packagePaths.filter(
+            p => path.basename(p) !== constants.DOT_SOCKET_DOT_FACTS_JSON,
+          )
+
+      // Append coana's reachability report, but not twice: a pre-generated facts
+      // input can resolve to the same path coana wrote its report to.
+      const reportPath = reachabilityReport
+        ? path.resolve(cwd, reachabilityReport)
+        : undefined
+      scanPaths = [
+        ...pathsForScan.filter(p => path.resolve(cwd, p) !== reportPath),
+        ...(reachabilityReport ? [reachabilityReport] : []),
+      ]
+
+      tier1ReachabilityScanId = reachResult.data?.tier1ReachabilityScanId
+    }
+
+    // Brotli-compress any .socket.facts.json paths in scanPaths just before
+    // upload. depscan's api-v0 multipart boundary streams brotli decode based
+    // on the .br filename suffix. Coana keeps writing plain .socket.facts.json
+    // on disk, so the local read paths (extractTier1ReachabilityScanId,
+    // extractReachabilityErrors) stay correct. The cleanup() in the finally
+    // block removes the temp dirs whether the upload succeeded or threw.
+    const compressed = await compressSocketFactsForUpload(scanPaths)
+    let fullScanCResult: Awaited<ReturnType<typeof fetchCreateOrgFullScan>>
+    try {
+      fullScanCResult = await fetchCreateOrgFullScan(
+        compressed.paths,
+        orgSlug,
         {
-          ok: false,
-          message: 'Missing Scan ID',
-          cause: 'Server did not respond with a scan ID',
-          data: fullScanCResult.data,
+          commitHash,
+          commitMessage,
+          committers,
+          pullRequest,
+          repoName,
+          branchName,
+          scanType: reach.runReachabilityAnalysis
+            ? constants.SCAN_TYPE_SOCKET_TIER1
+            : constants.SCAN_TYPE_SOCKET,
+          workspace,
         },
         {
-          interactive,
-          outputKind,
+          cwd,
+          defaultBranch,
+          pendingHead,
+          tmp,
         },
       )
+    } finally {
+      await compressed.cleanup()
     }
-  } else {
-    spinner.stop()
 
-    await outputCreateNewScan(fullScanCResult, { interactive, outputKind })
-  }
+    const scanId = fullScanCResult.ok ? fullScanCResult.data?.id : undefined
+
+    if (reach && scanId && tier1ReachabilityScanId) {
+      await finalizeTier1Scan(tier1ReachabilityScanId, scanId)
+    } else if (
+      reach.runReachabilityAnalysis &&
+      scanId &&
+      !tier1ReachabilityScanId
+    ) {
+      // Reachability analysis ran and a scan was created, but no full
+      // application reachability scan id was extracted from the facts file.
+      // Surface this instead of silently skipping finalize — otherwise the
+      // reachability row stays stuck (e.g. at COANA_DONE) and the full scan is
+      // never linked to its reachability report.
+      logger.warn(
+        'Reachability analysis ran but no full application reachability scan ID was found; skipping reachability finalize. The scan was created but its reachability report was not linked.',
+      )
+    }
+
+    // On a successful scan, clean up the `.socket.facts.json` coana wrote at
+    // the path we instructed it to write to (via `--socket-mode`). Failed
+    // scans leave the file in place for debugging. Producer-written files
+    // (e.g. from `socket manifest gradle --facts`) are NOT touched here —
+    // those are user-owned input that the user can clean up themselves; in
+    // the --reach path coana overwrites that file with its enriched output
+    // anyway, so it's the same path that gets removed. `--reach-retain-facts-file`
+    // opts out of this cleanup so the report can be inspected; the user is then
+    // responsible for deleting it before the next full application reachability
+    // scan (a stale file is picked up as pre-generated input and would make those
+    // results unreliable).
+    if (
+      fullScanCResult.ok &&
+      scanId &&
+      reachabilityReport &&
+      !reach.reachRetainFactsFile
+    ) {
+      try {
+        await unlink(path.resolve(cwd, reachabilityReport))
+        debugFn(
+          'notice',
+          `[socket-facts] removed coana output after successful scan: ${reachabilityReport}`,
+        )
+      } catch {
+        // Best-effort — file may already be gone or unwritable.
+      }
+    }
+
+    if (report && fullScanCResult.ok) {
+      if (scanId) {
+        await handleScanReport({
+          filepath: '-',
+          fold: constants.FOLD_SETTING_VERSION,
+          includeLicensePolicy: true,
+          orgSlug,
+          outputKind,
+          reportLevel,
+          scanId,
+          short: false,
+        })
+      } else {
+        await outputCreateNewScan(
+          {
+            ok: false,
+            message: 'Missing Scan ID',
+            cause: 'Server did not respond with a scan ID',
+            data: fullScanCResult.data,
+          },
+          {
+            interactive,
+            outputKind,
+          },
+        )
+      }
+    } else {
+      spinner.stop()
+
+      await outputCreateNewScan(fullScanCResult, { interactive, outputKind })
+    }
+  })
 }

--- a/src/utils/fs.mts
+++ b/src/utils/fs.mts
@@ -18,6 +18,7 @@
  */
 
 import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 import constants from '../constants.mts'
@@ -65,4 +66,16 @@ export async function findUp(
     dir = path.dirname(dir)
   }
   return undefined
+}
+
+export async function withTmpDir<T>(
+  prefix: string,
+  fn: (tmpDir: string) => Promise<T>,
+): Promise<T> {
+  const tmpDir = await fs.mkdtemp(path.join(tmpdir(), prefix))
+  try {
+    return await fn(tmpDir)
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+  }
 }


### PR DESCRIPTION
## Summary
- Fixes `socket scan create --auto-manifest --reach` on sbt/Scala projects sometimes failing reachability analysis because the resolved-paths sidecar pointed at `scala-compiler`/`scala-library`/`scala-reflect` jars that had already been deleted.
- Root cause: the sbt facts producer runs sbt with an isolated per-run global base (for `plugins/` isolation), which is also where sbt provisions the project's Scala toolchain (`<global base>/boot`). That directory was deleted immediately after the facts run, before a later `coana run` could read the sidecar paths pointing into it.
- Fix: the caller now owns the temp directory's lifetime. `withTmpDir` moved to `src/utils/fs.mts` (shared), and `tmpDir` is threaded as a required parameter through `generateAutoManifest` → `convertSbtToFacts` → `runManifestFacts` → `runManifestScript` → `runSbt`, so it isn't deleted until after reachability analysis has consumed the sidecar. All three callers (`socket scan create`, `socket manifest auto`, `socket manifest scala --facts`) now allocate their own tmp dir uniformly via `withTmpDir`, rather than some paths conditionally opting in.

Linear: REA-688

## Test plan
- [x] `pnpm check:tsc` / `pnpm check:lint` clean
- [x] `pnpm build` succeeds
- [x] Relevant unit tests pass (`generate_auto_manifest`, `handle-create-new-scan`, `cmd-manifest-scala`, `cmd-manifest-auto`)
- [x] Verified live against a real sbt/Scala project with `socket scan create --auto-manifest --reach` (local Coana build) — reachability analysis no longer fails to resolve the Scala standard library

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes temp-directory lifetime on the scan-create and reachability path for sbt; mis-timed cleanup could still break sidecar resolution, but the change is narrowly scoped to sbt global-base handling.
> 
> **Overview**
> Fixes **`socket scan create --auto-manifest --reach`** on sbt/Scala projects where reachability could fail because resolved-path sidecar entries pointed at **`scala-library` / compiler jars** under sbt’s isolated global base that had already been deleted.
> 
> **Lifetime change:** callers now own a shared temp directory via **`withTmpDir`** (moved to `fs.mts`). That directory is passed as **`tmpDir`** through auto-manifest / sbt facts generation into **`runSbt`**, which uses it as **`sbt.global.base`** (where the Scala toolchain is provisioned under `boot`). For scan create, the temp dir wraps the whole flow—auto-manifest, reachability, and upload—so toolchain paths stay valid until Coana consumes the sidecar. Standalone **`socket manifest auto`** and **`socket manifest scala --facts`** allocate their own tmp dir the same way; when no caller **`tmpDir`** is passed, sbt facts still use a short-lived ephemeral dir (facts-only, no reach sidecar).
> 
> Release **1.1.151** with changelog note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54a0e555aab18a88758925b7bf11563f9c6bd8af. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->