### PR TITLE
chore(release): 1.1.150

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [1.1.150](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.150) - 2026-07-31
 
 ### Changed
 - Updated the Coana CLI to v `15.9.9`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.150-prerelease",
+  "version": "1.1.150",
   "description": "CLI for Socket.dev",
   "homepage": "https://github.com/SocketDev/socket-cli",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Strip the `1.1.150-prerelease` version hint so `package.json` carries a bare, releasable version.
- Promote the CHANGELOG's `[Unreleased]` section to `## [1.1.150] - 2026-07-31`.

## Release steps
1. Merge this PR into `v1.x`.
2. Dispatch `npm-publish.yml` with `dry-run: false` against the `v1.x` tip (pick a non-`latest` dist-tag, e.g. `next` or `backport` — `latest` is guarded to `main` only).
3. Once published, open a follow-up PR bumping `package.json` to `1.1.151-prerelease` and adding a fresh empty `[Unreleased]` section.

## Test plan
- [ ] `pnpm check` passes
- [ ] Confirm `v1.x` tip carries a bare version before dispatching the publish workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only version and changelog edits; no source or dependency changes in this PR.
> 
> **Overview**
> **Release 1.1.150** — metadata-only changes to ship the version already documented under `[Unreleased]`.
> 
> `package.json` version moves from `1.1.150-prerelease` to **`1.1.150`** so npm publish can target a stable release. The changelog **`[Unreleased]`** section is renamed to **`[1.1.150]`** with date **2026-07-31** and a release tag link; the listed **Changed** and **Fixed** bullets are unchanged (Coana 15.9.9, `socket scan view` cached results, `socket fix` vulnerability discovery and error handling, sbt/Scala reachability).
> 
> No runtime or CLI behavior changes in this diff—follow-up after merge is bumping to `1.1.151-prerelease` and restoring an empty `[Unreleased]` section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f8cd6ea5d57cee4b558b0266f6a9fad5b3ef9a7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->