### PR TITLE
fix(manifest): keep the Maven extension build out of the developer's home directory

### DIFF
--- a/packages/cli/src/commands/manifest/scripts/maven-extension/build-jar.sh
+++ b/packages/cli/src/commands/manifest/scripts/maven-extension/build-jar.sh
@@ -5,6 +5,22 @@
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-( cd "$here" && ./mvnw -q --batch-mode package )
+
+# Keep the downloaded artifacts and the Maven distribution out of the developer's ~/.m2. The path is
+# stable so the plugin closure stays cached between runs; point SOCKET_CLI_MAVEN_HOME elsewhere for a
+# cold build.
+tmp_root="${TMPDIR:-/tmp}"
+maven_home="${SOCKET_CLI_MAVEN_HOME:-${tmp_root%/}/socket-cli-maven-home}"
+mkdir -p "$maven_home"
+# Absolute, because the Maven invocation below runs after a cd into the extension directory: a
+# relative SOCKET_CLI_MAVEN_HOME or TMPDIR would otherwise create one tree here and write another
+# under the extension directory.
+maven_home="$(cd "$maven_home" && pwd)"
+
+(
+  cd "$here"
+  MAVEN_USER_HOME="$maven_home" ./mvnw -q --batch-mode \
+    -Dmaven.repo.local="$maven_home/repository" package
+)
 cp -f "$here/target/coana-maven-extension.jar" "$here/coana-maven-extension.jar"
 echo "Coana Maven extension jar: $here/coana-maven-extension.jar"

--- a/packages/cli/test/unit/scripts/maven-extension-build-jar.test.mts
+++ b/packages/cli/test/unit/scripts/maven-extension-build-jar.test.mts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the Maven extension build script's cache-root resolution.
+ *
+ * Purpose: build-jar.sh creates the Maven home up front, then runs Maven from
+ * inside the extension directory. Those two steps must agree on which
+ * directory they mean, so the resolved home has to be absolute before the cd.
+ *
+ * Related Files:
+ * - src/commands/manifest/scripts/maven-extension/build-jar.sh (implementation)
+ */
+
+import {
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { safeDelete } from '@socketsecurity/lib-stable/fs/safe'
+import { spawn } from '@socketsecurity/lib-stable/process/spawn/child'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+const BUILD_JAR_PATH = path.join(
+  __dirname,
+  '../../../src/commands/manifest/scripts/maven-extension/build-jar.sh',
+)
+
+/**
+ * The script's leading cache-root resolution, up to the subshell that invokes
+ * Maven. Running just this part exercises the shipped lines without needing a
+ * JDK, the Maven wrapper, or the network.
+ */
+function readResolutionPrelude(): string {
+  const lines = readFileSync(BUILD_JAR_PATH, 'utf8').split('\n')
+  const subshellAt = lines.indexOf('(')
+  if (subshellAt === -1) {
+    throw new Error('build-jar.sh no longer opens a subshell with a bare "("')
+  }
+  return lines.slice(0, subshellAt).join('\n')
+}
+
+/**
+ * Run the prelude with `cwd` as the working directory and report the
+ * `maven_home` it settled on.
+ */
+async function resolveMavenHome(
+  cwd: string,
+  env: Record<string, string | undefined>,
+): Promise<string> {
+  const preludePath = path.join(cwd, 'prelude.sh')
+  writeFileSync(
+    preludePath,
+    `${readResolutionPrelude()}\nprintf '%s\\n' "$maven_home"\n`,
+  )
+
+  const result = await spawn('bash', [preludePath], {
+    cwd,
+    env: { ...process.env, ...env },
+  })
+  return result.stdout.trim()
+}
+
+describe('maven-extension build-jar.sh cache root', () => {
+  let workDir: string
+
+  beforeEach(() => {
+    workDir = realpathSync(
+      mkdtempSync(path.join(os.tmpdir(), 'build-jar-test-')),
+    )
+  })
+
+  afterEach(async () => {
+    await safeDelete(workDir)
+  })
+
+  it('anchors a relative SOCKET_CLI_MAVEN_HOME to the caller, not the extension directory', async () => {
+    const mavenHome = await resolveMavenHome(workDir, {
+      SOCKET_CLI_MAVEN_HOME: 'relative/maven-home',
+    })
+
+    // Absolute, so the cd into the extension directory cannot re-anchor it.
+    expect(path.isAbsolute(mavenHome)).toBe(true)
+    expect(realpathSync(mavenHome)).toBe(
+      path.join(workDir, 'relative/maven-home'),
+    )
+    // The directory the script created is the one Maven will be pointed at.
+    expect(statSync(mavenHome).isDirectory()).toBe(true)
+  })
+
+  it('anchors a relative TMPDIR to the caller', async () => {
+    const mavenHome = await resolveMavenHome(workDir, {
+      SOCKET_CLI_MAVEN_HOME: undefined,
+      TMPDIR: 'relative-tmp',
+    })
+
+    expect(path.isAbsolute(mavenHome)).toBe(true)
+    expect(realpathSync(mavenHome)).toBe(
+      path.join(workDir, 'relative-tmp/socket-cli-maven-home'),
+    )
+  })
+
+  it('leaves an absolute SOCKET_CLI_MAVEN_HOME alone', async () => {
+    const absoluteHome = path.join(workDir, 'absolute/maven-home')
+
+    const mavenHome = await resolveMavenHome(workDir, {
+      SOCKET_CLI_MAVEN_HOME: absoluteHome,
+    })
+
+    expect(realpathSync(mavenHome)).toBe(absoluteHome)
+  })
+})


### PR DESCRIPTION
Building the Coana Maven extension writes into your own home directory. `build-jar.sh` calls the bundled Maven wrapper with no repository override, so every run drops the plugin and dependency closure into `~/.m2/repository` and the wrapper's own downloaded Maven distribution into `~/.m2/wrapper/dists`. Run the script once and your personal Maven cache now holds artifacts you never asked for.

The bigger problem is reproducibility, not tidiness. When a build reads and writes a cache that lives in your home directory, it can quietly succeed because of something an unrelated project downloaded months ago. The same build on a clean machine, or in CI, does not have that cache and can fail for reasons nobody can reproduce locally.

This change points the build at a directory under the OS temp dir instead, so it stops touching your home Maven tree and always resolves from a cache it owns.

<details>

<summary><b>The change</b> — two overrides, because Maven splits the work between two programs</summary>

Setting one override alone leaves the other half still writing to the home directory:

| Override | What it moves | Which program reads it |
| --- | --- | --- |
| `-Dmaven.repo.local` | the downloaded artifacts (the local repository) | the `mvn` binary |
| `MAVEN_USER_HOME` | the wrapper's own Maven distribution | the `mvnw` shell script, not `mvn` |

Both now point inside a single directory under the OS temp root, and the Maven invocation runs in a subshell so the environment change does not leak into the rest of the script.

</details>

<details>

<summary><b>Why a stable path and not a fresh one each run</b> — a cold cache every time would make the build slow and network-dependent</summary>

A brand new temp directory per run is the most isolated option, but it throws away the cache every time. The extension build needs a full plugin closure, so every invocation would re-download it and the build would become slow and dependent on the network being up.

A stable path under the temp dir keeps the isolation while letting the cache stay warm between runs. Anyone who genuinely wants a cold build can set `SOCKET_CLI_MAVEN_HOME` to somewhere else.

</details>

<details>

<summary><b>How this was verified</b> — Maven's behaviour was measured before and after, not assumed</summary>

Maven's behaviour was checked directly before and after, by recording a timestamp and then listing files newer than it.

**Confirming the leak is real**, using a dependency version that was not already cached:

- Before the run, the version was absent from the local repository.
- After a run with no override, the jar, pom and checksums were present in the local repository, along with newly written parent and BOM metadata.

**Confirming the overrides work:**

- With `-Dmaven.repo.local` pointed at a temp directory, that directory received the full closure and the local repository under the home directory received zero new files.
- `MAVEN_USER_HOME` on its own does **not** move the artifact repository. The `mvn` binary ignores it, and the directory is never even created. It only moves the wrapper distribution, which is why the fix sets both.
- With `MAVEN_USER_HOME` pointed at a temp directory, the requested Maven distribution was unpacked there and the wrapper directory under the home directory was unchanged.

**Confirming the patched script end to end:**

- `build-jar.sh` ran to completion and produced `coana-maven-extension.jar`.
- The temp directory held the artifact repository and the wrapper distribution.
- Zero new files appeared anywhere under the home Maven directory.

</details>

<details>

<summary><b>Scope</b> — only the extension build; the JVM test fixtures are a separate PR</summary>

Only `build-jar.sh` changes. The Maven, Gradle and sbt compatibility fixtures under `scripts/test/` have the same class of problem and are being handled separately; they are untouched here.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script-only change for the CLI Maven extension jar; no runtime manifest or auth paths are touched.
> 
> **Overview**
> **`build-jar.sh`** no longer lets the bundled `mvnw` populate the developer’s **`~/.m2`**. The Maven invocation runs in a subshell with **`MAVEN_USER_HOME`** and **`-Dmaven.repo.local`** both aimed at a stable directory under the OS temp root (default **`socket-cli-maven-home`**), so wrapper distributions and dependency/plugin caches stay out of the home Maven tree while remaining warm across runs.
> 
> **`SOCKET_CLI_MAVEN_HOME`** overrides that base path when someone wants a cold or custom cache location. The jar copy step and output path are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e7512bfad3b974116a7f5df0858e98c15f47569. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
