### PR TITLE
ci(npm-publish): make v1.x own the latest dist-tag

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,8 +11,10 @@ name: Publish to npm registry
 #   3. Dispatch this workflow with dry-run=true (the default): the `verify`
 #      job builds, packs, and smoke-tests all three variants — uploads
 #      nothing, marks nothing, and needs no publish credential.
-#   4. Dispatch with dry-run=false + a NON-latest dist-tag (the guard below
-#      refuses `latest` off the default branch). `verify` runs again and
+#   4. Dispatch with dry-run=false + dist-tag=latest. This branch is the line
+#      customers consume, so it owns `latest`; the guard below refuses that
+#      tag from anywhere else, and the default branch (the 2.x prerelease
+#      line) publishes under next/beta/canary/rc. `verify` runs again and
 #      hands its three tarballs to `publish`, which cuts the v<X.Y.Z> tag +
 #      the immutable GitHub release — both belong to the `socket` package,
 #      exactly one of each per run — then STAGES those exact tarballs.
@@ -78,23 +80,33 @@ jobs:
       # npm trusted publishing authorizes on repository + workflow filename +
       # GitHub environment. It does NOT pin a branch. The `npm-publish`
       # environment's deployment-branch policy (main + v1.x) is the outer
-      # gate; this guard is the in-repo half: `latest` may only be published
-      # from the default branch, so a v1.x dispatch must pick an explicit
-      # non-latest dist-tag (next, beta, canary, backport, ...). Dry runs
-      # pass regardless of dist-tag — they upload nothing, and a
-      # default-input dry run (dist-tag defaults to latest) must stay green.
-      - name: Guard the latest dist-tag to the default branch
+      # gate; this guard is the in-repo half.
+      #
+      # `latest` is what an untagged install of the package resolves to, so it
+      # belongs to the line customers consume — and that is THIS branch. The
+      # default branch carries the 2.x PRERELEASE line and is refused `latest`
+      # by its own copy of this workflow, which reads the owning branch from
+      # `release.latestDistTagBranch` in .config/repo/socket-wheelhouse.json.
+      #
+      # This ran inverted until 2026-08-03, and the cost was visible on the
+      # package page: `socket@latest` sat on 1.1.147 for a week while 1.1.148
+      # through 1.1.152 — including a CVE bump — published under a `staged`
+      # side tag no untagged install resolves.
+      #
+      # Dry runs pass regardless of dist-tag: they upload nothing.
+      - name: Guard the latest dist-tag to the consumable release line
         if: ${{ inputs.dry-run == false && inputs.dist-tag == 'latest' }}
         env:
+          LATEST_BRANCH: v1.x
           REF: ${{ github.ref }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          if [ "$REF" != "refs/heads/$DEFAULT_BRANCH" ]; then
+          if [ "$REF" != "refs/heads/$LATEST_BRANCH" ]; then
             echo "Refusing to publish dist-tag 'latest' from $REF." >&2
-            echo "Only refs/heads/$DEFAULT_BRANCH may publish 'latest'." >&2
-            echo "Re-dispatch from the default branch, or pick a non-latest dist-tag." >&2
+            echo "Only refs/heads/$LATEST_BRANCH may publish 'latest' — it is the line customers consume." >&2
+            echo "Re-dispatch from $LATEST_BRANCH, or pick a prerelease dist-tag (next, beta, canary, rc)." >&2
             exit 1
           fi
+          echo "dist-tag 'latest' is allowed from $REF (consumable line: $LATEST_BRANCH)."
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 (2026-05-20)
         with:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -88,11 +88,6 @@ jobs:
       # by its own copy of this workflow, which reads the owning branch from
       # `release.latestDistTagBranch` in .config/repo/socket-wheelhouse.json.
       #
-      # This ran inverted until 2026-08-03, and the cost was visible on the
-      # package page: `socket@latest` sat on 1.1.147 for a week while 1.1.148
-      # through 1.1.152 — including a CVE bump — published under a `staged`
-      # side tag no untagged install resolves.
-      #
       # Dry runs pass regardless of dist-tag: they upload nothing.
       - name: Guard the latest dist-tag to the consumable release line
         if: ${{ inputs.dry-run == false && inputs.dist-tag == 'latest' }}


### PR DESCRIPTION
`v1.x` is the line customers consume, so it should own the `latest` dist-tag — the tag an untagged `npm install socket` resolves to. The guard ran the other way, refusing `latest` from this branch and reserving it for the default branch, which carries the 2.x prerelease line.

The cost was visible on the package page. `socket@latest` sat on 1.1.147 for a week while 1.1.148 through 1.1.152, including a commons-io CVE bump, published under a `staged` side tag that no untagged install ever resolves.

<details>
<summary><b>What changed</b></summary>

The guard now compares the dispatched ref against `v1.x` instead of the repo's default branch, and logs the allow case so a passing run says why. The file header's step 4 said to pick a NON-latest dist-tag; it now says `dist-tag=latest`. The `dist-tag` input already defaulted to `latest`, so that default becomes usable rather than something the guard immediately rejects.

Dry runs are unaffected — they pass regardless of dist-tag because they upload nothing.
</details>

<details>
<summary><b>The matching half on the default branch</b></summary>

Our shared publish-workflow template now guards `latest` to a *consumable release line* rather than to the default branch, and reads which branch that is from a `release.latestDistTagBranch` setting in this repo's own config. It defaults to the repo's default branch, so other repos sharing that template are unaffected. socket-cli declares `v1.x`.

That half is already on `main`. This PR is the other half.
</details>

**Already done manually:** `latest` was repointed to 1.1.152 and the `staged` tag removed, so `socket` now carries a single dist-tag. Without this PR the next v1.x release would recreate `staged` and still refuse to move `latest`.

**Ran:** `actionlint` clean on the edited workflow.
**Did not run:** no dispatch — the publish path is unchanged apart from which ref may request `latest`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which branch can publish npm's `latest` dist-tag—a customer-facing install resolution path—but only tightens alignment with the intended release line and does not alter build/publish mechanics beyond the ref check.
> 
> **Overview**
> Fixes the **npm publish guard** so **`dist-tag=latest`** is only allowed when the workflow runs from **`v1.x`**, not from the repo default branch. Untagged `npm install socket` resolves to `latest`, so the consumable 1.x line should own that tag; the previous rule blocked `v1.x` from publishing `latest` and left newer 1.x releases on side tags like `staged`.
> 
> The workflow header and step comments now describe this policy (2.x prerelease on default uses next/beta/canary/rc). The guard compares `github.ref` to **`refs/heads/v1.x`**, logs when `latest` is allowed, and **dry runs** still skip the check because nothing is uploaded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eb812804a4425c770963f2993a5eb3e9bf114f4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->