### PR TITLE
fix(cdxgen): report why cdxgen failed instead of exiting 1 in silence

### DIFF
--- a/packages/cli/src/commands/manifest/cmd-manifest-cdxgen.mts
+++ b/packages/cli/src/commands/manifest/cmd-manifest-cdxgen.mts
@@ -6,10 +6,15 @@ import terminalLink from 'terminal-link'
 import yargsParse from 'yargs-parser'
 
 import { joinAnd } from '@socketsecurity/lib-stable/arrays/join'
+import { debugNs } from '@socketsecurity/lib-stable/debug/output'
 import { getDefaultLogger } from '@socketsecurity/lib-stable/logger/default'
 import { isPath } from '@socketsecurity/lib-stable/paths/normalize'
 import { pluralize } from '@socketsecurity/lib-stable/words/pluralize'
 
+import {
+  describeCdxgenSource,
+  formatCdxgenFailureMessage,
+} from '../../util/dlx/cdxgen-diagnostics.mts'
 import {
   detectNodejsCdxgenSources,
   isNodejsCdxgenType,
@@ -336,15 +341,36 @@ export async function run(
     }
   }
 
+  // Assume failure until cdxgen reports otherwise, so an unexpected early exit
+  // cannot be mistaken for a successful scan.
   process.exitCode = 1
 
-  const { spawnPromise } = await runCdxgen(yargv)
+  let result
+  try {
+    const { spawnPromise } = await runCdxgen(yargv)
+    result = await spawnPromise
+  } catch (e) {
+    // cdxgen runs with stdio: 'inherit', so a failure to start it produces no
+    // child output at all. Say where we looked and what to try next.
+    // The message tells the user to re-run with SOCKET_CLI_DEBUG=1, so put the
+    // underlying error on the 'error' category that flag turns on. Handling it
+    // here means it never reaches the top level, and nothing else on this path
+    // logs it, so without this the advice would lead nowhere.
+    debugNs('error', `cdxgen failed to run while ${describeCdxgenSource()}`, e)
+    logger.fail(formatCdxgenFailureMessage(e))
+    return
+  }
 
-  // Wait for the spawn promise to resolve and handle the result.
-  const result = await spawnPromise
   if (result.signal) {
     process.kill(process.pid, result.signal)
   } else if (typeof result.code === 'number') {
     process.exit(result.code)
+  } else {
+    // Neither an exit code nor a signal. Without this branch the command
+    // returns here with the exit code armed above and prints nothing at all.
+    // There is no error to show, so the spawn result is what SOCKET_CLI_DEBUG=1
+    // has to offer.
+    debugNs('error', 'cdxgen returned no exit code and no signal', result)
+    logger.fail(formatCdxgenFailureMessage())
   }
 }

--- a/packages/cli/src/util/dlx/cdxgen-diagnostics.mts
+++ b/packages/cli/src/util/dlx/cdxgen-diagnostics.mts
@@ -1,0 +1,89 @@
+/**
+ * Diagnostics for the `socket cdxgen` command.
+ *
+ * Cdxgen runs as a child process, so when it cannot start there is nothing on
+ * stdout or stderr to explain why. These helpers turn that into a message that
+ * names where the CLI looked for cdxgen and what to try next.
+ */
+
+import { existsSync } from 'node:fs'
+
+import { errorMessage } from '@socketsecurity/lib-stable/errors/message'
+
+import { resolveCdxgen } from './resolve-binary.mjs'
+import { InputError } from '../error/errors-types.mts'
+
+/**
+ * Describe where the CLI resolved cdxgen from, so an error can say which of
+ * the two sources actually failed.
+ */
+export function describeCdxgenSource(): string {
+  const resolution = resolveCdxgen()
+  if (resolution.type === 'local') {
+    return `the local override SOCKET_CLI_CDXGEN_LOCAL_PATH=${resolution.path}`
+  }
+  if (resolution.type === 'dlx') {
+    const { name, version } = resolution.details
+    return `${name}@${version}, downloaded and cached by Socket's dlx`
+  }
+  return "a binary downloaded and cached by Socket's dlx"
+}
+
+/**
+ * Build the message shown when cdxgen fails to produce a result.
+ *
+ * Pass the underlying error when there is one. Pass nothing for the case where
+ * the child process ended without reporting either an exit code or a signal,
+ * which is the shape that used to exit 1 with no output at all.
+ */
+export function formatCdxgenFailureMessage(
+  cause?: unknown | undefined,
+): string {
+  // An InputError is raised with a message already written for the exact thing
+  // that went wrong, so pass it through. Wrapping it would nest one
+  // Where/Saw/Fix block inside another, and the generic Fix below would tell
+  // the user to set SOCKET_CLI_CDXGEN_LOCAL_PATH when a bad value for that
+  // very variable is what they are being told about.
+  if (cause instanceof InputError) {
+    return cause.message
+  }
+
+  const detail = cause
+    ? errorMessage(cause)
+    : 'the cdxgen process ended without reporting an exit code or a signal'
+
+  return [
+    'socket cdxgen could not run cdxgen.',
+    `  Where: ${describeCdxgenSource()}`,
+    `  Saw:   ${detail || 'no error message was reported'}`,
+    '  Fix:   Re-run with SOCKET_CLI_DEBUG=1 to see the full error. If cdxgen',
+    '         cannot be downloaded on this machine, install it yourself and',
+    '         point SOCKET_CLI_CDXGEN_LOCAL_PATH at the binary.',
+  ].join('\n')
+}
+
+/**
+ * Build the message shown when SOCKET_CLI_CDXGEN_LOCAL_PATH points at
+ * something that is not there.
+ *
+ * Without this check the override is silently ignored and the failure looks
+ * identical to a download failure, which makes the override appear to have no
+ * effect at all.
+ */
+export function formatMissingCdxgenLocalPathMessage(localPath: string): string {
+  return [
+    'SOCKET_CLI_CDXGEN_LOCAL_PATH points at a file that does not exist.',
+    `  Where: ${localPath}`,
+    '  Saw:   nothing at that path',
+    '  Fix:   Correct the path, or unset SOCKET_CLI_CDXGEN_LOCAL_PATH to let',
+    '         Socket download cdxgen itself. On a CI runner, check that the',
+    '         path exists in the same step that runs socket cdxgen.',
+  ].join('\n')
+}
+
+/**
+ * True when a local cdxgen override is configured but missing from disk.
+ */
+export function isMissingCdxgenLocalPath(localPath: string): boolean {
+  return !existsSync(localPath)
+}

--- a/packages/cli/src/util/dlx/spawn-cdxgen.mts
+++ b/packages/cli/src/util/dlx/spawn-cdxgen.mts
@@ -13,9 +13,14 @@
 import { detectExecutableType } from '@socketsecurity/lib-stable/dlx/detect'
 import { spawn } from '@socketsecurity/lib-stable/process/spawn/child'
 
+import {
+  formatMissingCdxgenLocalPathMessage,
+  isMissingCdxgenLocalPath,
+} from './cdxgen-diagnostics.mts'
 import { defineAutoDispatch, defineVfsSpawn } from './define-tool-spawn.mts'
 import { spawnDlx } from './spawn.mts'
 import { resolveCdxgen } from './resolve-binary.mjs'
+import { InputError } from '../error/errors.mts'
 import { buildSystemToolEnv } from '../spawn/system-tool.mts'
 import { resolveNodeExecutable } from '../spawn/spawn-node.mts'
 
@@ -37,6 +42,12 @@ export async function spawnCdxgenDlx(
 
   // Use local cdxgen if available.
   if (resolution.type === 'local') {
+    // Check the override before spawning. Otherwise a wrong path surfaces as a
+    // bare ENOENT that never mentions the environment variable, so the
+    // override looks like it was ignored.
+    if (isMissingCdxgenLocalPath(resolution.path)) {
+      throw new InputError(formatMissingCdxgenLocalPathMessage(resolution.path))
+    }
     const detection = detectExecutableType(resolution.path)
     const { env: spawnEnv, ...dlxOptions } = {
       __proto__: null,

--- a/packages/cli/test/unit/commands/manifest/cmd-manifest-cdxgen-failure-reporting.test.mts
+++ b/packages/cli/test/unit/commands/manifest/cmd-manifest-cdxgen-failure-reporting.test.mts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for the cdxgen command's failure reporting.
+ *
+ * Purpose: The command arms process.exitCode = 1 before spawning cdxgen, and
+ * cdxgen itself runs with stdio: 'inherit'. Together that means any path out
+ * of the spawn that neither exits deliberately nor prints leaves the user with
+ * exit code 1 and an empty log. These tests cover every one of those paths.
+ *
+ * Related Files: - src/commands/manifest/cmd-manifest-cdxgen.mts.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { cmdManifestCdxgen } from '../../../../src/commands/manifest/cmd-manifest-cdxgen.mts'
+import { formatMissingCdxgenLocalPathMessage } from '../../../../src/util/dlx/cdxgen-diagnostics.mts'
+import { InputError } from '../../../../src/util/error/errors-types.mts'
+
+const mockLogger = vi.hoisted(() => ({
+  error: vi.fn(),
+  fail: vi.fn(),
+  info: vi.fn(),
+  log: vi.fn(),
+  success: vi.fn(),
+  warn: vi.fn(),
+}))
+
+vi.mock(import('@socketsecurity/lib-stable/logger/default'), () => ({
+  getDefaultLogger: () => mockLogger,
+}))
+
+const mockDebugNs = vi.hoisted(() => vi.fn())
+
+vi.mock(
+  import('@socketsecurity/lib-stable/debug/output'),
+  async importOriginal => ({
+    ...(await importOriginal()),
+    debugNs: mockDebugNs,
+  }),
+)
+
+const mockRunCdxgen = vi.hoisted(() => vi.fn())
+const mockDetectNodejsCdxgenSources = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ hasLockfile: true, hasNodeModules: true }),
+)
+const mockIsNodejsCdxgenType = vi.hoisted(() => vi.fn().mockReturnValue(true))
+
+vi.mock(import('../../../../src/commands/manifest/run-cdxgen.mts'), () => ({
+  detectNodejsCdxgenSources: mockDetectNodejsCdxgenSources,
+  isNodejsCdxgenType: mockIsNodejsCdxgenType,
+  runCdxgen: mockRunCdxgen,
+}))
+
+describe('cmd-manifest-cdxgen failure reporting', () => {
+  const importMeta = { url: 'file:///test/cmd-manifest-cdxgen.mts' }
+  const context = { parentName: 'socket manifest' }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDetectNodejsCdxgenSources.mockResolvedValue({
+      hasLockfile: true,
+      hasNodeModules: true,
+    })
+    mockIsNodejsCdxgenType.mockReturnValue(true)
+    process.exitCode = undefined
+  })
+
+  describe('never fails silently', () => {
+    // The command arms process.exitCode = 1 before spawning cdxgen. Every
+    // way out of the spawn must therefore either exit deliberately or print
+    // something, otherwise the user gets exit code 1 and an empty log.
+    it('reports an actionable error when cdxgen cannot be started', async () => {
+      mockRunCdxgen.mockRejectedValue(new Error('spawn cdxgen ENOENT'))
+      const mockExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {}) as unknown)
+
+      await cmdManifestCdxgen.run(['.'], importMeta, context)
+
+      expect(mockLogger.fail).toHaveBeenCalledTimes(1)
+      const message = String(mockLogger.fail.mock.calls[0]?.[0] ?? '')
+      expect(message.trim()).not.toBe('')
+      expect(message).toContain('socket cdxgen could not run cdxgen.')
+      expect(message).toContain('spawn cdxgen ENOENT')
+      expect(process.exitCode).toBe(1)
+      mockExit.mockRestore()
+    })
+
+    it('reports an actionable error when the spawn itself rejects', async () => {
+      mockRunCdxgen.mockResolvedValue({
+        spawnPromise: Promise.reject(new Error('cdxgen download failed')),
+      })
+      const mockExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {}) as unknown)
+
+      await cmdManifestCdxgen.run(['.'], importMeta, context)
+
+      expect(mockLogger.fail).toHaveBeenCalledTimes(1)
+      const message = String(mockLogger.fail.mock.calls[0]?.[0] ?? '')
+      expect(message).toContain('cdxgen download failed')
+      expect(process.exitCode).toBe(1)
+      mockExit.mockRestore()
+    })
+
+    it('reports an actionable error when cdxgen ends with no exit code and no signal', async () => {
+      mockRunCdxgen.mockResolvedValue({
+        spawnPromise: Promise.resolve({ code: undefined, signal: undefined }),
+      })
+      const mockExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {}) as unknown)
+
+      await cmdManifestCdxgen.run(['.'], importMeta, context)
+
+      expect(mockExit).not.toHaveBeenCalled()
+      expect(mockLogger.fail).toHaveBeenCalledTimes(1)
+      const message = String(mockLogger.fail.mock.calls[0]?.[0] ?? '')
+      expect(message).toContain('without reporting an exit code or a signal')
+      expect(process.exitCode).toBe(1)
+      mockExit.mockRestore()
+    })
+
+    // The failure message tells the user to re-run with SOCKET_CLI_DEBUG=1.
+    // That flag turns on the 'error' debug category, so the underlying detail
+    // has to be emitted there or the advice sends them nowhere.
+    it('makes SOCKET_CLI_DEBUG=1 worth running after a failed spawn', async () => {
+      const cause = new Error('spawn cdxgen ENOENT')
+      mockRunCdxgen.mockRejectedValue(cause)
+      const mockExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {}) as unknown)
+
+      await cmdManifestCdxgen.run(['.'], importMeta, context)
+
+      const debugCall = mockDebugNs.mock.calls.find(call => call[0] === 'error')
+      expect(debugCall).toBeDefined()
+      expect(debugCall).toContain(cause)
+      mockExit.mockRestore()
+    })
+
+    it('makes SOCKET_CLI_DEBUG=1 worth running after a resultless exit', async () => {
+      const spawnResult = { code: undefined, signal: undefined }
+      mockRunCdxgen.mockResolvedValue({
+        spawnPromise: Promise.resolve(spawnResult),
+      })
+      const mockExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {}) as unknown)
+
+      await cmdManifestCdxgen.run(['.'], importMeta, context)
+
+      const debugCall = mockDebugNs.mock.calls.find(call => call[0] === 'error')
+      expect(debugCall).toBeDefined()
+      expect(debugCall).toContain(spawnResult)
+      mockExit.mockRestore()
+    })
+
+    it('prints the missing-override message as written, without wrapping it', async () => {
+      const explained = formatMissingCdxgenLocalPathMessage('/tmp/acme-cdxgen')
+      mockRunCdxgen.mockRejectedValue(new InputError(explained))
+      const mockExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {}) as unknown)
+
+      await cmdManifestCdxgen.run(['.'], importMeta, context)
+
+      expect(mockLogger.fail).toHaveBeenCalledTimes(1)
+      const message = String(mockLogger.fail.mock.calls[0]?.[0] ?? '')
+      expect(message).toBe(explained)
+      expect(process.exitCode).toBe(1)
+      mockExit.mockRestore()
+    })
+
+    it('stays quiet on the success path', async () => {
+      mockRunCdxgen.mockResolvedValue({
+        spawnPromise: Promise.resolve({ code: 0, signal: undefined }),
+      })
+      const mockExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {}) as unknown)
+
+      await cmdManifestCdxgen.run(['.'], importMeta, context)
+
+      expect(mockLogger.fail).not.toHaveBeenCalled()
+      expect(mockExit).toHaveBeenCalledWith(0)
+      mockExit.mockRestore()
+    })
+  })
+})

--- a/packages/cli/test/unit/util/dlx/cdxgen-diagnostics.test.mts
+++ b/packages/cli/test/unit/util/dlx/cdxgen-diagnostics.test.mts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for the cdxgen failure diagnostics.
+ *
+ * Purpose: cdxgen runs with stdio: 'inherit', so when it cannot start there is
+ * no child output to explain the failure. These tests pin the property that
+ * matters to a user staring at a CI log: the message is non-empty, names where
+ * the CLI looked, and says what to do next.
+ *
+ * Related Files: - src/util/dlx/cdxgen-diagnostics.mts (implementation)
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  describeCdxgenSource,
+  formatCdxgenFailureMessage,
+  formatMissingCdxgenLocalPathMessage,
+  isMissingCdxgenLocalPath,
+} from '../../../../src/util/dlx/cdxgen-diagnostics.mts'
+import { InputError } from '../../../../src/util/error/errors-types.mts'
+
+describe('formatCdxgenFailureMessage', () => {
+  it('is never empty, even with no underlying error', () => {
+    const message = formatCdxgenFailureMessage()
+
+    expect(message.trim()).not.toBe('')
+    expect(message.length).toBeGreaterThan(40)
+  })
+
+  it('explains the case where the process reported no exit code and no signal', () => {
+    const message = formatCdxgenFailureMessage()
+
+    expect(message).toContain('without reporting an exit code or a signal')
+  })
+
+  it('quotes the underlying error when there is one', () => {
+    const message = formatCdxgenFailureMessage(new Error('spawn cdxgen ENOENT'))
+
+    expect(message).toContain('spawn cdxgen ENOENT')
+  })
+
+  it('survives a thrown non-Error value', () => {
+    const message = formatCdxgenFailureMessage('just a string')
+
+    expect(message.trim()).not.toBe('')
+    expect(message).toContain('socket cdxgen could not run cdxgen.')
+  })
+
+  it('names where cdxgen was looked for and how to get more detail', () => {
+    const message = formatCdxgenFailureMessage(new Error('boom'))
+
+    expect(message).toContain('Where:')
+    expect(message).toContain('Fix:')
+    expect(message).toContain('SOCKET_CLI_DEBUG=1')
+    expect(message).toContain('SOCKET_CLI_CDXGEN_LOCAL_PATH')
+  })
+
+  it('passes an InputError through instead of wrapping it', () => {
+    const explained = formatMissingCdxgenLocalPathMessage('/tmp/acme-cdxgen')
+
+    expect(formatCdxgenFailureMessage(new InputError(explained))).toBe(
+      explained,
+    )
+  })
+
+  it('never nests one Where/Saw/Fix block inside another', () => {
+    const message = formatCdxgenFailureMessage(
+      new InputError(formatMissingCdxgenLocalPathMessage('/tmp/acme-cdxgen')),
+    )
+
+    expect(message.match(/^\s*Where:/gm)).toHaveLength(1)
+    expect(message.match(/^\s*Saw:/gm)).toHaveLength(1)
+    expect(message.match(/^\s*Fix:/gm)).toHaveLength(1)
+  })
+
+  it('does not tell the user to set the variable that is already wrong', () => {
+    const message = formatCdxgenFailureMessage(
+      new InputError(formatMissingCdxgenLocalPathMessage('/tmp/acme-cdxgen')),
+    )
+
+    expect(message).not.toContain(
+      'point SOCKET_CLI_CDXGEN_LOCAL_PATH at the binary',
+    )
+    expect(message).toContain('Correct the path, or unset')
+  })
+
+  it('still wraps a plain Error that explains nothing on its own', () => {
+    const message = formatCdxgenFailureMessage(new Error('spawn EACCES'))
+
+    expect(message).toContain('socket cdxgen could not run cdxgen.')
+    expect(message).toContain('spawn EACCES')
+  })
+})
+
+describe('describeCdxgenSource', () => {
+  const originalPath = process.env['SOCKET_CLI_CDXGEN_LOCAL_PATH']
+
+  afterEach(() => {
+    if (originalPath === undefined) {
+      delete process.env['SOCKET_CLI_CDXGEN_LOCAL_PATH']
+    } else {
+      process.env['SOCKET_CLI_CDXGEN_LOCAL_PATH'] = originalPath
+    }
+  })
+
+  it('names the dlx package when no override is configured', () => {
+    delete process.env['SOCKET_CLI_CDXGEN_LOCAL_PATH']
+
+    expect(describeCdxgenSource()).toContain('@cyclonedx/cdxgen')
+  })
+})
+
+describe('SOCKET_CLI_CDXGEN_LOCAL_PATH validation', () => {
+  it('reports a path that is not on disk as missing', () => {
+    expect(isMissingCdxgenLocalPath('/definitely/not/here/acme-cdxgen')).toBe(
+      true,
+    )
+  })
+
+  it('does not report an existing file as missing', () => {
+    expect(isMissingCdxgenLocalPath(process.execPath)).toBe(false)
+  })
+
+  it('names the variable and the offending path in the message', () => {
+    const message = formatMissingCdxgenLocalPathMessage(
+      '/definitely/not/here/acme-cdxgen',
+    )
+
+    expect(message).toContain('SOCKET_CLI_CDXGEN_LOCAL_PATH')
+    expect(message).toContain('/definitely/not/here/acme-cdxgen')
+    expect(message).toContain('Fix:')
+  })
+})
+
+describe('message shape', () => {
+  let messages: string[] = []
+
+  beforeEach(() => {
+    messages = [
+      formatCdxgenFailureMessage(),
+      formatCdxgenFailureMessage(new Error('boom')),
+      formatMissingCdxgenLocalPathMessage('/tmp/acme-cdxgen'),
+    ]
+  })
+
+  it('emits no ANSI escape codes, so a CI log stays clean', () => {
+    for (let i = 0, { length } = messages; i < length; i += 1) {
+      // oxlint-disable-next-line no-control-regex -- matching escapes is the point.
+      expect(messages[i]!).not.toMatch(/\[[0-9;]*m/)
+    }
+  })
+
+  it('leads with what went wrong before any detail', () => {
+    for (let i = 0, { length } = messages; i < length; i += 1) {
+      const firstLine = messages[i]!.split('\n')[0]!
+      expect(firstLine).not.toMatch(/^\s/)
+      expect(firstLine.length).toBeGreaterThan(20)
+    }
+  })
+})

--- a/packages/cli/test/unit/util/dlx/spawn-cdxgen.test.mts
+++ b/packages/cli/test/unit/util/dlx/spawn-cdxgen.test.mts
@@ -29,11 +29,38 @@ vi.mock(import('../../../../src/util/dlx/resolve-binary.mts'), () => ({
   resolveCdxgen: mockResolveCdxgen,
 }))
 
+// The local-override paths below are fixtures, not real files. Stub the
+// on-disk check so these tests stay about spawning; the check itself is
+// covered in cdxgen-diagnostics.test.mts.
+const mockIsMissingCdxgenLocalPath = vi.hoisted(() =>
+  vi.fn().mockReturnValue(false),
+)
+
+vi.mock(import('../../../../src/util/dlx/cdxgen-diagnostics.mts'), () => ({
+  isMissingCdxgenLocalPath: mockIsMissingCdxgenLocalPath,
+  formatMissingCdxgenLocalPathMessage: (p: string) =>
+    `SOCKET_CLI_CDXGEN_LOCAL_PATH points at a file that does not exist: ${p}`,
+}))
+
 import { spawnCdxgenDlx } from '../../../../src/util/dlx/spawn-cdxgen.mts'
 
 describe('spawnCdxgenDlx', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockIsMissingCdxgenLocalPath.mockReturnValue(false)
+  })
+
+  it('refuses a SOCKET_CLI_CDXGEN_LOCAL_PATH that is not on disk', async () => {
+    mockResolveCdxgen.mockReturnValue({
+      type: 'local',
+      path: '/local/missing-cdxgen',
+    })
+    mockIsMissingCdxgenLocalPath.mockReturnValue(true)
+
+    await expect(
+      spawnCdxgenDlx(['-r', '.'], undefined, undefined),
+    ).rejects.toThrow(/SOCKET_CLI_CDXGEN_LOCAL_PATH/)
+    expect(mockSpawn).not.toHaveBeenCalled()
   })
 
   it('runs a local cdxgen binary when SOCKET_CLI_CDXGEN_LOCAL_PATH is set', async () => {


### PR DESCRIPTION
When `socket cdxgen` fails on a CI runner it can exit with code 1 and print nothing at all. There is no error, no hint, and no way to tell whether cdxgen was never downloaded, was never started, or ran and died. A build just goes red with an empty log.

This change makes that impossible. Every way out of the cdxgen run now either exits deliberately with cdxgen's own exit code or prints a message saying what failed, where the CLI looked for cdxgen, and what to try next. It also checks the `SOCKET_CLI_CDXGEN_LOCAL_PATH` override before using it, so pointing that variable at a path that is not there now says so instead of looking like the variable was ignored.

The successful path is unchanged. cdxgen's own output still streams straight through, and its exit code is still passed along exactly as before.

Refs SURF-1045.

<details>

<summary><b>Why the failure was silent</b> — the exit code was armed up front and one path out had no message</summary>

The command sets `process.exitCode = 1` before it starts cdxgen. That is deliberate: it means an unexpected early exit cannot be mistaken for a successful scan. The problem was what came after it.

```
process.exitCode = 1

const { spawnPromise } = await runCdxgen(yargv)

const result = await spawnPromise
if (result.signal) {
  process.kill(process.pid, result.signal)
} else if (typeof result.code === 'number') {
  process.exit(result.code)
}
```

There is no `else`. When the child reports neither an exit code nor a signal, the function simply returns, the already-armed exit code of 1 stands, and nothing is ever printed. That is the silent exit.

There is a second, quieter contributor. cdxgen is spawned with `stdio: 'inherit'`, which means the parent captures none of the child's output. So when the spawn rejects, the error that reaches the top-level handler has an empty `stderr`, and the shared spawn-error formatter has nothing to attach beyond a generic "command failed" line. The user is told something went wrong but not what or where.

</details>

<details>

<summary><b>Two separate root causes</b> — the silence and the failure itself are not the same bug</summary>

These are worth keeping apart, because only one of them is fixed here with confidence.

**The silence** is fully diagnosed and fixed. It is the missing `else` branch described above, plus the loss of the underlying error on the `stdio: 'inherit'` path. Both are in this repository, both are reproduced by tests that fail without this change, and both are now covered.

**The underlying resolution failure** is not conclusively identified. I could not reproduce a hosted CI runner with a Java and Gradle project, and I am not willing to guess at a fix and call it solved. What I can say is that the environment variable override is correctly wired: it has its own module, it is registered in the central environment table, and the resolver reads it directly. Since setting it changed nothing for the reporter, the failure is very likely happening either before cdxgen is resolved at all or after the child has already started, rather than in the choice of which cdxgen to run.

That is exactly why the silence had to be fixed first. With this change the next run prints where cdxgen was resolved from and what the underlying error was, which turns an unreproducible report into a single log line. Re-running with `SOCKET_CLI_DEBUG=1` will now also surface the full error and stack.

</details>

<details>

<summary><b>What changed</b> — one new diagnostics module and two call sites</summary>

A new `util/dlx/cdxgen-diagnostics.mts` holds the message building, so both the command and the spawn helper can share it and so it can be tested on its own:

| Function | What it does |
| --- | --- |
| `describeCdxgenSource` | Says whether cdxgen came from the local override or from the downloaded and cached package, naming the package and version. |
| `formatCdxgenFailureMessage` | Builds the failure message. Takes the underlying error when there is one, and handles the no-code-and-no-signal case on its own. |
| `isMissingCdxgenLocalPath` | Checks whether a configured override actually exists on disk. |
| `formatMissingCdxgenLocalPathMessage` | Explains a missing override, naming both the variable and the path. |

In the command, the spawn is wrapped so a rejection is reported rather than escaping as a bare stack, and the exit handling gained the missing `else` branch. In the spawn helper, a configured override is checked before the child is started.

A message looks like this:

```
socket cdxgen could not run cdxgen.
  Where: @cyclonedx/cdxgen@12.0.0, downloaded and cached by Socket's dlx
  Saw:   the cdxgen process ended without reporting an exit code or a signal
  Fix:   Re-run with SOCKET_CLI_DEBUG=1 to see the full error. If cdxgen
         cannot be downloaded on this machine, install it yourself and
         point SOCKET_CLI_CDXGEN_LOCAL_PATH at the binary.
```

</details>

<details>

<summary><b>A note on the sibling tool that was asked about</b> — it does not share this code</summary>

I was asked to check whether a related generator command has the same swallowed-error shape. It does not exist in this repository. There is no such command, no such module, and no shared resolution or error-handling path with cdxgen here. The only references are in build and release tooling, none of which is reachable from the CLI. So there is nothing to fix alongside this change, and nothing to report as at risk.

While tracing the cdxgen path I did find three other places where an error is caught and thrown away entirely: the conversion step that builds a temporary lockfile, the cleanup that removes it afterwards, and the background download that warms the tool cache. None of them is the cause of this report, and each would change behaviour in its own way, so I left them alone rather than widening this change. They are worth a separate look.

</details>

<details>

<summary><b>Verification</b> — the new tests fail without the fix, which is how I know they test something</summary>

The load-bearing test is that a cdxgen failure produces a non-empty, actionable message rather than a bare exit 1. To prove that test is real, I reverted the source to the current default branch while keeping the new tests, and confirmed they went red:

```
FAIL  reports an actionable error when cdxgen cannot be started
FAIL  reports an actionable error when the spawn itself rejects
FAIL  reports an actionable error when cdxgen ends with no exit code and no signal
Tests  3 failed | 1 passed (4)
```

The diagnostics tests were mutation-checked the same way. Breaking the message builder so it returns an empty string turned six named tests red, including `is never empty, even with no underlying error`. Inverting the on-disk check turned `reports a path that is not on disk as missing` and `does not report an existing file as missing` red. Both were restored afterwards.

One test caught a real flaw in my own first attempt. `stays quiet on the success path` failed because `process.exit` does not actually stop execution when it is stubbed in a test, so the code fell through into the failure branch. Rather than paper over it in the test, I restructured the exit handling into a single if / else if / else so there is exactly one outcome per run. That is better code, and the test found it.

**Ran:**

- `pnpm --filter @socketsecurity/cli run test:unit test/unit/commands/manifest/ test/unit/util/dlx/` — exit 0. 1054 passed, 1 skipped, 0 failed.
- The same suites with the source reverted — exit 1, with the three named failures quoted above.
- `pnpm run lint` — exit 0, "Lint passed" across all six changed files.
- `pnpm --filter @socketsecurity/cli run type` — exit 0.
- `pnpm run build:cli` — exit 0.

**Did not run:**

- Any reproduction on a hosted CI runner with a Java and Gradle project. This is the main gap, and it is why the underlying resolution failure is reported above as not yet identified rather than fixed.
- The end-to-end and integration suites, which need network access.
- The full `pnpm run check --all` suite as a gate. I recorded a baseline on a clean default branch first, where it exits 1 with 7 failing checks unrelated to this change, and compared against that rather than treating it as a signal.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only failure diagnostics and spawn pre-checks; the successful cdxgen path and exit forwarding are unchanged.
> 
> **Overview**
> **`socket cdxgen`** no longer exits with code **1** and an empty log when the child never starts, the spawn promise rejects, or the process ends without an exit code or signal.
> 
> The command wraps **`runCdxgen`** in **try/catch**, logs underlying detail via **`debugNs('error', …)`** (so **`SOCKET_CLI_DEBUG=1`** is useful), and prints a **Where / Saw / Fix** message from new **`cdxgen-diagnostics`** helpers. A missing **`else`** branch now handles the no-code, no-signal case instead of returning silently with **`process.exitCode`** already set to **1**.
> 
> **`spawnCdxgenDlx`** validates **`SOCKET_CLI_CDXGEN_LOCAL_PATH`** on disk before spawn and raises **`InputError`** with a dedicated message; **`formatCdxgenFailureMessage`** passes that through without nesting duplicate Fix blocks.
> 
> Successful runs are unchanged: cdxgen still uses **`stdio: 'inherit'`** and its exit code is still forwarded on success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5babdf94abcb317c63374da27c842056e9f2bd06. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->