### PR TITLE
refactor(github): retry GitHub requests through the fleet's shared pRetry

### DIFF
--- a/src/utils/github-errors.mts
+++ b/src/utils/github-errors.mts
@@ -12,12 +12,17 @@
  * - Classifying a GitHub response as a blocking error (rate limit / abuse
  *   detection / auth) with a clear, actionable message.
  * - A bounded-retry request wrapper that respects `Retry-After` /
- *   `x-ratelimit-reset` for short reset windows and retries transient 5xx /
- *   network failures with capped exponential backoff.
+ *   `x-ratelimit-reset` for short reset windows and hands transient 5xx /
+ *   network failures to the fleet's shared `pRetry` for backoff.
  */
 
+import process from 'node:process'
+import { setTimeout as sleep } from 'node:timers/promises'
+
 import { debugFn } from '@socketsecurity/registry/lib/debug'
+import { envAsNumber } from '@socketsecurity/registry/lib/env'
 import { logger } from '@socketsecurity/registry/lib/logger'
+import { pRetry } from '@socketsecurity/registry/lib/promises'
 
 import { apiFetch } from './api.mts'
 import { debugApiRequest, debugApiResponse } from './debug.mts'
@@ -35,12 +40,12 @@ import type { CResult } from '../types.mts'
 // constant for it in constants.mts, so define it locally.
 const HTTP_STATUS_TOO_MANY_REQUESTS = 429
 
-// Retry at most this many times for transient (5xx / network) failures,
-// counting the initial attempt.
-const MAX_TRANSIENT_ATTEMPTS = 3
-
-// Cap for exponential backoff between transient retries.
-const MAX_BACKOFF_MS = 10_000
+// Base delay before the first transient retry. Mirrors the default in
+// @socketsecurity/lib's releases/github-retry-config, including the env var
+// name, so both socket-cli lines back off against the GitHub API on the same
+// schedule. Read live rather than captured at import so a test or a CI job can
+// set it to 0 and skip the real wallclock wait.
+const DEFAULT_RETRY_BASE_DELAY_MS = 5000
 
 // Only wait-and-retry a rate-limited response when the reset window is at
 // most this many seconds. The usual primary-limit reset is up to an hour
@@ -167,14 +172,43 @@ export function classifyGitHubResponse(
   return undefined
 }
 
-function backoffMs(attempt: number): number {
-  return Math.min(1000 * 2 ** (attempt - 1), MAX_BACKOFF_MS)
+/**
+ * Retry policy for transient GitHub failures. Same values as the shared
+ * GITHUB_RETRY_CONFIG in @socketsecurity/lib: two retries on top of the initial
+ * attempt, delay doubling each time, capped at 10 seconds. Built per call
+ * rather than at import so the env override is read live.
+ */
+function githubRetryOptions(): {
+  backoffFactor: number
+  baseDelayMs: number
+  maxDelayMs: number
+  retries: number
+} {
+  return {
+    backoffFactor: 2,
+    baseDelayMs: envAsNumber(
+      process.env['SOCKET_GITHUB_RETRY_BASE_DELAY_MS'],
+      DEFAULT_RETRY_BASE_DELAY_MS,
+    ),
+    maxDelayMs: 10_000,
+    retries: 2,
+  }
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => {
-    setTimeout(resolve, ms)
-  })
+/**
+ * Thrown by one request attempt to tell `pRetry` what happened. `retryable`
+ * false means another attempt cannot help, so the retry loop stops early
+ * instead of burning its budget. The CResult is what the caller sees.
+ */
+class GitHubRequestFailure extends Error {
+  result: CResult<never>
+  retryable: boolean
+  constructor(result: CResult<never>, retryable: boolean) {
+    super(result.message)
+    this.name = 'GitHubRequestFailure'
+    this.result = result
+    this.retryable = retryable
+  }
 }
 
 /**
@@ -192,7 +226,8 @@ function sleep(ms: number): Promise<void> {
  *   short (<= CHEAP_RATE_LIMIT_WAIT_MAX_SECONDS); otherwise surface the error
  *   immediately. Long primary-limit resets are not worth blocking on.
  * - Auth: never retried.
- * - 5xx / network: capped exponential backoff, MAX_TRANSIENT_ATTEMPTS total.
+ * - 5xx / network: handed to the fleet's shared `pRetry` for exponential
+ *   backoff, on the policy in `githubRetryOptions`.
  */
 export async function githubApiRequest(
   url: string,
@@ -205,31 +240,42 @@ export async function githubApiRequest(
 ): Promise<CResult<{ response: Response; bodyText: string }>> {
   const method = init.method || 'GET'
   let rateLimitWaitUsed = false
-  for (let attempt = 1; ; attempt += 1) {
+  // pRetry rethrows whichever error it stored first. Track the newest one
+  // ourselves so the caller always sees the failure that actually ended the
+  // run, not an earlier one it had already recovered past.
+  let lastFailure: GitHubRequestFailure | undefined
+
+  const fail = (
+    result: CResult<never>,
+    retryable: boolean,
+  ): GitHubRequestFailure => {
+    const failure = new GitHubRequestFailure(result, retryable)
+    lastFailure = failure
+    return failure
+  }
+
+  const attempt = async (): Promise<{
+    response: Response
+    bodyText: string
+  }> => {
     debugApiRequest(method, url)
     let response: Response
     try {
-      // eslint-disable-next-line no-await-in-loop
       response = await fetchImpl(url, init)
       debugApiResponse(method, url, response.status)
     } catch (e) {
       debugApiResponse(method, url, undefined, e)
-      // Network-level failure (DNS, connection reset, timeout). Retry a few
-      // times with bounded backoff before giving up.
-      if (attempt < MAX_TRANSIENT_ATTEMPTS) {
-        debugFn('notice', `retry: network error while ${context}`, attempt)
-        // eslint-disable-next-line no-await-in-loop
-        await sleep(backoffMs(attempt))
-        continue
-      }
-      return {
-        ok: false,
-        message: 'Network error connecting to GitHub',
-        cause: formatErrorWithDetail(`Network error while ${context}`, e),
-      }
+      // Network-level failure (DNS, connection reset, timeout).
+      throw fail(
+        {
+          ok: false,
+          message: 'Network error connecting to GitHub',
+          cause: formatErrorWithDetail(`Network error while ${context}`, e),
+        },
+        true,
+      )
     }
 
-    // eslint-disable-next-line no-await-in-loop
     const bodyText = await response.text()
 
     const blocking = classifyGitHubResponse(
@@ -241,10 +287,10 @@ export async function githubApiRequest(
     if (blocking) {
       // Auth failures never succeed on retry.
       if (blocking.message === GITHUB_ERR_AUTH_FAILED) {
-        return blocking
+        throw fail(blocking, false)
       }
-      // Rate limit / abuse: retry once, but only when the reset window is
-      // short enough to be worth waiting on.
+      // Rate limit / abuse: wait once, but only when the reset window is short
+      // enough to be worth waiting on.
       const waitSeconds = getRateLimitWaitSeconds(response.headers)
       if (
         !rateLimitWaitUsed &&
@@ -255,35 +301,59 @@ export async function githubApiRequest(
         logger.info(
           `GitHub rate limit hit while ${context}; waiting ${waitSeconds}s before one retry...`,
         )
-        // Add a second of slack so we retry just past the reset boundary.
-        // eslint-disable-next-line no-await-in-loop
+        // GitHub told us exactly when the quota comes back, so this wait is
+        // honoring a server instruction rather than backing off. Backoff is
+        // pRetry's job and its delay is capped well below a reset window.
+        // A second of slack lands the retry just past the reset boundary.
         await sleep((waitSeconds + 1) * 1000)
-        continue
+        throw fail(blocking, true)
       }
-      return blocking
+      throw fail(blocking, false)
     }
 
-    // Transient server errors: retry with bounded backoff, then surface.
+    // Transient server errors.
     if (response.status >= HTTP_STATUS_INTERNAL_SERVER_ERROR) {
-      if (attempt < MAX_TRANSIENT_ATTEMPTS) {
+      throw fail(
+        {
+          ok: false,
+          message: 'GitHub server error',
+          cause:
+            `GitHub server error (${response.status}) while ${context}. ` +
+            'GitHub may be experiencing issues; try again shortly.',
+        },
+        true,
+      )
+    }
+
+    return { response, bodyText }
+  }
+
+  try {
+    const data = await pRetry(attempt, {
+      ...githubRetryOptions(),
+      onRetry(attemptNumber: number, e: unknown) {
+        if (e instanceof GitHubRequestFailure && !e.retryable) {
+          // Stop now; another attempt cannot change the answer.
+          return false
+        }
         debugFn(
           'notice',
-          `retry: GitHub ${response.status} while ${context}`,
-          attempt,
+          `retry: ${e instanceof Error ? e.message : 'failure'} while ${context}`,
+          attemptNumber,
         )
-        // eslint-disable-next-line no-await-in-loop
-        await sleep(backoffMs(attempt))
-        continue
-      }
-      return {
+        return undefined
+      },
+      onRetryCancelOnFalse: true,
+    })
+    return { ok: true, data }
+  } catch {
+    /* c8 ignore next - `lastFailure` is set on every throw out of `attempt`. */
+    return (
+      lastFailure?.result ?? {
         ok: false,
-        message: 'GitHub server error',
-        cause:
-          `GitHub server error (${response.status}) while ${context}. ` +
-          'GitHub may be experiencing issues; try again shortly.',
+        message: 'GitHub request failed',
+        cause: `GitHub request failed while ${context}.`,
       }
-    }
-
-    return { ok: true, data: { response, bodyText } }
+    )
   }
 }

--- a/src/utils/github-errors.test.mts
+++ b/src/utils/github-errors.test.mts
@@ -1,4 +1,6 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import process from 'node:process'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import {
   GITHUB_ERR_ABUSE_DETECTION,
@@ -54,7 +56,11 @@ describe('classifyGitHubResponse', () => {
     const result = classifyGitHubResponse(
       403,
       new Headers({ 'x-ratelimit-remaining': '0' }),
-      '{"message":"API rate limit exceeded"}',
+      // A body that says nothing about throttling, so this case proves the
+      // HEADER detector fired. With a body that also says "rate limit" the
+      // two detectors cover for each other and deleting either one leaves
+      // this test green.
+      '{"message":"Forbidden"}',
       ctx,
     )
     expect(result?.ok).toBe(false)
@@ -158,8 +164,25 @@ describe('isGitHubBlockingError', () => {
 })
 
 describe('githubApiRequest', () => {
+  // The retry backoff sleeps through `node:timers/promises`, which
+  // `vi.useFakeTimers()` does not reliably intercept, so the fake-timer trick
+  // cannot make these tests fast. Zeroing the base delay through the env
+  // override can, and it exercises the override at the same time. Each test
+  // that cares about a specific delay sets the env itself.
+  const ENV_KEY = 'SOCKET_GITHUB_RETRY_BASE_DELAY_MS'
+  let savedBaseDelay: string | undefined
+
+  beforeEach(() => {
+    savedBaseDelay = process.env[ENV_KEY]
+    process.env[ENV_KEY] = '0'
+  })
+
   afterEach(() => {
-    vi.useRealTimers()
+    if (savedBaseDelay === undefined) {
+      delete process.env[ENV_KEY]
+    } else {
+      process.env[ENV_KEY] = savedBaseDelay
+    }
   })
 
   it('returns the response and body text on success', async () => {
@@ -211,23 +234,23 @@ describe('githubApiRequest', () => {
   })
 
   it('waits and retries once on a short rate-limit window, then succeeds', async () => {
-    vi.useFakeTimers()
     const fake = fakeFetch([
       {
+        // `retry-after: 0` keeps the test quick. The branch under test is
+        // "the reset window is short enough to wait out", not the length of
+        // the wait itself.
         status: 403,
-        headers: { 'x-ratelimit-remaining': '0', 'retry-after': '1' },
+        headers: { 'x-ratelimit-remaining': '0', 'retry-after': '0' },
         body: '{"message":"API rate limit exceeded"}',
       },
       { status: 200, body: '{"recovered":true}' },
     ])
-    const promise = githubApiRequest(
+    const result = await githubApiRequest(
       'https://api.github.com/x',
       {},
       'x',
       fake.fetchImpl,
     )
-    await vi.runAllTimersAsync()
-    const result = await promise
     expect(result.ok).toBe(true)
     if (result.ok) {
       expect(result.data.bodyText).toBe('{"recovered":true}')
@@ -235,20 +258,73 @@ describe('githubApiRequest', () => {
     expect(fake.calls()).toBe(2)
   })
 
-  it('retries transient 5xx with bounded backoff, then surfaces a server error', async () => {
-    vi.useFakeTimers()
-    const fake = fakeFetch([{ status: 503, body: 'unavailable' }])
-    const promise = githubApiRequest(
+  it('waits out the reset window only once, then surfaces the rate limit', async () => {
+    const fake = fakeFetch([
+      {
+        status: 403,
+        headers: { 'x-ratelimit-remaining': '0', 'retry-after': '0' },
+        body: '{"message":"API rate limit exceeded"}',
+      },
+    ])
+    const result = await githubApiRequest(
       'https://api.github.com/x',
       {},
       'x',
       fake.fetchImpl,
     )
-    await vi.runAllTimersAsync()
-    const result = await promise
+    expect(result.ok ? '' : result.message).toBe(GITHUB_ERR_RATE_LIMIT)
+    // The first response buys one wait-and-retry. The second identical
+    // response is surfaced rather than waited on again.
+    expect(fake.calls()).toBe(2)
+  })
+
+  it('retries transient 5xx with bounded backoff, then surfaces a server error', async () => {
+    const fake = fakeFetch([{ status: 503, body: 'unavailable' }])
+    const result = await githubApiRequest(
+      'https://api.github.com/x',
+      {},
+      'x',
+      fake.fetchImpl,
+    )
     expect(result.ok).toBe(false)
     expect(result.ok ? '' : result.message).toBe('GitHub server error')
     // Initial attempt + 2 retries = 3 total.
     expect(fake.calls()).toBe(3)
+  })
+
+  it('retries a network-level failure, then surfaces it', async () => {
+    let calls = 0
+    const result = await githubApiRequest(
+      'https://api.github.com/x',
+      {},
+      'x',
+      () => {
+        calls += 1
+        return Promise.reject(new Error('ECONNRESET'))
+      },
+    )
+    expect(result.ok ? '' : result.message).toBe(
+      'Network error connecting to GitHub',
+    )
+    expect(calls).toBe(3)
+  })
+
+  it('honors SOCKET_GITHUB_RETRY_BASE_DELAY_MS for the backoff delay', async () => {
+    process.env[ENV_KEY] = '40'
+    const fake = fakeFetch([{ status: 503, body: 'unavailable' }])
+    const started = Date.now()
+    const result = await githubApiRequest(
+      'https://api.github.com/x',
+      {},
+      'x',
+      fake.fetchImpl,
+    )
+    const elapsed = Date.now() - started
+    expect(result.ok).toBe(false)
+    expect(fake.calls()).toBe(3)
+    // Two retries at a 40ms base with doubling means at least 40 + 80 ms of
+    // real waiting. A zeroed override finishes far below that, so this fails
+    // if the env var stops reaching the retry policy.
+    expect(elapsed).toBeGreaterThanOrEqual(120)
   })
 })


### PR DESCRIPTION
## What this changes

`src/utils/github-errors.mts` had its own retry loop: a `for (let attempt = 1; ; attempt += 1)` counter, a `backoffMs()` function computing `Math.min(1000 * 2 ** (attempt - 1), 10_000)`, and a hand-written `sleep()` promise. The fleet already ships that exact helper as `pRetry`, and `@socketsecurity/registry` is already a dependency of this branch, so the loop was a second copy of code we maintain elsewhere. Two copies of a backoff policy for the same API will drift apart, and the local copy had no way to make the delay short in a test.

This PR hands the transient-failure retries to `pRetry` and deletes the local loop. `MAX_TRANSIENT_ATTEMPTS`, `MAX_BACKOFF_MS`, `backoffMs()`, and `sleep()` are gone.

**Nothing about the rate-limit detection changes.** `classifyGitHubResponse`, `getRateLimitWaitSeconds`, and `isGitHubBlockingError` behave exactly as before, and the scan loop still short-circuits on a blocking error rather than reporting a silent success on a throttled run. That fix is the reason this file exists and it is fully preserved.

## The retry policy is now the shared one, which changes two things a user can notice

<details>
<summary>Transient failures now back off on the fleet's 5s/10s schedule instead of the local 1s/2s one</summary>

The retry policy adopted here matches `GITHUB_RETRY_CONFIG` in `@socketsecurity/lib`, which is the fleet's chosen policy for the GitHub API: two retries on top of the initial attempt, delay doubling each time, capped at 10 seconds, with jitter.

| | Before | After |
| --- | --- | --- |
| Total attempts on a 5xx or network failure | 3 | 3, unchanged |
| Delay before retry 1 | 1s | 5s, plus jitter |
| Delay before retry 2 | 2s | 10s, plus jitter |
| Delay cap | 10s | 10s, unchanged |

So a GitHub outage that never recovers now costs up to about 15 seconds of waiting instead of 3. That is deliberate: a GitHub 5xx frequently needs more than a second to clear, and one second of backoff mostly buys you a second failure. The attempt count is unchanged, so no request is made that was not made before.

The rate-limit path picks up one extra backoff delay it did not have. When GitHub reports a short reset window, the code still waits out that window and retries; that retry is now driven by `pRetry`, so the configured backoff is added on top of the server's window. In practice that is a few extra seconds on an already-throttled run.

</details>

<details>
<summary>The backoff delay is now settable through SOCKET_GITHUB_RETRY_BASE_DELAY_MS, which is what makes the retry path testable</summary>

The base delay is read from `SOCKET_GITHUB_RETRY_BASE_DELAY_MS` on every call, falling back to 5000. The name and the default are deliberately identical to the override in `@socketsecurity/lib`'s `releases/github-retry-config`, so both socket-cli lines answer to the same knob and cannot drift on the value.

This is not a convenience. The old tests reached for `vi.useFakeTimers()` plus `vi.runAllTimersAsync()`, which worked only because the local `sleep()` used a plain `setTimeout`. `pRetry` sleeps through `node:timers/promises`, which fake timers do not reliably intercept, so the first run of the converted tests **hung for the full real delay and timed out**. Setting the override to `0` is the fix, and it is fake-timer-independent. The tests now do that in a `beforeEach` and restore the previous value afterwards.

</details>

<details>
<summary>Why the classifier is still local rather than imported from socket-lib, and what happens next</summary>

The classification logic in this file — deciding from a status, headers, and body that a response is a rate limit, abuse detection, or an auth failure, and the idea of a *blocking* error that should stop a loop over repositories — has been contributed upstream to `socket-lib` as `github/error-classification` in **SocketDev/socket-lib#221**, so there is now one canonical copy to converge on.

This branch cannot import it yet, and the reason is a hard one rather than a matter of taste. `@socketsecurity/lib` declares `engines.node: ">=22"`. This branch declares `engines.node: ">=18.20.8"` and its CI compatibility matrix actively tests Node **20**, 22, and 24. Adding that library here would either put an unsupported-on-Node-20 dependency into the line that owns the `latest` npm dist-tag, or force a Node floor raise, and neither belongs inside a retry refactor. This branch is also pinned to `@socketsecurity/registry@1.1.17`, the pre-split package, so pulling in `@socketsecurity/lib@6.x` alongside it would ship two generations of the same utility library in one bundle.

`pRetry` was available without any of that, because `@socketsecurity/registry@1.1.17` already exports it with the identical option shape that `socket-lib`'s copy uses. That is the part of the deduplication this branch can take today, so that is what this PR does.

One thing did improve on the way through. The test named `flags a 403 with x-ratelimit-remaining: 0 as a rate limit` used a response body that *also* said "rate limit", so the body detector was quietly covering for the header detector: deleting the header check left that test green. The body is now one that says nothing about throttling, so the test finally proves what its name claims. That header-only `403` is precisely the shape that used to be misread as "this repository has no manifests".

</details>

## Testing

<details>
<summary>Every detector touched was broken on purpose and confirmed to turn a named test red</summary>

| Mutation applied | Named test that went red |
| --- | --- |
| `x-ratelimit-remaining: 0` detector removed | `classifyGitHubResponse > flags a 403 with x-ratelimit-remaining: 0 as a rate limit` |
| classifier always returns "not a blocking error" | 10 tests, including `githubApiRequest > surfaces a long-window rate limit immediately without retrying` and `githubApiRequest > never retries an auth failure` |
| auth failure marked retryable | `githubApiRequest > never retries an auth failure` |
| transient 5xx marked non-retryable | `githubApiRequest > retries transient 5xx with bounded backoff, then surfaces a server error`, `githubApiRequest > honors SOCKET_GITHUB_RETRY_BASE_DELAY_MS for the backoff delay` |
| env override no longer reaches the retry policy | `githubApiRequest > honors SOCKET_GITHUB_RETRY_BASE_DELAY_MS for the backoff delay` |
| retry loop no longer stops early on a non-retryable failure | `githubApiRequest > surfaces a long-window rate limit immediately without retrying`, `githubApiRequest > never retries an auth failure`, `githubApiRequest > waits out the reset window only once, then surfaces the rate limit` |
| caller shown the first failure instead of the last | 5 tests, including `githubApiRequest > retries a network-level failure, then surfaces it` |

The source was restored and diffed byte-for-byte against the pre-mutation copy after each run.

</details>

Three tests are new: one that a short reset window is waited out only once before the rate limit is surfaced, one that a network-level failure is retried and then reported, and one that the env override actually reaches the backoff by measuring elapsed time.

**Ran**, all from a clean worktree off this branch's base, with a baseline captured first:

| Gate | Baseline on the unmodified base | With this change |
| --- | --- | --- |
| `vitest run src/utils/github-errors.test.mts src/commands/scan/create-scan-from-github.test.mts` | 25 passed, exit `0` | 28 passed, exit `0` |
| `vitest run src/utils src/commands/scan` | not captured | 40 files, 530 passed, exit `0` |
| `pnpm run lint` | 369 warnings, 0 errors, exit `0` | 369 warnings, 0 errors, exit `0` — identical count, no finding names this file |
| `pnpm run check:lint` | exit `0` | exit `0`, after fixing the import-order and function-scoping errors it raised on the first pass |
| `pnpm run check:tsc` | exit `0` | exit `0` |

**Did not run**

- The full test suite and the end-to-end suites. The change is scoped to one utility module and its one consumer, both of which are covered above.
- A live call against the real GitHub API. The retry paths are exercised through the module's existing injectable `fetchImpl` parameter, which is what it is there for.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how long `socket scan github` waits on GitHub 5xx/network and short rate-limit retries without altering rate-limit/auth classification, so outage behavior shifts but silent-success misreads should not return.
> 
> **Overview**
> Replaces the hand-written retry loop in `github-errors.mts` (local `backoffMs`, `sleep`, and attempt counter) with the shared **`pRetry`** helper from `@socketsecurity/registry`, aligned with the fleet **`GITHUB_RETRY_CONFIG`** (two retries, doubling delay capped at 10s).
> 
> Transient **5xx and network** failures still get three attempts total, but backoff now starts at **5s** (not 1s) unless **`SOCKET_GITHUB_RETRY_BASE_DELAY_MS`** overrides it—read per request so tests can set `0`. **`GitHubRequestFailure`** tells `pRetry` when to stop early (auth, long rate limits) and keeps the **last** failure for the caller. Short-window rate-limit handling still waits once on `Retry-After` / reset headers; classification and blocking-error behavior are unchanged.
> 
> Tests drop fake timers (incompatible with `node:timers/promises`), zero the env delay in `beforeEach`, and add coverage for single rate-limit wait, network retries, and env-driven backoff timing. One classifier test now uses a **403 + `x-ratelimit-remaining: 0`** body that does not mention rate limits, so the header path is actually exercised.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a28451a3766154ee0654a1edc797d0c8c389ee6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->