### PR TITLE
fix(ci): send real branch and PR for CI scans

### DIFF
--- a/src/commands/ci/handle-ci.mts
+++ b/src/commands/ci/handle-ci.mts
@@ -1,4 +1,5 @@
 import { debugDir, debugFn } from '@socketsecurity/registry/lib/debug'
+import { envAsString } from '@socketsecurity/registry/lib/env'
 import { logger } from '@socketsecurity/registry/lib/logger'
 
 import { getDefaultOrgSlug } from './fetch-default-org-slug.mts'
@@ -10,6 +11,19 @@ import {
 } from '../../utils/git.mts'
 import { serializeResultJson } from '../../utils/serialize-result-json.mts'
 import { handleCreateNewScan } from '../scan/handle-create-new-scan.mts'
+
+/**
+ * Derive the pull request number from the CI environment. GitHub Actions
+ * pull_request events check out `refs/pull/<n>/merge`, so the number is
+ * recoverable from GITHUB_REF; returns 0 outside a PR run (the API omits
+ * `pull_request` for falsy values).
+ */
+export function detectCiPullRequestNumber(): number {
+  const match = /^refs\/pull\/(\d+)\//.exec(
+    envAsString(process.env['GITHUB_REF']),
+  )
+  return match ? Number(match[1]) : 0
+}
 
 export async function handleCi(autoManifest: boolean): Promise<void> {
   debugFn('notice', 'Starting CI scan')
@@ -49,7 +63,7 @@ export async function handleCi(autoManifest: boolean): Promise<void> {
     outputKind: 'json',
     // When 'pendingHead' is true, it requires 'branchName' set and 'tmp' false.
     pendingHead: true,
-    pullRequest: 0,
+    pullRequest: detectCiPullRequestNumber(),
     reach: {
       dynamicSbomInference: false,
       excludePaths: [],

--- a/src/commands/ci/handle-ci.test.mts
+++ b/src/commands/ci/handle-ci.test.mts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { detectCiPullRequestNumber } from './handle-ci.mts'
+
+let originalGithubRef: string | undefined
+
+describe('detectCiPullRequestNumber', () => {
+  beforeEach(() => {
+    originalGithubRef = process.env['GITHUB_REF']
+    delete process.env['GITHUB_REF']
+  })
+
+  afterEach(() => {
+    if (originalGithubRef === undefined) {
+      delete process.env['GITHUB_REF']
+    } else {
+      process.env['GITHUB_REF'] = originalGithubRef
+    }
+  })
+
+  it('derives the number from a pull request merge ref', () => {
+    process.env['GITHUB_REF'] = 'refs/pull/482/merge'
+    expect(detectCiPullRequestNumber()).toBe(482)
+  })
+
+  it('derives the number from a pull request head ref', () => {
+    process.env['GITHUB_REF'] = 'refs/pull/482/head'
+    expect(detectCiPullRequestNumber()).toBe(482)
+  })
+
+  it('returns 0 for a branch push', () => {
+    process.env['GITHUB_REF'] = 'refs/heads/feature-branch'
+    expect(detectCiPullRequestNumber()).toBe(0)
+  })
+
+  it('returns 0 for a tag push', () => {
+    process.env['GITHUB_REF'] = 'refs/tags/v1.2.3'
+    expect(detectCiPullRequestNumber()).toBe(0)
+  })
+
+  it('returns 0 when GITHUB_REF is not a numbered pull ref', () => {
+    process.env['GITHUB_REF'] = 'refs/pull/not-a-number/merge'
+    expect(detectCiPullRequestNumber()).toBe(0)
+  })
+
+  it('returns 0 outside GitHub Actions', () => {
+    expect(detectCiPullRequestNumber()).toBe(0)
+  })
+})

--- a/src/utils/git.mts
+++ b/src/utils/git.mts
@@ -21,11 +21,13 @@
  * Repository Information:
  * - detectDefaultBranch: Find default branch (main/master/develop/etc)
  * - getBaseBranch: Determine base branch (respects GitHub Actions env)
+ * - getCiBranch: Branch name a GitHub Actions run is on
  * - getRepoInfo: Extract owner/repo from git remote URL
  * - gitBranch: Get current branch or commit hash
  */
 
 import { debugDir, debugFn, isDebug } from '@socketsecurity/registry/lib/debug'
+import { envAsString } from '@socketsecurity/registry/lib/env'
 import { normalizePath } from '@socketsecurity/registry/lib/path'
 import { isSpawnError, spawn } from '@socketsecurity/registry/lib/spawn'
 
@@ -75,6 +77,32 @@ export async function getBaseBranch(cwd = process.cwd()): Promise<string> {
   // GitHub and GitLab default to branch name "main"
   // https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#about-the-default-branch
   return 'main'
+}
+
+/**
+ * The branch a GitHub Actions workflow run is on, or undefined when the
+ * environment does not identify one. Read straight from process.env because
+ * GITHUB_HEAD_REF is not part of the constants.ENV snapshot.
+ */
+export function getCiBranch(): string | undefined {
+  // The head branch of a pull request, only set for pull_request and
+  // pull_request_target events. Checked first because GITHUB_REF_NAME is
+  // '<pr_number>/merge' on those events, which is not a branch name.
+  // https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables
+  const githubHeadRef = envAsString(process.env['GITHUB_HEAD_REF'])
+  if (githubHeadRef) {
+    return githubHeadRef
+  }
+  // The pushed ref. GITHUB_REF_TYPE tells branches and tags apart, and a tag
+  // is not a branch name.
+  const githubRefName = envAsString(process.env['GITHUB_REF_NAME'])
+  if (
+    envAsString(process.env['GITHUB_REF_TYPE']) === 'branch' &&
+    githubRefName
+  ) {
+    return githubRefName
+  }
+  return undefined
 }
 
 export type RepoInfo = {
@@ -132,6 +160,14 @@ export async function gitBranch(
   } catch (e) {
     // Expected in detached HEAD state, fallback to rev-parse.
     debugDir('inspect', { message: 'In detached HEAD state', error: e })
+  }
+  // Detached HEAD is the normal state in CI checkouts (actions/checkout),
+  // where the commit-SHA fallback below would mislabel the scan's branch — a
+  // SHA can never match the repo's default branch, so scans vanish from the
+  // Main/PR tabs. Prefer the branch the CI run says it is on.
+  const ciBranch = getCiBranch()
+  if (ciBranch) {
+    return ciBranch
   }
   // Fallback to using rev-parse to get the short commit hash in a
   // detached HEAD state.

--- a/src/utils/git.test.mts
+++ b/src/utils/git.test.mts
@@ -1,0 +1,140 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { spawn } from '@socketsecurity/registry/lib/spawn'
+
+import { getCiBranch, gitBranch } from './git.mts'
+
+// GitHub Actions sets these in its own runs, so they have to be cleared for
+// the tests to exercise anything other than the CI job they run inside.
+const GITHUB_ENV_VARS = [
+  'GITHUB_HEAD_REF',
+  'GITHUB_REF_NAME',
+  'GITHUB_REF_TYPE',
+]
+
+const originalEnv = new Map<string, string | undefined>()
+
+async function createTempRepo(): Promise<string> {
+  const repoPath = mkdtempSync(path.join(tmpdir(), 'socket-git-branch-'))
+  const options = { cwd: repoPath }
+  await spawn('git', ['init', '--initial-branch', 'feature-branch'], options)
+  await spawn('git', ['config', 'user.email', 'test@socket.dev'], options)
+  await spawn('git', ['config', 'user.name', 'Socket Test'], options)
+  await spawn('git', ['config', 'commit.gpgsign', 'false'], options)
+  writeFileSync(path.join(repoPath, 'README.md'), '# test\n')
+  await spawn('git', ['add', 'README.md'], options)
+  await spawn('git', ['commit', '-m', 'Initial commit'], options)
+  return repoPath
+}
+
+describe('getCiBranch', () => {
+  beforeEach(() => {
+    for (const name of GITHUB_ENV_VARS) {
+      originalEnv.set(name, process.env[name])
+      delete process.env[name]
+    }
+  })
+
+  afterEach(() => {
+    for (const name of GITHUB_ENV_VARS) {
+      const value = originalEnv.get(name)
+      if (value === undefined) {
+        delete process.env[name]
+      } else {
+        process.env[name] = value
+      }
+    }
+    originalEnv.clear()
+  })
+
+  it('returns the pull request head branch', () => {
+    process.env['GITHUB_HEAD_REF'] = 'feature/pr-branch'
+    expect(getCiBranch()).toBe('feature/pr-branch')
+  })
+
+  it('prefers the pull request head branch over the merge ref', () => {
+    process.env['GITHUB_HEAD_REF'] = 'feature/pr-branch'
+    // What GitHub Actions actually sets on a pull_request event.
+    process.env['GITHUB_REF_NAME'] = '123/merge'
+    process.env['GITHUB_REF_TYPE'] = 'branch'
+    expect(getCiBranch()).toBe('feature/pr-branch')
+  })
+
+  it('returns the pushed branch ref outside a pull request', () => {
+    process.env['GITHUB_REF_NAME'] = 'main'
+    process.env['GITHUB_REF_TYPE'] = 'branch'
+    expect(getCiBranch()).toBe('main')
+  })
+
+  it('ignores a tag ref', () => {
+    process.env['GITHUB_REF_NAME'] = 'v1.2.3'
+    process.env['GITHUB_REF_TYPE'] = 'tag'
+    expect(getCiBranch()).toBeUndefined()
+  })
+
+  it('returns undefined outside GitHub Actions', () => {
+    expect(getCiBranch()).toBeUndefined()
+  })
+})
+
+describe('gitBranch', () => {
+  let repoPath = ''
+
+  beforeEach(async () => {
+    for (const name of GITHUB_ENV_VARS) {
+      originalEnv.set(name, process.env[name])
+      delete process.env[name]
+    }
+    repoPath = await createTempRepo()
+  })
+
+  afterEach(() => {
+    for (const name of GITHUB_ENV_VARS) {
+      const value = originalEnv.get(name)
+      if (value === undefined) {
+        delete process.env[name]
+      } else {
+        process.env[name] = value
+      }
+    }
+    originalEnv.clear()
+    rmSync(repoPath, { force: true, recursive: true })
+  })
+
+  it('returns the checked out branch', async () => {
+    expect(await gitBranch(repoPath)).toBe('feature-branch')
+  })
+
+  it('falls back to the commit hash in a detached HEAD with no CI env', async () => {
+    await spawn('git', ['checkout', '--detach'], { cwd: repoPath })
+    const shortHash = (
+      await spawn('git', ['rev-parse', '--short', 'HEAD'], { cwd: repoPath })
+    ).stdout
+    expect(await gitBranch(repoPath)).toBe(shortHash)
+  })
+
+  it('returns the pull request head branch in a detached HEAD', async () => {
+    await spawn('git', ['checkout', '--detach'], { cwd: repoPath })
+    process.env['GITHUB_HEAD_REF'] = 'feature/pr-branch'
+    process.env['GITHUB_REF_NAME'] = '123/merge'
+    process.env['GITHUB_REF_TYPE'] = 'branch'
+    expect(await gitBranch(repoPath)).toBe('feature/pr-branch')
+  })
+
+  it('returns the pushed branch ref in a detached HEAD', async () => {
+    await spawn('git', ['checkout', '--detach'], { cwd: repoPath })
+    process.env['GITHUB_REF_NAME'] = 'main'
+    process.env['GITHUB_REF_TYPE'] = 'branch'
+    expect(await gitBranch(repoPath)).toBe('main')
+  })
+
+  it('prefers the checked out branch over the CI env', async () => {
+    process.env['GITHUB_REF_NAME'] = 'main'
+    process.env['GITHUB_REF_TYPE'] = 'branch'
+    expect(await gitBranch(repoPath)).toBe('feature-branch')
+  })
+})


### PR DESCRIPTION

## Actions needed

- Merge this, then cut a v1.x release. This is the backport that unblocks Netflix, and they run the published `latest` dist-tag (v1.1.152, on `v1.x`), so nothing changes for them until a release ships.
- Nothing to port to `main`. Both fixes are already there with tests.

## What was broken

Scans from `socket ci` in GitHub Actions did not show up in either the Main or the PR tab of the dashboard. Two separate causes, both already fixed on `main` (SURF-634), neither on `v1.x`:

1. `actions/checkout` leaves HEAD detached, which is the normal state in CI. `gitBranch` handled that by falling back to a short commit SHA, and a SHA can never match the repo default branch, so the scan was not a main-branch scan. On a pull request it was not a PR scan either.
2. `socket ci` hardcoded `pullRequest: 0`, so a scan from a `pull_request` event could not land in the PR tab even with the branch right.

## The fix

`getCiBranch()` in `src/utils/git.mts` reads the branch the workflow says it is on before falling back to the SHA: `GITHUB_HEAD_REF` first (the pull request head branch), then `GITHUB_REF_NAME` when `GITHUB_REF_TYPE` is `branch`. `GITHUB_HEAD_REF` has to win, because on a `pull_request` event `GITHUB_REF_NAME` is `<pr_number>/merge`, which is not a branch name.

`detectCiPullRequestNumber()` in `src/commands/ci/handle-ci.mts` pulls the number out of `GITHUB_REF`, which is `refs/pull/<n>/merge` on those events. Outside a pull request it returns 0 and the API request omits `pull_request` as before.

<details>
<summary>Port notes and test results</summary>

`main` is a monorepo and keeps this logic in `packages/cli/src/util/git/git-remote-info.mts`. `v1.x` is the old flat tree, so no files were copied. The branch logic went into the existing `src/utils/git.mts`, next to `getBaseBranch`, and the pull request logic into the existing `handle-ci.mts`.

`main` reads the environment through `getGithubRefName()` / `getGithubRefType()` helpers that do not exist on `v1.x`. Here the values are read straight from `process.env` with `envAsString`, because neither `GITHUB_HEAD_REF` nor `GITHUB_REF` is part of the frozen `constants.ENV` snapshot that `getBaseBranch` uses.

16 new tests, all passing, no mocks. `getCiBranch` is covered directly; `gitBranch` is covered against a real temporary git repo that gets detached with `git checkout --detach`, so the detached-HEAD path is the real thing rather than a stub. The tests clear `GITHUB_HEAD_REF`, `GITHUB_REF_NAME`, `GITHUB_REF_TYPE`, and `GITHUB_REF` first, otherwise they would silently read the values of the CI job they run inside.

Checked that the tests are not vacuous. Disabling the branch preference in `git.mts` fails exactly the two detached-HEAD CI tests, and both report the commit SHA (`expected 'b3833ac' to be 'feature/pr-branch'`) that is the bug customers see. Making `detectCiPullRequestNumber` always return 0 fails exactly the two `refs/pull/<n>/...` tests. Everything else stayed green in both runs, and both breaks were reverted.

`tsgo --noEmit` and eslint are clean.
</details>

## Not in this PR

`make_default_branch` still defaults to `false` here, same as on `main`. Flipping it would make every CI run establish the server-side default branch for every customer, which is an open product question tracked on SURF-634, so it stays as-is.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to CI metadata for scan creation; no auth or API contract changes beyond sending correct branch/PR fields that were previously wrong or omitted.
> 
> **Overview**
> Fixes GitHub Actions `socket ci` scans missing from the dashboard **Main** and **PR** tabs by labeling scans with the workflow’s real branch and PR number instead of a detached-HEAD commit SHA and hardcoded `pullRequest: 0`.
> 
> **Branch detection:** Adds `getCiBranch()` to read `GITHUB_HEAD_REF` (PR head) or `GITHUB_REF_NAME` when `GITHUB_REF_TYPE` is `branch`, and wires `gitBranch()` to use it before falling back to a short SHA in detached HEAD (typical `actions/checkout`).
> 
> **PR number:** Adds `detectCiPullRequestNumber()` to parse `GITHUB_REF` (`refs/pull/<n>/merge` or `head`) and passes that into `handleCreateNewScan` instead of always `0`.
> 
> Adds vitest coverage for both helpers and for `gitBranch` in detached HEAD with CI env vars cleared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc93cb1f72d6946e4b79978082c2d06aca7dcb70. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
