### PR TITLE
chore(release): 1.1.153

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [1.1.153](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.153) - 2026-08-04
 
 ### Changed
 - Updated the Coana CLI to v `15.10.2`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket",
-  "version": "1.1.153-prerelease",
+  "version": "1.1.153",
   "description": "CLI for Socket.dev",
   "contentPolicy": {
     "class": "dual-use"


### PR DESCRIPTION
## Summary
Release bump commit for **1.1.153**, per the [v1.x release guide](https://app.notion.com/p/socketdev/Releasing-socket-cli-v1-x-3ae4cb3adfeb81049c8ae362aeff2b24).

- `package.json`: `1.1.153-prerelease` → `1.1.153` (strips the hint suffix so a real run isn't refused by the prerelease guard).
- `CHANGELOG.md`: promotes `## [Unreleased]` to `## [1.1.153](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.153) - 2026-08-04`.

No source changes. The only user-facing content in this release is the Coana CLI bump to `15.10.2` (#1473).

## Version check
`1.1.153` is unused: the highest published `1.1.x` on `socket`, `@socketsecurity/cli`, and `@socketsecurity/cli-with-sentry` is `1.1.152`, and no `v1.1.153` git tag or release exists — so nothing is burned.

## After this lands
1. Dry run: `gh workflow run npm-publish.yml --repo SocketDev/socket-cli --ref v1.x -f dist-tag=latest -f dry-run=true`
2. Real run: same with `-f dry-run=false` (human action).
3. Promote the three staged uploads via `pnpm stage approve <stage-id>` with 2FA.
4. Reset the tree to `1.1.154-prerelease` with an empty `## [Unreleased]` section.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog metadata only; no runtime or CLI logic changes in the diff.
> 
> **Overview**
> Release-only bump for **1.1.153**: no application source changes in this PR.
> 
> `package.json` moves from `1.1.153-prerelease` to `1.1.153`, dropping the prerelease hint so npm publish’s guard accepts a real release version. `CHANGELOG.md` promotes `## [Unreleased]` to `## [1.1.153]` dated 2026-08-04; the listed change is the Coana CLI update to `15.10.2` (from prior unreleased work).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f23c1ba783f0e38a37b1197321ea9631163261c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->