### PR TITLE
fix(ci): point workflows at the org-level SOCKET_API_TOKEN_FOR_CLI_AND_SFW secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }} # zizmor: ignore[secrets-outside-env]
+          SOCKET_API_KEY: ${{ secrets.SOCKET_API_TOKEN_FOR_CLI_AND_SFW }} # zizmor: ignore[secrets-outside-env]
         run: | # zizmor: ignore[github-env]
           # Pinned version + per-platform checksum pairs. Bumping a tool
           # requires updating the matching version AND every platform's
@@ -293,7 +293,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }} # zizmor: ignore[secrets-outside-env]
+          SOCKET_API_KEY: ${{ secrets.SOCKET_API_TOKEN_FOR_CLI_AND_SFW }} # zizmor: ignore[secrets-outside-env]
         run: | # zizmor: ignore[github-env]
           # Pinned version + per-platform checksum pairs. Bumping a tool
           # requires updating the matching version AND every platform's
@@ -475,7 +475,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }} # zizmor: ignore[secrets-outside-env]
+          SOCKET_API_KEY: ${{ secrets.SOCKET_API_TOKEN_FOR_CLI_AND_SFW }} # zizmor: ignore[secrets-outside-env]
         run: | # zizmor: ignore[github-env]
           # Pinned version + per-platform checksum pairs. Bumping a tool
           # requires updating the matching version AND every platform's

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Probe tier1 legacy_mode (DIAGNOSTIC - REMOVE AFTER USE)
         if: matrix.node-version == 22
         env:
-          SOCKET_CLI_API_TOKEN: ${{ secrets.SOCKET_API_TOKEN }} # zizmor: ignore[secrets-outside-env]
+          SOCKET_CLI_API_TOKEN: ${{ secrets.SOCKET_API_TOKEN_FOR_CLI_AND_SFW }} # zizmor: ignore[secrets-outside-env]
         run: |
           set -eu
           auth=$(printf '%s:' "$SOCKET_CLI_API_TOKEN" | base64 -w0)
@@ -186,5 +186,5 @@ jobs:
 
       - name: Run e2e tests
         env:
-          SOCKET_CLI_API_TOKEN: ${{ secrets.SOCKET_API_TOKEN }} # zizmor: ignore[secrets-outside-env]
+          SOCKET_CLI_API_TOKEN: ${{ secrets.SOCKET_API_TOKEN_FOR_CLI_AND_SFW }} # zizmor: ignore[secrets-outside-env]
         run: pnpm run e2e-tests

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -206,7 +206,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }} # zizmor: ignore[secrets-outside-env]
+          SOCKET_API_KEY: ${{ secrets.SOCKET_API_TOKEN_FOR_CLI_AND_SFW }} # zizmor: ignore[secrets-outside-env]
         run: | # zizmor: ignore[github-env]
           # Pinned version + per-platform checksum pairs. Bumping a tool
           # requires updating the matching version AND every platform's


### PR DESCRIPTION
## Summary

The repo-level `SOCKET_API_TOKEN` and `SOCKET_API_KEY` secrets were removed when these moved to the organization level, where the token is now named `SOCKET_API_TOKEN_FOR_CLI_AND_SFW`. Both old names silently resolved to an empty string.

Two symptoms:

- **e2e-tests failed outright.** `SOCKET_CLI_API_TOKEN` arrived empty, so `cmd-scan-reach.e2e.test.mts` threw `SOCKET_CLI_API_TOKEN environment variable not set` and `cmd-fix.e2e.test.mts` collected zero tests.
- **Every CI job silently downgraded to sfw-free.** The `Download sfw` step picks its tier with `[ -n "$SOCKET_API_KEY" ] && USE_ENTERPRISE=true`, so an empty value quietly took the free path. Lint / Type Check / Test Matrix stayed green while no longer exercising sfw-enterprise.

## Changes

Six references, all to the same org-level secret:

| File | Env var | Count |
| --- | --- | --- |
| `e2e-tests.yml` | `SOCKET_CLI_API_TOKEN` | 2 |
| `ci.yml` | `SOCKET_API_KEY` | 3 |
| `npm-publish.yml` | `SOCKET_API_KEY` | 1 |

`SOCKET_RELEASE_APP_PRIVATE_KEY` and `SOCKET_RELEASE_CLIENT_ID` kept their names at the org level, so those references are deliberately untouched.

## Verifying the fix

`SOCKET_CLI_API_TOKEN` now arrives masked (`***`) instead of blank, the suite runs for ~3m instead of aborting after 42s, and **`cmd-fix.e2e.test.mts` passes** where it previously collected zero tests. Both sfw repos (`SocketDev/firewall-release`, `SocketDev/sfw-free`) are public, so the enterprise download path works with the workflow's own `github.token`.

## ⚠️ e2e is still red, for an unrelated pre-existing reason

Restoring the token uncovered **three reach tests that were already failing on `v1.x`** and were previously masked by the missing token:

| Test | Failure |
| --- | --- |
| `multi-ecosystem filtering › --reach-ecosystems pypi` | exit 1, expected 0 |
| `npm-test-workspace-mono › reachability on workspace mono` | exit 1, expected 0 |
| `target and cwd flags › --cwd sets working directory` | `expected [ '.', '.', '.' ] to include 'packages/package-a'` |

This PR changes only secret *names*, and it sits on `v1.x` with Coana `15.10.9`, so this run is a clean baseline for them. A separate dispatch on `15.10.10` produced the **identical** three failures (`3 failed | 15 passed`), confirming the pending Coana bump neither causes nor worsens them.

Worth noting separately: the `Probe tier1 legacy_mode (DIAGNOSTIC - REMOVE AFTER USE)` step can no longer work regardless of the token — `api.socket.dev` returns a Cloudflare interstitial to its plain `curl`, so the JSON parse always fails. It challenges on request shape, not auth; the same HTML comes back with a valid token. It should probably just be removed.