### PR TITLE
fix(scan): reject every --reach-* modifier when --reach is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+- `socket scan create` now rejects every `--reach-*` modifier when `--reach` is not enabled. Previously flags such as `--reach-debug` were silently ignored, making a plain SBOM scan look like a reachability scan.
+
 ## [1.1.157](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.157) - 2026-08-12
 
 ### Changed

--- a/src/commands/scan/cmd-scan-create.mts
+++ b/src/commands/scan/cmd-scan-create.mts
@@ -504,30 +504,28 @@ async function run(
   const isUsingNonDefaultConcurrency =
     reachConcurrency !== reachabilityFlags['reachConcurrency']?.default
 
-  const isUsingNonDefaultAnalytics =
-    reachDisableAnalytics !==
-    reachabilityFlags['reachDisableAnalytics']?.default
-
   const isUsingNonDefaultVersion =
     reachVersion !== reachabilityFlags['reachVersion']?.default
 
+  // Compare every boolean reach flag against its declared default so newly
+  // added flags require --reach automatically instead of relying on a
+  // hand-maintained list. The deprecated no-op
+  // --reach-disable-analysis-splitting is excluded on purpose.
+  const isUsingAnyBooleanReachFlag = Object.entries(reachabilityFlags).some(
+    ({ 0: name, 1: flag }) =>
+      flag.type === 'boolean' &&
+      name !== 'reachDisableAnalysisSplitting' &&
+      cli.flags[name] !== flag.default,
+  )
+
   const isUsingAnyReachabilityFlags =
-    dynamicSbomInference ||
     hasReachEcosystems ||
     hasReachExcludePaths ||
-    isUsingNonDefaultAnalytics ||
+    isUsingAnyBooleanReachFlag ||
     isUsingNonDefaultConcurrency ||
     isUsingNonDefaultMemoryLimit ||
     isUsingNonDefaultTimeout ||
-    isUsingNonDefaultVersion ||
-    reachContinueOnAnalysisErrors ||
-    reachContinueOnInstallErrors ||
-    reachContinueOnMissingLockFiles ||
-    reachContinueOnNoSourceFiles ||
-    reachEnableAnalysisSplitting ||
-    reachLazyMode ||
-    reachSkipCache ||
-    reachUseOnlyPregeneratedSboms
+    isUsingNonDefaultVersion
 
   // Validate target constraints when --reach is enabled.
   const reachTargetValidation = reach

--- a/src/commands/scan/cmd-scan-create.mts
+++ b/src/commands/scan/cmd-scan-create.mts
@@ -512,7 +512,7 @@ async function run(
   // hand-maintained list. The deprecated no-op
   // --reach-disable-analysis-splitting is excluded on purpose.
   const isUsingAnyBooleanReachFlag = Object.entries(reachabilityFlags).some(
-    ({ 0: name, 1: flag }) =>
+    ([name, flag]) =>
       flag.type === 'boolean' &&
       name !== 'reachDisableAnalysisSplitting' &&
       cli.flags[name] !== flag.default,

--- a/src/commands/scan/cmd-scan-create.test.mts
+++ b/src/commands/scan/cmd-scan-create.test.mts
@@ -199,6 +199,95 @@ describe('socket scan create', async () => {
       'xyz',
       '--branch',
       'abc',
+      '--reach-debug',
+      FLAG_CONFIG,
+      '{"apiToken":"fakeToken"}',
+    ],
+    'should fail when --reach-debug is used without --reach',
+    async cmd => {
+      const { code, stderr, stdout } = await spawnSocketCli(binCliPath, cmd)
+      const output = stdout + stderr
+      expect(output).toContain(
+        'Reachability analysis flags require --reach to be enabled',
+      )
+      expect(output).toContain('add --reach flag to use --reach-* options')
+      expect(
+        code,
+        'should exit with non-zero code when validation fails',
+      ).not.toBe(0)
+    },
+  )
+
+  cmdit(
+    [
+      'scan',
+      'create',
+      FLAG_ORG,
+      'fakeOrg',
+      'target',
+      FLAG_DRY_RUN,
+      '--repo',
+      'xyz',
+      '--branch',
+      'abc',
+      '--reach-retain-facts-file',
+      FLAG_CONFIG,
+      '{"apiToken":"fakeToken"}',
+    ],
+    'should fail when --reach-retain-facts-file is used without --reach',
+    async cmd => {
+      const { code, stderr, stdout } = await spawnSocketCli(binCliPath, cmd)
+      const output = stdout + stderr
+      expect(output).toContain(
+        'Reachability analysis flags require --reach to be enabled',
+      )
+      expect(output).toContain('add --reach flag to use --reach-* options')
+      expect(
+        code,
+        'should exit with non-zero code when validation fails',
+      ).not.toBe(0)
+    },
+  )
+
+  cmdit(
+    [
+      'scan',
+      'create',
+      FLAG_ORG,
+      'fakeOrg',
+      'target',
+      FLAG_DRY_RUN,
+      '--repo',
+      'xyz',
+      '--branch',
+      'abc',
+      '--reach-disable-analysis-splitting',
+      FLAG_CONFIG,
+      '{"apiToken":"fakeToken"}',
+    ],
+    'should succeed when deprecated no-op --reach-disable-analysis-splitting is used without --reach',
+    async cmd => {
+      const { code, stdout } = await spawnSocketCli(binCliPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(
+        code,
+        'should exit with code 0 for the deprecated no-op flag',
+      ).toBe(0)
+    },
+  )
+
+  cmdit(
+    [
+      'scan',
+      'create',
+      FLAG_ORG,
+      'fakeOrg',
+      'target',
+      FLAG_DRY_RUN,
+      '--repo',
+      'xyz',
+      '--branch',
+      'abc',
       '--exclude-paths',
       'tests',
       FLAG_CONFIG,


### PR DESCRIPTION
## Problem

Running `socket scan create --reach-debug .` completes successfully as a plain SBOM scan — no reachability analysis runs, and there is no warning that the flag did nothing. A user can easily believe they have a working reachability scan and ship that report as a reachability assessment.

`socket scan create` already has a guard ("Reachability analysis flags require --reach to be enabled"), but it relied on a hand-maintained list of flags that had drifted out of sync. Four boolean flags were missing and slipped through silently:

- `--reach-debug`
- `--reach-detailed-analysis-log-file`
- `--reach-disable-external-tool-checks`
- `--reach-retain-facts-file`

## Fix

Derive the boolean-flag portion of the guard from the `reachabilityFlags` definition itself (comparing each boolean flag against its declared default), so newly added reach flags are covered automatically instead of relying on the list being kept up to date. The deprecated no-op `--reach-disable-analysis-splitting` remains exempt on purpose.

With this change, `socket scan create --reach-debug .` exits non-zero with:

```
✖ Reachability analysis flags require --reach to be enabled (add --reach flag to use --reach-* options)
```

## Tests

- New: `--reach-debug` without `--reach` fails.
- New: `--reach-retain-facts-file` without `--reach` fails.
- New: deprecated no-op `--reach-disable-analysis-splitting` without `--reach` still succeeds.
- All 33 `cmd-scan-create` tests pass; `pnpm run check` passes.