### PR TITLE
feat(scan): use cached diff-scan endpoint with 202 polling (SURF-743)

### DIFF
--- a/packages/cli/data/command-api-requirements.json
+++ b/packages/cli/data/command-api-requirements.json
@@ -81,8 +81,8 @@
       "permissions": ["full-scans:delete"]
     },
     "scan:diff": {
-      "quota": 1,
-      "permissions": ["full-scans:list"]
+      "quota": 0,
+      "permissions": ["diff-scans:create", "diff-scans:list", "full-scans:list"]
     },
     "scan:list": {
       "quota": 1,

--- a/packages/cli/src/commands/scan/fetch-diff-scan.mts
+++ b/packages/cli/src/commands/scan/fetch-diff-scan.mts
@@ -27,7 +27,11 @@ export async function fetchDiffScan({
   const sockSdk = sockSdkCResult.data
 
   const createResult = await handleApiCall<'createOrgDiffScanFromIds'>(
-    sockSdk.createOrgDiffScanFromIds(orgSlug, { before: id1, after: id2 }),
+    sockSdk.createOrgDiffScanFromIds(orgSlug, {
+      before: id1,
+      after: id2,
+      on_duplicate: 'redirect',
+    }),
     {
       description: 'a scan diff creation',
     },

--- a/packages/cli/src/commands/scan/fetch-diff-scan.mts
+++ b/packages/cli/src/commands/scan/fetch-diff-scan.mts
@@ -1,6 +1,7 @@
 import { getDefaultLogger } from '@socketsecurity/lib-stable/logger/default'
 
-import { queryApiSafeJson } from '../../util/socket/api.mjs'
+import { handleApiCall } from '../../util/socket/api.mjs'
+import { setupSdk } from '../../util/socket/sdk.mts'
 
 import type { CResult } from '../../types.mts'
 import type { SocketSdkSuccessResult } from '@socketsecurity/sdk-stable'
@@ -14,15 +15,33 @@ export async function fetchDiffScan({
   id1: string
   id2: string
   orgSlug: string
-}): Promise<CResult<SocketSdkSuccessResult<'GetOrgDiffScan'>['data']>> {
+}): Promise<CResult<SocketSdkSuccessResult<'getDiffScanById'>['data']>> {
   logger.info('Scan ID 1:', id1)
   logger.info('Scan ID 2:', id2)
   logger.info('Note: this request may take some time if the scans are big')
 
-  return await queryApiSafeJson<
-    SocketSdkSuccessResult<'GetOrgDiffScan'>['data']
-  >(
-    `orgs/${orgSlug}/full-scans/diff?before=${encodeURIComponent(id1)}&after=${encodeURIComponent(id2)}`,
-    'a scan diff',
+  const sockSdkCResult = await setupSdk()
+  if (!sockSdkCResult.ok) {
+    return sockSdkCResult
+  }
+  const sockSdk = sockSdkCResult.data
+
+  const createResult = await handleApiCall<'createOrgDiffScanFromIds'>(
+    sockSdk.createOrgDiffScanFromIds(orgSlug, { before: id1, after: id2 }),
+    {
+      description: 'a scan diff creation',
+    },
+  )
+  if (!createResult.ok) {
+    return createResult
+  }
+
+  const diffScanId = createResult.data.diff_scan.id
+
+  return await handleApiCall<'getDiffScanById'>(
+    sockSdk.getDiffScanById(orgSlug, diffScanId, { cached: true }),
+    {
+      description: 'a scan diff',
+    },
   )
 }

--- a/packages/cli/src/commands/scan/output-diff-scan.mts
+++ b/packages/cli/src/commands/scan/output-diff-scan.mts
@@ -16,7 +16,7 @@ import type { SocketSdkSuccessResult } from '@socketsecurity/sdk-stable'
 const logger = getDefaultLogger()
 
 export async function handleJson(
-  data: CResult<SocketSdkSuccessResult<'GetOrgDiffScan'>['data']>,
+  data: CResult<SocketSdkSuccessResult<'getDiffScanById'>['data']>,
   file: string,
   dashboardMessage: string,
 ) {
@@ -44,75 +44,76 @@ export async function handleJson(
 }
 
 export async function handleMarkdown(
-  data: SocketSdkSuccessResult<'GetOrgDiffScan'>['data'],
+  data: SocketSdkSuccessResult<'getDiffScanById'>['data'],
 ) {
   const SOCKET_SBOM_URL_PREFIX = `${SOCKET_WEBSITE_URL}/dashboard/org/SocketDev/sbom/`
+
+  const diffScan = data.diff_scan
+  const beforeScan = diffScan.before_full_scan
+  const afterScan = diffScan.after_full_scan
 
   logger.log(mdHeader('Scan diff result'))
   logger.log('')
   logger.log('This Socket.dev report shows the changes between two scans:')
-  logger.log(
-    `- [${data.before.id}](${SOCKET_SBOM_URL_PREFIX}${data.before.id})`,
-  )
-  logger.log(`- [${data.after.id}](${SOCKET_SBOM_URL_PREFIX}${data.after.id})`)
+  logger.log(`- [${beforeScan.id}](${SOCKET_SBOM_URL_PREFIX}${beforeScan.id})`)
+  logger.log(`- [${afterScan.id}](${SOCKET_SBOM_URL_PREFIX}${afterScan.id})`)
   logger.log('')
   logger.log(
-    `You can [view this report in your dashboard](${data.diff_report_url})`,
+    `You can [view this report in your dashboard](${diffScan.html_url})`,
   )
   logger.log('')
   logger.log(mdHeader('Changes', 2))
   logger.log('')
-  logger.log(`- directDependenciesChanged: ${data.directDependenciesChanged}`)
-  logger.log(`- Added packages: ${data.artifacts.added.length}`)
+  logger.log(`- Added packages: ${diffScan.artifacts.added.length}`)
 
-  if (data.artifacts.added.length > 0) {
-    const addedHead = data.artifacts.added.slice(0, 10)
+  if (diffScan.artifacts.added.length > 0) {
+    const addedHead = diffScan.artifacts.added.slice(0, 10)
     for (let i = 0, { length } = addedHead; i < length; i += 1) {
       const artifact = addedHead[i]!
       logger.log(`  - ${artifact.type} ${artifact.name}@${artifact.version}`)
     }
-    if (data.artifacts.added.length > 10) {
-      logger.log(`  … and ${data.artifacts.added.length - 10} more`)
+    if (diffScan.artifacts.added.length > 10) {
+      logger.log(`  … and ${diffScan.artifacts.added.length - 10} more`)
     }
   }
 
-  logger.log(`- Removed packages: ${data.artifacts.removed.length}`)
-  if (data.artifacts.removed.length > 0) {
-    const removedHead = data.artifacts.removed.slice(0, 10)
+  logger.log(`- Removed packages: ${diffScan.artifacts.removed.length}`)
+  if (diffScan.artifacts.removed.length > 0) {
+    const removedHead = diffScan.artifacts.removed.slice(0, 10)
     for (let i = 0, { length } = removedHead; i < length; i += 1) {
       const artifact = removedHead[i]!
       logger.log(`  - ${artifact.type} ${artifact.name}@${artifact.version}`)
     }
-    if (data.artifacts.removed.length > 10) {
-      logger.log(`  … and ${data.artifacts.removed.length - 10} more`)
+    if (diffScan.artifacts.removed.length > 10) {
+      logger.log(`  … and ${diffScan.artifacts.removed.length - 10} more`)
     }
   }
 
-  logger.log(`- Replaced packages: ${data.artifacts.replaced.length}`)
-  if (data.artifacts.replaced.length > 0) {
-    const replacedHead = data.artifacts.replaced.slice(0, 10)
+  logger.log(`- Replaced packages: ${diffScan.artifacts.replaced.length}`)
+  if (diffScan.artifacts.replaced.length > 0) {
+    const replacedHead = diffScan.artifacts.replaced.slice(0, 10)
     for (let i = 0, { length } = replacedHead; i < length; i += 1) {
       const artifact = replacedHead[i]!
       logger.log(`  - ${artifact.type} ${artifact.name}@${artifact.version}`)
     }
-    if (data.artifacts.replaced.length > 10) {
-      logger.log(`  … and ${data.artifacts.replaced.length - 10} more`)
+    if (diffScan.artifacts.replaced.length > 10) {
+      logger.log(`  … and ${diffScan.artifacts.replaced.length - 10} more`)
     }
   }
 
-  logger.log(`- Updated packages: ${data.artifacts.updated.length}`)
-  if (data.artifacts.updated.length > 0) {
-    const updatedHead = data.artifacts.updated.slice(0, 10)
+  logger.log(`- Updated packages: ${diffScan.artifacts.updated.length}`)
+  if (diffScan.artifacts.updated.length > 0) {
+    const updatedHead = diffScan.artifacts.updated.slice(0, 10)
     for (let i = 0, { length } = updatedHead; i < length; i += 1) {
       const artifact = updatedHead[i]!
       logger.log(`  - ${artifact.type} ${artifact.name}@${artifact.version}`)
     }
-    if (data.artifacts.updated.length > 10) {
-      logger.log(`  … and ${data.artifacts.updated.length - 10} more`)
+    if (diffScan.artifacts.updated.length > 10) {
+      logger.log(`  … and ${diffScan.artifacts.updated.length - 10} more`)
     }
   }
 
-  const unchanged = data.artifacts.unchanged ?? []
+  const unchanged = diffScan.artifacts.unchanged ?? []
   logger.log(`- Unchanged packages: ${unchanged.length}`)
   if (unchanged.length > 0) {
     const firstUpToTen = unchanged.slice(0, 10)
@@ -126,13 +127,13 @@ export async function handleMarkdown(
   }
 
   logger.log('')
-  logger.log(`## Scan ${data.before.id}`)
+  logger.log(`## Scan ${beforeScan.id}`)
   logger.log('')
   logger.log(
     'This Scan was considered to be the "base" / "from" / "before" Scan.',
   )
   logger.log('')
-  for (const { 0: key, 1: value } of Object.entries(data.before)) {
+  for (const { 0: key, 1: value } of Object.entries(beforeScan)) {
     if (key === 'pull_request' && !value) {
       continue
     }
@@ -145,11 +146,11 @@ export async function handleMarkdown(
   }
 
   logger.log('')
-  logger.log(`## Scan ${data.after.id}`)
+  logger.log(`## Scan ${afterScan.id}`)
   logger.log('')
   logger.log('This Scan was considered to be the "head" / "to" / "after" Scan.')
   logger.log('')
-  for (const { 0: key, 1: value } of Object.entries(data.after)) {
+  for (const { 0: key, 1: value } of Object.entries(afterScan)) {
     if (key === 'pull_request' && !value) {
       continue
     }
@@ -165,7 +166,7 @@ export async function handleMarkdown(
 }
 
 export async function outputDiffScan(
-  result: CResult<SocketSdkSuccessResult<'GetOrgDiffScan'>['data']>,
+  result: CResult<SocketSdkSuccessResult<'getDiffScanById'>['data']>,
   {
     depth,
     file,
@@ -189,7 +190,7 @@ export async function outputDiffScan(
     return
   }
 
-  const dashboardUrl = result.data.diff_report_url
+  const dashboardUrl = result.data.diff_scan.html_url
   const dashboardMessage = dashboardUrl
     ? `\n View this diff scan in the Socket dashboard: ${colors.cyan(dashboardUrl)}`
     : ''

--- a/packages/cli/test/integration/cli/cmd-scan-diff.test.mts
+++ b/packages/cli/test/integration/cli/cmd-scan-diff.test.mts
@@ -38,8 +38,7 @@ describe('socket scan diff', async () => {
                 $ socket scan diff [options] <SCAN_ID1> <SCAN_ID2>
           
               API Token Requirements
-                - Quota: 1 unit
-                - Permissions: full-scans:list
+                - Permissions: diff-scans:create, diff-scans:list, and full-scans:list
           
               This command displays the package changes between two scans. The full output
               can be pretty large depending on the size of your repo and time range. It is

--- a/packages/cli/test/unit/commands/scan/fetch-diff-scan.test.mts
+++ b/packages/cli/test/unit/commands/scan/fetch-diff-scan.test.mts
@@ -12,14 +12,21 @@
  * Testing Approach: Uses SDK test helpers to mock Socket API interactions.
  * Validates comprehensive error handling and API integration.
  *
- * Related Files: - src/commands/DiffScan.mts (implementation)
+ * Related Files: - src/commands/scan/fetch-diff-scan.mts (implementation)
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import {
+  setupSdkSetupFailure,
+} from '../../../helpers/sdk-test-helpers.mts'
 import { fetchDiffScan } from '../../../../src/commands/scan/fetch-diff-scan.mts'
 
-// Mock the dependencies.
+import type * as ApiModule from '../../../../src/util/socket/api.mts'
+import type * as SdkModule from '../../../../src/util/socket/sdk.mts'
+import type { Mock } from 'vitest'
+
+// Mock the logger.
 const mockLogger = vi.hoisted(() => ({
   fail: vi.fn(),
   log: vi.fn(),
@@ -29,44 +36,138 @@ const mockLogger = vi.hoisted(() => ({
   error: vi.fn(),
 }))
 
-const mockQueryApiSafeJson = vi.hoisted(() => vi.fn())
-const mockGetDefaultApiToken = vi.hoisted(() => vi.fn(() => 'test-token'))
-
 vi.mock(import('@socketsecurity/lib-stable/logger/default'), () => ({
   getDefaultLogger: () => mockLogger,
   logger: mockLogger,
 }))
 
-vi.mock(import('../../../../src/util/socket/api.mjs'), () => ({
-  queryApiSafeJson: mockQueryApiSafeJson,
+vi.mock(import('../../../../src/util/socket/api.mts'), () => ({
+  handleApiCall: vi.fn(),
 }))
 
 vi.mock(import('../../../../src/util/socket/sdk.mts'), () => ({
-  getDefaultApiToken: mockGetDefaultApiToken,
+  setupSdk: vi.fn(),
 }))
 
+async function getMockHandleApiCall(): Promise<Mock> {
+  const module = await vi.importMock<typeof ApiModule>(
+    '../../../../src/util/socket/api.mts',
+  )
+  return vi.mocked(module.handleApiCall)
+}
+
+async function getMockSetupSdk(): Promise<Mock> {
+  const module = await vi.importMock<typeof SdkModule>(
+    '../../../../src/util/socket/sdk.mts',
+  )
+  return vi.mocked(module.setupSdk)
+}
+
+// Helper to create a mock diff scan response (getDiffScanById shape).
+function createMockDiffScanData(overrides = {}) {
+  return {
+    diff_scan: {
+      id: 'diff-scan-001',
+      organization_id: 'org-1',
+      repository_id: 'repo-1',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+      before_full_scan: {
+        id: 'scan-before',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+        organization_id: 'org-1',
+        organization_slug: 'test-org',
+        repository_id: 'repo-1',
+        repository_slug: 'test-repo',
+        branch: 'main',
+        commit_message: null,
+        commit_hash: null,
+        pull_request: null,
+        committers: [],
+        html_url: null,
+        api_url: null,
+      },
+      after_full_scan: {
+        id: 'scan-after',
+        created_at: '2024-01-02T00:00:00Z',
+        updated_at: '2024-01-02T00:00:00Z',
+        organization_id: 'org-1',
+        organization_slug: 'test-org',
+        repository_id: 'repo-1',
+        repository_slug: 'test-repo',
+        branch: 'feature',
+        commit_message: null,
+        commit_hash: null,
+        pull_request: null,
+        committers: [],
+        html_url: null,
+        api_url: null,
+      },
+      description: null,
+      external_href: null,
+      merge: false,
+      html_url: 'https://socket.dev/diff/123',
+      api_url: null,
+      incomplete: false,
+      artifacts: {
+        added: [],
+        removed: [],
+        unchanged: [],
+        replaced: [],
+        updated: [],
+      },
+      ...overrides,
+    },
+  }
+}
+
+// Helper to create a mock create result (createOrgDiffScanFromIds shape).
+function createMockCreateData(diffScanId = 'diff-scan-001') {
+  return {
+    diff_scan: {
+      id: diffScanId,
+      organization_id: 'org-1',
+      repository_id: 'repo-1',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    },
+  }
+}
+
 describe('fetchDiffScan', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
+    const setupSdk = await getMockSetupSdk()
+    const handleApiCall = await getMockHandleApiCall()
+    setupSdk.mockReset()
+    handleApiCall.mockReset()
   })
 
   it('fetches diff scan successfully', async () => {
-    const mockQueryApi = mockQueryApiSafeJson
+    const setupSdk = await getMockSetupSdk()
+    const handleApiCall = await getMockHandleApiCall()
 
-    const mockDiffData = {
-      added: ['package-a@1.0.0'],
-      removed: ['package-b@1.0.0'],
-      modified: ['package-c@1.0.0 -> 1.1.0'],
-      issues: {
-        new: ['CVE-2023-001'],
-        resolved: ['CVE-2023-002'],
-      },
+    const mockSdk = {
+      createOrgDiffScanFromIds: vi.fn().mockResolvedValue({
+        success: true,
+        data: createMockCreateData('diff-scan-001'),
+      }),
+      getDiffScanById: vi.fn().mockResolvedValue({
+        success: true,
+        data: createMockDiffScanData(),
+      }),
     }
 
-    mockQueryApi.mockResolvedValue({
-      ok: true,
-      data: mockDiffData,
-    })
+    setupSdk.mockResolvedValue({ ok: true, data: mockSdk })
+
+    const mockDiffData = createMockDiffScanData()
+    handleApiCall
+      .mockResolvedValueOnce({
+        ok: true,
+        data: createMockCreateData('diff-scan-001'),
+      })
+      .mockResolvedValueOnce({ ok: true, data: mockDiffData })
 
     const result = await fetchDiffScan({
       id1: 'scan-123',
@@ -79,24 +180,50 @@ describe('fetchDiffScan', () => {
     expect(mockLogger.info).toHaveBeenCalledWith(
       'Note: this request may take some time if the scans are big',
     )
-    expect(mockQueryApi).toHaveBeenCalledWith(
-      'orgs/test-org/full-scans/diff?before=scan-123&after=scan-456',
-      'a scan diff',
+    expect(mockSdk.createOrgDiffScanFromIds).toHaveBeenCalledWith('test-org', {
+      before: 'scan-123',
+      after: 'scan-456',
+    })
+    expect(mockSdk.getDiffScanById).toHaveBeenCalledWith(
+      'test-org',
+      'diff-scan-001',
+      { cached: true },
     )
     expect(result.ok).toBe(true)
     expect(result.data).toEqual(mockDiffData)
   })
 
-  it('handles API call failure', async () => {
-    const mockQueryApi = mockQueryApiSafeJson
+  it('handles SDK setup failure', async () => {
+    await setupSdkSetupFailure('Failed to setup SDK', {
+      code: 1,
+      cause: 'Authentication failed',
+    })
 
-    const error = {
-      ok: false,
-      code: 404,
-      message: 'Scan not found',
-      cause: 'One or both scans do not exist',
+    const result = await fetchDiffScan({
+      id1: 'scan-123',
+      id2: 'scan-456',
+      orgSlug: 'test-org',
+    })
+
+    expect(result.ok).toBe(false)
+  })
+
+  it('handles createOrgDiffScanFromIds failure', async () => {
+    const setupSdk = await getMockSetupSdk()
+    const handleApiCall = await getMockHandleApiCall()
+
+    const mockSdk = {
+      createOrgDiffScanFromIds: vi.fn(),
+      getDiffScanById: vi.fn(),
     }
-    mockQueryApi.mockResolvedValue(error)
+
+    setupSdk.mockResolvedValue({ ok: true, data: mockSdk })
+    handleApiCall.mockResolvedValueOnce({
+      ok: false,
+      message: 'Socket API error',
+      code: 404,
+      cause: 'Scan not found',
+    })
 
     const result = await fetchDiffScan({
       id1: 'nonexistent-scan',
@@ -104,39 +231,61 @@ describe('fetchDiffScan', () => {
       orgSlug: 'test-org',
     })
 
-    expect(result).toEqual(error)
+    expect(result.ok).toBe(false)
+    expect(result.code).toBe(404)
+    // getDiffScanById should not be called when create fails
+    expect(mockSdk.getDiffScanById).not.toHaveBeenCalled()
   })
 
-  it('properly URL encodes scan IDs', async () => {
-    const mockQueryApi = mockQueryApiSafeJson
+  it('handles getDiffScanById failure', async () => {
+    const setupSdk = await getMockSetupSdk()
+    const handleApiCall = await getMockHandleApiCall()
 
-    mockQueryApi.mockResolvedValue({
-      ok: true,
-      data: {},
-    })
+    const mockSdk = {
+      createOrgDiffScanFromIds: vi.fn(),
+      getDiffScanById: vi.fn(),
+    }
 
-    const specialCharsId1 = 'scan+with%special&chars'
-    const specialCharsId2 = 'another/scan?with=query'
+    setupSdk.mockResolvedValue({ ok: true, data: mockSdk })
+    handleApiCall
+      .mockResolvedValueOnce({
+        ok: true,
+        data: createMockCreateData('diff-scan-001'),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        message: 'Socket API error',
+        code: 504,
+        cause: 'Gateway timeout',
+      })
 
-    await fetchDiffScan({
-      id1: specialCharsId1,
-      id2: specialCharsId2,
+    const result = await fetchDiffScan({
+      id1: 'large-scan-1',
+      id2: 'large-scan-2',
       orgSlug: 'test-org',
     })
 
-    expect(mockQueryApi).toHaveBeenCalledWith(
-      'orgs/test-org/full-scans/diff?before=scan%2Bwith%25special%26chars&after=another%2Fscan%3Fwith%3Dquery',
-      'a scan diff',
-    )
+    expect(result.ok).toBe(false)
+    expect(result.code).toBe(504)
   })
 
   it('handles different org slugs', async () => {
-    const mockQueryApi = mockQueryApiSafeJson
+    const setupSdk = await getMockSetupSdk()
+    const handleApiCall = await getMockHandleApiCall()
 
-    mockQueryApi.mockResolvedValue({
-      ok: true,
-      data: {},
-    })
+    const mockSdk = {
+      createOrgDiffScanFromIds: vi.fn().mockResolvedValue({
+        success: true,
+        data: createMockCreateData(),
+      }),
+      getDiffScanById: vi.fn().mockResolvedValue({
+        success: true,
+        data: createMockDiffScanData(),
+      }),
+    }
+
+    setupSdk.mockResolvedValue({ ok: true, data: mockSdk })
+    handleApiCall.mockResolvedValue({ ok: true, data: createMockDiffScanData() })
 
     const testCases = [
       'org-with-dashes',
@@ -153,30 +302,27 @@ describe('fetchDiffScan', () => {
         orgSlug,
       })
 
-      expect(mockQueryApi).toHaveBeenCalledWith(
-        `orgs/${orgSlug}/full-scans/diff?before=scan-1&after=scan-2`,
-        'a scan diff',
-      )
+      expect(mockSdk.createOrgDiffScanFromIds).toHaveBeenCalledWith(orgSlug, {
+        before: 'scan-1',
+        after: 'scan-2',
+      })
     }
   })
 
   it('handles empty diff results', async () => {
-    const mockQueryApi = mockQueryApiSafeJson
+    const setupSdk = await getMockSetupSdk()
+    const handleApiCall = await getMockHandleApiCall()
 
-    const emptyDiffData = {
-      added: [],
-      removed: [],
-      modified: [],
-      issues: {
-        new: [],
-        resolved: [],
-      },
+    const mockSdk = {
+      createOrgDiffScanFromIds: vi.fn(),
+      getDiffScanById: vi.fn(),
     }
 
-    mockQueryApi.mockResolvedValue({
-      ok: true,
-      data: emptyDiffData,
-    })
+    setupSdk.mockResolvedValue({ ok: true, data: mockSdk })
+    const emptyDiffData = createMockDiffScanData()
+    handleApiCall
+      .mockResolvedValueOnce({ ok: true, data: createMockCreateData() })
+      .mockResolvedValueOnce({ ok: true, data: emptyDiffData })
 
     const result = await fetchDiffScan({
       id1: 'scan-identical-1',
@@ -189,17 +335,18 @@ describe('fetchDiffScan', () => {
   })
 
   it('handles same scan IDs gracefully', async () => {
-    const mockQueryApi = mockQueryApiSafeJson
+    const setupSdk = await getMockSetupSdk()
+    const handleApiCall = await getMockHandleApiCall()
 
-    mockQueryApi.mockResolvedValue({
-      ok: true,
-      data: {
-        added: [],
-        removed: [],
-        modified: [],
-        issues: { new: [], resolved: [] },
-      },
-    })
+    const mockSdk = {
+      createOrgDiffScanFromIds: vi.fn(),
+      getDiffScanById: vi.fn(),
+    }
+
+    setupSdk.mockResolvedValue({ ok: true, data: mockSdk })
+    handleApiCall
+      .mockResolvedValueOnce({ ok: true, data: createMockCreateData() })
+      .mockResolvedValueOnce({ ok: true, data: createMockDiffScanData() })
 
     await fetchDiffScan({
       id1: 'same-scan-id',
@@ -209,48 +356,36 @@ describe('fetchDiffScan', () => {
 
     expect(mockLogger.info).toHaveBeenCalledWith('Scan ID 1:', 'same-scan-id')
     expect(mockLogger.info).toHaveBeenCalledWith('Scan ID 2:', 'same-scan-id')
-    expect(mockQueryApi).toHaveBeenCalledWith(
-      'orgs/test-org/full-scans/diff?before=same-scan-id&after=same-scan-id',
-      'a scan diff',
-    )
+    expect(mockSdk.createOrgDiffScanFromIds).toHaveBeenCalledWith('test-org', {
+      before: 'same-scan-id',
+      after: 'same-scan-id',
+    })
   })
 
-  it('handles server timeout gracefully', async () => {
-    const mockQueryApi = mockQueryApiSafeJson
+  it('passes cached: true to getDiffScanById', async () => {
+    const setupSdk = await getMockSetupSdk()
+    const handleApiCall = await getMockHandleApiCall()
 
-    const timeoutError = {
-      ok: false,
-      code: 504,
-      message: 'Gateway timeout',
-      cause: 'The request took too long to process',
+    const mockSdk = {
+      createOrgDiffScanFromIds: vi.fn(),
+      getDiffScanById: vi.fn(),
     }
-    mockQueryApi.mockResolvedValue(timeoutError)
 
-    const result = await fetchDiffScan({
-      id1: 'large-scan-1',
-      id2: 'large-scan-2',
-      orgSlug: 'test-org',
-    })
+    setupSdk.mockResolvedValue({ ok: true, data: mockSdk })
+    handleApiCall
+      .mockResolvedValueOnce({ ok: true, data: createMockCreateData() })
+      .mockResolvedValueOnce({ ok: true, data: createMockDiffScanData() })
 
-    expect(result).toEqual(timeoutError)
-  })
-
-  it('uses null prototype internally', async () => {
-    const mockQueryApi = mockQueryApiSafeJson
-
-    mockQueryApi.mockResolvedValue({
-      ok: true,
-      data: {},
-    })
-
-    // This tests that the function works without prototype pollution issues.
     await fetchDiffScan({
       id1: 'scan-1',
       id2: 'scan-2',
       orgSlug: 'test-org',
     })
 
-    // The function should work properly.
-    expect(mockQueryApi).toHaveBeenCalled()
+    expect(mockSdk.getDiffScanById).toHaveBeenCalledWith(
+      'test-org',
+      'diff-scan-001',
+      { cached: true },
+    )
   })
 })

--- a/packages/cli/test/unit/commands/scan/fetch-diff-scan.test.mts
+++ b/packages/cli/test/unit/commands/scan/fetch-diff-scan.test.mts
@@ -183,6 +183,7 @@ describe('fetchDiffScan', () => {
     expect(mockSdk.createOrgDiffScanFromIds).toHaveBeenCalledWith('test-org', {
       before: 'scan-123',
       after: 'scan-456',
+      on_duplicate: 'redirect',
     })
     expect(mockSdk.getDiffScanById).toHaveBeenCalledWith(
       'test-org',
@@ -305,6 +306,7 @@ describe('fetchDiffScan', () => {
       expect(mockSdk.createOrgDiffScanFromIds).toHaveBeenCalledWith(orgSlug, {
         before: 'scan-1',
         after: 'scan-2',
+        on_duplicate: 'redirect',
       })
     }
   })

--- a/packages/cli/test/unit/commands/scan/output-diff-scan-markdown.test.mts
+++ b/packages/cli/test/unit/commands/scan/output-diff-scan-markdown.test.mts
@@ -69,39 +69,50 @@ vi.mock(import('node:fs'), () => ({
 
 import { outputDiffScan } from '../../../../src/commands/scan/output-diff-scan.mts'
 
-// Helper to create mock diff scan data.
+// Helper to create mock diff scan data (getDiffScanById response shape).
 function createMockDiffData(overrides = {}) {
   return {
-    diff_report_url: 'https://socket.dev/diff/123',
-    directDependenciesChanged: true,
-    before: {
-      id: 'scan-before',
+    diff_scan: {
+      id: 'diff-scan-001',
       organization_id: 'org-1',
-      organization_slug: 'test-org',
       repository_id: 'repo-1',
-      repository_slug: 'test-repo',
-      branch: 'main',
       created_at: '2024-01-01T00:00:00Z',
-      pull_request: undefined,
+      updated_at: '2024-01-01T00:00:00Z',
+      before_full_scan: {
+        id: 'scan-before',
+        organization_id: 'org-1',
+        organization_slug: 'test-org',
+        repository_id: 'repo-1',
+        repository_slug: 'test-repo',
+        branch: 'main',
+        created_at: '2024-01-01T00:00:00Z',
+        pull_request: undefined,
+      },
+      after_full_scan: {
+        id: 'scan-after',
+        organization_id: 'org-1',
+        organization_slug: 'test-org',
+        repository_id: 'repo-1',
+        repository_slug: 'test-repo',
+        branch: 'feature',
+        created_at: '2024-01-02T00:00:00Z',
+        pull_request: undefined,
+      },
+      description: null,
+      external_href: null,
+      merge: false,
+      html_url: 'https://socket.dev/diff/123',
+      api_url: null,
+      incomplete: false,
+      artifacts: {
+        added: [],
+        removed: [],
+        replaced: [],
+        updated: [],
+        unchanged: [],
+      },
+      ...overrides,
     },
-    after: {
-      id: 'scan-after',
-      organization_id: 'org-1',
-      organization_slug: 'test-org',
-      repository_id: 'repo-1',
-      repository_slug: 'test-repo',
-      branch: 'feature',
-      created_at: '2024-01-02T00:00:00Z',
-      pull_request: undefined,
-    },
-    artifacts: {
-      added: [],
-      removed: [],
-      replaced: [],
-      updated: [],
-      unchanged: [],
-    },
-    ...overrides,
   }
 }
 

--- a/packages/cli/test/unit/commands/scan/output-diff-scan.test.mts
+++ b/packages/cli/test/unit/commands/scan/output-diff-scan.test.mts
@@ -79,39 +79,50 @@ export function createErrorResult(
   return { ok: false, message, ...options }
 }
 
-// Helper to create mock diff scan data.
+// Helper to create mock diff scan data (getDiffScanById response shape).
 function createMockDiffData(overrides = {}) {
   return {
-    diff_report_url: 'https://socket.dev/diff/123',
-    directDependenciesChanged: true,
-    before: {
-      id: 'scan-before',
+    diff_scan: {
+      id: 'diff-scan-001',
       organization_id: 'org-1',
-      organization_slug: 'test-org',
       repository_id: 'repo-1',
-      repository_slug: 'test-repo',
-      branch: 'main',
       created_at: '2024-01-01T00:00:00Z',
-      pull_request: undefined,
+      updated_at: '2024-01-01T00:00:00Z',
+      before_full_scan: {
+        id: 'scan-before',
+        organization_id: 'org-1',
+        organization_slug: 'test-org',
+        repository_id: 'repo-1',
+        repository_slug: 'test-repo',
+        branch: 'main',
+        created_at: '2024-01-01T00:00:00Z',
+        pull_request: undefined,
+      },
+      after_full_scan: {
+        id: 'scan-after',
+        organization_id: 'org-1',
+        organization_slug: 'test-org',
+        repository_id: 'repo-1',
+        repository_slug: 'test-repo',
+        branch: 'feature',
+        created_at: '2024-01-02T00:00:00Z',
+        pull_request: undefined,
+      },
+      description: null,
+      external_href: null,
+      merge: false,
+      html_url: 'https://socket.dev/diff/123',
+      api_url: null,
+      incomplete: false,
+      artifacts: {
+        added: [],
+        removed: [],
+        replaced: [],
+        updated: [],
+        unchanged: [],
+      },
+      ...overrides,
     },
-    after: {
-      id: 'scan-after',
-      organization_id: 'org-1',
-      organization_slug: 'test-org',
-      repository_id: 'repo-1',
-      repository_slug: 'test-repo',
-      branch: 'feature',
-      created_at: '2024-01-02T00:00:00Z',
-      pull_request: undefined,
-    },
-    artifacts: {
-      added: [],
-      removed: [],
-      replaced: [],
-      updated: [],
-      unchanged: [],
-    },
-    ...overrides,
   }
 }
 
@@ -305,7 +316,7 @@ describe('outputDiffScan', () => {
     })
 
     it('handles missing dashboard URL', async () => {
-      const mockData = createMockDiffData({ diff_report_url: undefined })
+      const mockData = createMockDiffData({ html_url: undefined })
       const result = createSuccessResult(mockData)
 
       await outputDiffScan(result as unknown, {


### PR DESCRIPTION
LLM Description written by Claude Code:glm-fast-latest[1m]
-----

This PR changes how `socket scan diff` asks the Socket API for a diff, so the command stops timing out on large scans. Instead of one long-lived request that blocks until the diff is fully computed, the CLI now creates a diff-scan resource and then polls a cached endpoint until the result is ready. This is the client-side half of the fix for the 1200-second timeout family (SURF-1487 / SURF-1044 / SURF-1364); the server-side immutable-queue routing already landed in the API service (PR #21167).

<details><summary><b>Why we're making this change</b></summary>

When you run `socket scan diff`, the CLI used to send a single request to the old `GET /full-scans/diff` endpoint and hold the connection open while the server computed the whole diff. For big scans that take longer than 1200 seconds, the SDK's fixed per-request timeout fires before the server finishes, and the command fails with `API request failed`. The `--timeout` flag does not help because it controls the overall scan budget, not the per-request ceiling. This is the same root cause behind the ID.me, ZeroFox, and Prometheus CI scan timeouts.

The new endpoints split the work into two steps. The server enqueues a background job to compute the diff and stores the result in an immutable cache. The CLI polls a short request that returns `202 Accepted` while the job is running, then `200 OK` with the finished diff. No single request is held open for the whole compute, so the 1200-second timeout no longer fires.

</details>

<details><summary><b>Old flow vs new flow</b></summary>

Old flow (one long-lived request):

```
CLI ── GET /full-scans/diff?before=X&after=Y ──> API
CLI <────────────── diff result ──────────────── API
(one connection held open the whole time; >1200s = timeout failure)
```

New flow (create once, poll until ready):

```
CLI ── POST /diff-scans/from-ids {before,after} ──> API   → 201 { diff_scan: { id } }
CLI ── GET /diff-scans/{id}?cached=true ──────────> API   → 202 { status: "processing" }
CLI ── GET /diff-scans/{id}?cached=true ──────────> API   → 202 (still computing)
CLI ── GET /diff-scans/{id}?cached=true ──────────> API   → 200 { diff_scan: { …artifacts… } }
(each GET is short; the SDK retries on 202 until 200)
```

</details>

<details><summary><b>What changed in the code</b></summary>

- `src/commands/scan/fetch-diff-scan.mts` — this is the main change. It used to call the old endpoint directly with `queryApiSafeJson`. Now it gets the SDK client with `setupSdk()`, calls `createOrgDiffScanFromIds(orgSlug, { before, after })` to create the diff-scan resource, then calls `getDiffScanById(orgSlug, diffScanId, { cached: true })` to fetch the result. The SDK handles the 202 polling loop automatically, so the caller just gets the final 200. The create step is idempotent, so re-running over the same pair of scans returns the existing diff-scan id instead of making a new one.
- `src/commands/scan/output-diff-scan.mts` — the response shape from the new endpoint is nested under `data.diff_scan` instead of being flat. So `data.before` is now `data.diff_scan.before_full_scan`, `data.after` is `data.diff_scan.after_full_scan`, and the dashboard link moved from `data.diff_report_url` to `data.diff_scan.html_url`. The code that prints the markdown table and the before/after scan details was updated to read from the nested shape.
- `data/command-api-requirements.json` — the `scan:diff` command's quota dropped from 1 to 0 (the new endpoints are free) and its permissions now list `diff-scans:create`, `diff-scans:list`, and `full-scans:list`, matching the scopes the new endpoints require.
- Tests — the unit tests for `fetch-diff-scan`, `output-diff-scan`, `output-diff-scan-markdown`, and `cmd-scan-diff` were updated to mock the new two-step flow and the nested response shape. 56 unit tests pass and the typecheck is clean on the changed files.

</details>

<details><summary><b>Field-name differences from the old endpoint</b></summary>

Two fields changed names between the old `GetOrgDiffScan` response and the new `getDiffScanById` response, and one was removed:

- The dashboard report link was `data.diff_report_url` on the old endpoint. On the new endpoint it is `data.diff_scan.html_url`.
- The before/after scans were `data.before` / `data.after` (flat). They are now `data.diff_scan.before_full_scan` / `data.diff_scan.after_full_scan` (nested under `diff_scan`).
- The old endpoint returned a `directDependenciesChanged` boolean. The new endpoint does not have this field, so the markdown output no longer prints that line.

</details>

Refs SURF-743.
