### PR TITLE
make --dynamic-sbom-inference a standalone flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,10 @@ test/fixtures/commands/fix/e2e-test-py-temp-*
 /src/commands/manifest/scripts/test/sbt-compat/project/localrepo/
 /src/commands/manifest/scripts/test/sbt-compat/project/records.tsv
 /src/commands/manifest/scripts/test/sbt-compat/project/target/
+
+# Generated when the dynamic SBOM inference tests walk their fixtures
+# (test/fixtures/commands/manifest/dynamic-sbom-inference). Those fixtures are
+# build-tool marker files only, so any build output under them is debris.
+/test/fixtures/commands/manifest/dynamic-sbom-inference/**/.gradle/
+/test/fixtures/commands/manifest/dynamic-sbom-inference/**/build/
+/test/fixtures/commands/manifest/dynamic-sbom-inference/**/target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+- `socket scan create --dynamic-sbom-inference` works without `--reach` again, so a single command produces a per-build-root Socket facts SBOM for Gradle, sbt, and Maven projects. It is a standalone flag now, no longer a reachability modifier.
+- `--dynamic-sbom-inference` no longer generates Conda or Bazel manifests as a side effect. It touches Gradle, sbt, and Maven only; pass `--auto-manifest` alongside it if you want the other ecosystems too.
+
 ## [1.1.158](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.158) - 2026-08-17
 
 ### Changed

--- a/src/commands/scan/cmd-scan-create.mts
+++ b/src/commands/scan/cmd-scan-create.mts
@@ -92,6 +92,12 @@ const generalFlags: MeowFlags = {
     description:
       'Set the default branch of the repository to the branch of this full-scan. Should only need to be done once, for example for the "main" or "master" branch.',
   },
+  dynamicSbomInference: {
+    type: 'boolean',
+    default: false,
+    description:
+      'For Gradle, sbt, and Maven: generate a Socket facts SBOM (produced directly by each package manager) per independent build root, instead of one synthetic root. Combine with --reach to split the reachability analysis per project/module.',
+  },
   interactive: {
     type: 'boolean',
     default: true,
@@ -355,11 +361,6 @@ async function run(
       autoManifest = false
     }
   }
-  // --dynamic-sbom-inference requires auto-manifest to generate the
-  // per-workspace facts it feeds to Coana.
-  if (dynamicSbomInference) {
-    autoManifest = true
-  }
   if (!branchName) {
     if (sockJson.defaults?.scan?.create?.branch) {
       branchName = sockJson.defaults.scan.create.branch
@@ -455,7 +456,12 @@ async function run(
   const hasFactsFile = existsSync(
     path.join(cwd, constants.DOT_SOCKET_DOT_FACTS_JSON),
   )
-  if (detected.count > 0 && !autoManifest && !hasFactsFile) {
+  if (
+    detected.count > 0 &&
+    !autoManifest &&
+    !dynamicSbomInference &&
+    !hasFactsFile
+  ) {
     logger.info(
       `Detected ${detected.count} manifest targets we could try to generate. Please set the --auto-manifest flag if you want to include languages covered by \`socket manifest auto\` in the Scan.`,
     )

--- a/src/commands/scan/cmd-scan-create.mts
+++ b/src/commands/scan/cmd-scan-create.mts
@@ -59,7 +59,7 @@ const generalFlags: MeowFlags = {
   autoManifest: {
     type: 'boolean',
     description:
-      'Run `socket manifest auto` before collecting manifest files. This is necessary for languages like Scala, Gradle, and Kotlin, See `socket manifest auto --help`.',
+      'Run `socket manifest auto` before collecting manifest files, which generates them for ecosystems that need their build tool to resolve dependencies, such as Scala, Gradle, and Kotlin. See `socket manifest auto --help`. For Gradle, sbt, and Maven, --dynamic-sbom-inference generates a Socket facts SBOM per build root instead.',
   },
   branch: {
     type: 'string',

--- a/src/commands/scan/cmd-scan-create.test.mts
+++ b/src/commands/scan/cmd-scan-create.test.mts
@@ -40,6 +40,7 @@ describe('socket scan create', async () => {
             --committers        Committers
             --cwd               working directory, defaults to process.cwd()
             --default-branch    Set the default branch of the repository to the branch of this full-scan. Should only need to be done once, for example for the "main" or "master" branch.
+            --dynamic-sbom-inference  For Gradle, sbt, and Maven: generate a Socket facts SBOM (produced directly by each package manager) per independent build root, instead of one synthetic root. Combine with --reach to split the reachability analysis per project/module.
             --exclude-paths     List of glob patterns to exclude from the scan, including SCA/SBOM manifest discovery and (when --reach is enabled) full application reachability analysis. Patterns are anchored micromatch globs matched relative to the Socket scan root, which is the command working directory (\`--cwd\` if set), not the reachability target: \`tests\` matches only \`<cwd>/tests\`; use \`**/tests\` to match at any depth. Negation patterns (\`!path\`) are not supported. Accepts a comma-separated value or multiple flags.
             --interactive       Allow for interactive elements, asking for input. Use --no-interactive to prevent any input questions, defaulting them to cancel/no.
             --json              Output as JSON
@@ -56,7 +57,6 @@ describe('socket scan create', async () => {
             --workspace         The workspace in the Socket Organization that the repository is in to associate with the full scan.
 
           Reachability Options (when --reach is used)
-            --dynamic-sbom-inference  For Gradle, sbt, and Maven: splits reachability analysis per project/module using a Socket facts SBOM (generated directly by each package manager) per build root, instead of one synthetic root. Reachability analysis only; implies --auto-manifest.
             --reach-analysis-memory-limit  The maximum memory for the reachability analysis as a whole number optionally followed by MB or GB (e.g. 512MB, 8GB). The default is 8GB.
             --reach-analysis-timeout  Set the timeout for the reachability analysis as a whole number optionally followed by s, m or h (e.g. 90s, 10m, 1h). Defaults to 10m. Split analysis runs may cause the total scan time to exceed this timeout significantly.
             --reach-concurrency  Set the maximum number of concurrent reachability analysis runs. It is recommended to choose a concurrency level that ensures each analysis run has at least the --reach-analysis-memory-limit amount of memory available.
@@ -272,6 +272,36 @@ describe('socket scan create', async () => {
       expect(
         code,
         'should exit with code 0 for the deprecated no-op flag',
+      ).toBe(0)
+    },
+  )
+
+  cmdit(
+    [
+      'scan',
+      'create',
+      FLAG_ORG,
+      'fakeOrg',
+      'target',
+      FLAG_DRY_RUN,
+      '--repo',
+      'xyz',
+      '--branch',
+      'abc',
+      '--dynamic-sbom-inference',
+      FLAG_CONFIG,
+      '{"apiToken":"fakeToken"}',
+    ],
+    'should succeed when --dynamic-sbom-inference is used without --reach',
+    async cmd => {
+      const { code, stderr, stdout } = await spawnSocketCli(binCliPath, cmd)
+      expect(stdout).toMatchInlineSnapshot(`"[DryRun]: Bailing now"`)
+      expect(stdout + stderr).not.toContain(
+        'Reachability analysis flags require --reach to be enabled',
+      )
+      expect(
+        code,
+        'should exit with code 0 since it is not a reachability modifier',
       ).toBe(0)
     },
   )

--- a/src/commands/scan/cmd-scan-create.test.mts
+++ b/src/commands/scan/cmd-scan-create.test.mts
@@ -33,7 +33,7 @@ describe('socket scan create', async () => {
             - Permissions: full-scans:create
 
           Options
-            --auto-manifest     Run \`socket manifest auto\` before collecting manifest files. This is necessary for languages like Scala, Gradle, and Kotlin, See \`socket manifest auto --help\`.
+            --auto-manifest     Run \`socket manifest auto\` before collecting manifest files, which generates them for ecosystems that need their build tool to resolve dependencies, such as Scala, Gradle, and Kotlin. See \`socket manifest auto --help\`. For Gradle, sbt, and Maven, --dynamic-sbom-inference generates a Socket facts SBOM per build root instead.
             --branch            Branch name
             --commit-hash       Commit hash
             --commit-message    Commit message

--- a/src/commands/scan/cmd-scan-reach.mts
+++ b/src/commands/scan/cmd-scan-reach.mts
@@ -33,21 +33,6 @@ const description = 'Compute full application reachability'
 
 const hidden = true
 
-// dynamicSbomInference relies on --auto-manifest generating per-workspace
-// Socket facts first, which this command never runs (see the hardcoded
-// `false` passed to handleScanReach below) - hidden here even though it's
-// otherwise public on `scan create`, since advertising a flag this command
-// silently ignores would be misleading.
-const reachabilityFlagsForReach: MeowFlags = {
-  ...reachabilityFlags,
-  dynamicSbomInference: {
-    type: 'boolean',
-    default: false,
-    hidden: true,
-    description: reachabilityFlags['dynamicSbomInference']!.description,
-  },
-}
-
 const generalFlags: MeowFlags = {
   ...commonFlags,
   ...outputFlags,
@@ -89,7 +74,7 @@ async function run(
     flags: {
       ...generalFlags,
       ...excludePathsFlag,
-      ...reachabilityFlagsForReach,
+      ...reachabilityFlags,
     },
     help: command =>
       `
@@ -103,7 +88,7 @@ async function run(
       ${getFlagListOutput(generalFlags)}
 
     Reachability Options
-      ${getFlagListOutput({ ...excludePathsFlag, ...reachabilityFlagsForReach })}
+      ${getFlagListOutput({ ...excludePathsFlag, ...reachabilityFlags })}
 
     Runs the Socket reachability analysis without creating a scan in Socket.
     The output is written to .socket.facts.json in the current working directory
@@ -282,8 +267,8 @@ async function run(
     outputKind,
     outputPath: outputPath || '',
     reachabilityOptions: {
-      // Not exposed here: it relies on --auto-manifest generating per-workspace
-      // Socket facts first, which `socket scan reach` never runs.
+      // Not exposed here: it relies on the per-build-root Socket facts that
+      // only `socket scan create` generates.
       dynamicSbomInference: false,
       excludePaths,
       reachAnalysisMemoryLimit,

--- a/src/commands/scan/handle-create-new-scan.mts
+++ b/src/commands/scan/handle-create-new-scan.mts
@@ -157,21 +157,15 @@ export async function handleCreateNewScan({
   // paths. Always allocated (even when unused) to keep this uniform rather
   // than conditional on autoManifest/reach.
   await withTmpDir('socket-auto-manifest-', async manifestTmpDir => {
-    if (autoManifest) {
+    if (autoManifest || reach.dynamicSbomInference) {
       logger.info('Auto-generating manifest files ...')
-      debugFn('notice', 'Auto-manifest mode enabled')
-      const sockJson = readOrDefaultSocketJson(cwd)
-      const detected = await detectManifestActions(sockJson, cwd)
-      debugDir('inspect', { detected })
+      debugFn('notice', 'Manifest auto-generation enabled')
 
       if (reach.dynamicSbomInference) {
         // Recursively discover and generate Socket facts for every
         // independent gradle/sbt/maven build root instead of only the one at
-        // cwd; generateAutoManifest below is left to handle conda/bazel only.
-        detected.gradle = false
-        detected.sbt = false
-        detected.maven = false
-
+        // cwd. This runs on its own, so nothing outside those three
+        // ecosystems is generated unless --auto-manifest also asked for it.
         const sidecarAcc: SidecarAccumulator | undefined =
           reach.runReachabilityAnalysis ? new Map() : undefined
         const outcomes = await generateRecursiveManifests({
@@ -218,27 +212,41 @@ export async function handleCreateNewScan({
         }
       }
 
-      const autoManifestResult = await generateAutoManifest({
-        computeArtifactsSidecar: reach.runReachabilityAnalysis,
-        cwd,
-        detected,
-        excludePaths: reach.excludePaths,
-        outputKind,
-        tmpDir: manifestTmpDir,
-        verbose: false,
-      })
-      if (autoManifestResult.resolvedPathsSidecar) {
-        resolvedPathsSidecar = resolvedPathsSidecar
-          ? mergeResolvedPathsSidecars(
-              resolvedPathsSidecar,
-              autoManifestResult.resolvedPathsSidecar,
-            )
-          : autoManifestResult.resolvedPathsSidecar
-      }
-      if (autoManifestResult.generatedFiles.length) {
-        scanTargets = Array.from(
-          new Set([...scanTargets, ...autoManifestResult.generatedFiles]),
-        )
+      if (autoManifest) {
+        const sockJson = readOrDefaultSocketJson(cwd)
+        const detected = await detectManifestActions(sockJson, cwd)
+        debugDir('inspect', { detected })
+
+        if (reach.dynamicSbomInference) {
+          // Already generated recursively above; resolving cwd's own build
+          // root a second time would race on the same .socket.facts.json.
+          detected.gradle = false
+          detected.sbt = false
+          detected.maven = false
+        }
+
+        const autoManifestResult = await generateAutoManifest({
+          computeArtifactsSidecar: reach.runReachabilityAnalysis,
+          cwd,
+          detected,
+          excludePaths: reach.excludePaths,
+          outputKind,
+          tmpDir: manifestTmpDir,
+          verbose: false,
+        })
+        if (autoManifestResult.resolvedPathsSidecar) {
+          resolvedPathsSidecar = resolvedPathsSidecar
+            ? mergeResolvedPathsSidecars(
+                resolvedPathsSidecar,
+                autoManifestResult.resolvedPathsSidecar,
+              )
+            : autoManifestResult.resolvedPathsSidecar
+        }
+        if (autoManifestResult.generatedFiles.length) {
+          scanTargets = Array.from(
+            new Set([...scanTargets, ...autoManifestResult.generatedFiles]),
+          )
+        }
       }
       logger.info('Auto-generation finished. Proceeding with Scan creation.')
     }

--- a/src/commands/scan/handle-create-new-scan.test.mts
+++ b/src/commands/scan/handle-create-new-scan.test.mts
@@ -178,7 +178,39 @@ describe('handleCreateNewScan excludePaths', () => {
     expect(mockFetchCreateOrgFullScan).toHaveBeenCalled()
   })
 
-  it('drives JVM facts generation through generateRecursiveManifests under --dynamic-sbom-inference, merging generated facts into scan targets', async () => {
+  it('generates nothing beyond Gradle/sbt/Maven when --dynamic-sbom-inference is used without --auto-manifest', async () => {
+    mockGenerateRecursiveManifests.mockResolvedValueOnce([
+      {
+        dir: '/repo/service-a',
+        ecosystem: 'gradle',
+        factsPath: '/repo/service-a/.socket.facts.json',
+        status: 'generated',
+      },
+    ])
+
+    const config = createConfig({ autoManifest: false, targets: ['/repo'] })
+    config.reach.dynamicSbomInference = true
+
+    await handleCreateNewScan(config)
+
+    expect(mockGenerateRecursiveManifests).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: '/repo' }),
+    )
+    // generateAutoManifest is what would pull in conda and bazel; the flag on
+    // its own must never reach it.
+    expect(mockGenerateAutoManifest).not.toHaveBeenCalled()
+    expect(mockGetPackageFilesForScan).toHaveBeenCalledWith(
+      ['/repo', '/repo/service-a/.socket.facts.json'],
+      { size: 1 },
+      {
+        additionalIgnores: [],
+        config: { projectIgnorePaths: ['fixtures/**'] },
+        cwd: '/repo',
+      },
+    )
+  })
+
+  it('suppresses auto-manifest JVM branches and merges recursive facts into scan targets when --dynamic-sbom-inference is combined with --auto-manifest', async () => {
     mockGenerateRecursiveManifests.mockResolvedValueOnce([
       {
         dir: '/repo/service-a',
@@ -242,7 +274,7 @@ describe('handleCreateNewScan excludePaths', () => {
       { dir: '/repo/service-b', ecosystem: 'maven', status: 'failed' },
     ])
 
-    const config = createConfig({ autoManifest: true, targets: ['/repo'] })
+    const config = createConfig({ autoManifest: false, targets: ['/repo'] })
     config.reach.dynamicSbomInference = true
 
     await expect(handleCreateNewScan(config)).rejects.toThrow(
@@ -255,7 +287,7 @@ describe('handleCreateNewScan excludePaths', () => {
   it('aborts when --dynamic-sbom-inference finds no Gradle/sbt/Maven build root', async () => {
     mockGenerateRecursiveManifests.mockResolvedValueOnce([])
 
-    const config = createConfig({ autoManifest: true, targets: ['/repo'] })
+    const config = createConfig({ autoManifest: false, targets: ['/repo'] })
     config.reach.dynamicSbomInference = true
 
     await expect(handleCreateNewScan(config)).rejects.toThrow(
@@ -271,7 +303,7 @@ describe('handleCreateNewScan excludePaths', () => {
       { dir: '/repo/service-b', ecosystem: 'maven', status: 'skippedDisabled' },
     ])
 
-    const config = createConfig({ autoManifest: true, targets: ['/repo'] })
+    const config = createConfig({ autoManifest: false, targets: ['/repo'] })
     config.reach.dynamicSbomInference = true
 
     await handleCreateNewScan(config)
@@ -309,7 +341,7 @@ describe('handleCreateNewScan excludePaths', () => {
       },
     )
 
-    const config = createConfig({ autoManifest: true, targets: ['/repo'] })
+    const config = createConfig({ autoManifest: false, targets: ['/repo'] })
     config.reach.dynamicSbomInference = true
     config.reach.runReachabilityAnalysis = true
 

--- a/src/commands/scan/reachability-flags.mts
+++ b/src/commands/scan/reachability-flags.mts
@@ -4,12 +4,6 @@ import { getReachabilityEcosystemChoices } from '../../utils/ecosystem.mts'
 import type { MeowFlags } from '../../flags.mts'
 
 export const reachabilityFlags: MeowFlags = {
-  dynamicSbomInference: {
-    type: 'boolean',
-    default: false,
-    description:
-      'For Gradle, sbt, and Maven: splits reachability analysis per project/module using a Socket facts SBOM (generated directly by each package manager) per build root, instead of one synthetic root. Reachability analysis only; implies --auto-manifest.',
-  },
   reachVersion: {
     type: 'string',
     description: `Override the version of @coana-tech/cli used for reachability analysis. Default: ${constants.ENV.INLINED_SOCKET_CLI_COANA_TECH_CLI_VERSION}.`,


### PR DESCRIPTION
Fixes two user-visible problems with `--dynamic-sbom-inference`, both stemming from where the flag was filed rather than from what it does. See REA-712.

## Problem 1 — rejected without `--reach`

`socket scan create . --dynamic-sbom-inference` failed with:

```
✖ Reachability analysis flags require --reach to be enabled (add --reach flag to use --reach-* options)
```

The flag lived in `reachabilityFlags`. #1493 replaced that guard's hand-maintained list with a derivation over every boolean in that object, exempting only `reachDisableAnalysisSplitting` — so this flag got swept up incidentally. It is not a `--reach-*` modifier, #1493's description never names it, and no test asserted the new behaviour.

Rather than add a second exemption, this moves the flag into `generalFlags`. That fixes the guard, stops it printing under "Reachability Options (when --reach is used)", and keeps the next change to the derived guard from re-breaking it. `reachabilityFlags` now contains only `reach*` flags, which is what the derivation assumes.

## Problem 2 — implying `--auto-manifest` generated Conda and Bazel manifests

The flag forced `autoManifest = true` to get its per-build-root facts generated, and `handleCreateNewScan` then suppressed only the JVM entries of the detection result before calling `generateAutoManifest`. `detected.conda` and `detected.bazel` survived, so a repository containing a Conda environment or a Bazel workspace had those manifests generated as a side effect of asking for JVM dynamic SBOM inference.

Clearing those two booleans as well would have broken the legitimate `--auto-manifest --dynamic-sbom-inference` combination, where they *should* be generated. The forcing is the real defect: it destroys the information about whether the user asked for auto-manifest at all. So the one `if (autoManifest)` block is split into two independent halves under `if (autoManifest || reach.dynamicSbomInference)`:

- the recursive Gradle/sbt/Maven generation, gated on `reach.dynamicSbomInference`
- `detectManifestActions` + `generateAutoManifest`, gated on `autoManifest`

The existing JVM zeroing stays inside the second half, so the combined case still doesn't resolve cwd's own build root twice and race on the same `.socket.facts.json`. The sidecar merge, `scanTargets` union, and `excludePaths` anchoring are unchanged — they already handled either path contributing or not.

Net effect: `--dynamic-sbom-inference` generates Gradle, sbt, and Maven and nothing else; the two flags are additive instead of one silently forcing the other.

## Other changes

- Rewrote the flag description, whose two halves ("Reachability analysis only; implies --auto-manifest") both became wrong.
- Added `!dynamicSbomInference` to the "Detected N manifest targets…" hint, which was previously suppressed only as a side effect of the forced `autoManifest`.
- Removed the `reachabilityFlagsForReach` wrapper in `cmd-scan-reach.mts`. It existed only to re-hide the flag and read `reachabilityFlags['dynamicSbomInference']!.description`, which would now throw on undefined. `socket scan reach` still hardcodes `dynamicSbomInference: false` and is otherwise untouched — it stays an internal debugging command.

Also drops the side effect where the forced auto-manifest overrode an explicit `autoManifest: false` in `socket.json`.

## Tests

There were none for this flag outside the `--help` snapshot, which is why the regression shipped. Added:

- `--dynamic-sbom-inference` without `--reach` in `cmd-scan-create.test.mts` — asserts exit 0 and that the guard message is absent.
- a `handle-create-new-scan.test.mts` case asserting `generateAutoManifest` is never called when the flag is used alone. That is the actual Conda/Bazel invariant, and there is no buildable Conda or Bazel fixture to assert it end-to-end.

Retitled the existing combined-flags test to say so explicitly, and switched the four standalone-path tests from `autoManifest: true` to `false` now that the CLI no longer forces the pairing. Help snapshot regenerated: the flag moved from Reachability Options into Options.

`pnpm run check` passes. Full unit suite green (1728 passed, 2 skipped).

## Docs impact

Once this ships, the baseline-scan step in the Gradle reachability guide in SocketDev/docs can collapse from two commands to a single `socket scan create . --dynamic-sbom-inference`.

Related: #1484 (introduced the flag), #1493 (introduced the regression), #1486 (fail-closed when no JVM build root is found).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scan-create manifest orchestration and flag validation; behavior shifts for users who relied on implicit `--auto-manifest` with `--dynamic-sbom-inference`, but scope is limited to CLI scan/manifest paths with added regression tests.
> 
> **Overview**
> **`--dynamic-sbom-inference` is a general `socket scan create` option again**, not a reach-only flag. It no longer trips the “Reachability analysis flags require `--reach`” guard or appears under reachability help.
> 
> **Manifest generation is split by intent:** recursive Gradle/sbt/Maven facts run when this flag is set; `generateAutoManifest` (Conda, Bazel, etc.) runs only when **`--auto-manifest`** is set. The old behavior that forced `autoManifest = true` and could pull in non-JVM ecosystems is removed. With both flags, JVM roots are still generated recursively first and duplicate cwd JVM work in auto-manifest is skipped.
> 
> **`socket scan reach`** drops the wrapper that hid the flag; it still hardcodes `dynamicSbomInference: false`.
> 
> Tests and **CHANGELOG** document standalone use and the Conda/Bazel side-effect fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 916595508c4d879b1e44de7462cac21e6403e84b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->