### PR TITLE
feat(login): add socket login --device (RFC 8628 device flow)

### DIFF
--- a/packages/cli/src/commands/login/attempt-device-login.mts
+++ b/packages/cli/src/commands/login/attempt-device-login.mts
@@ -1,0 +1,348 @@
+import { request as nodeHttpRequest } from 'node:http'
+import { request as nodeHttpsRequest } from 'node:https'
+import { setTimeout as sleep } from 'node:timers/promises'
+
+import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent'
+import open from 'open'
+
+import { joinAnd } from '@socketsecurity/lib-stable/arrays/join'
+import { errorMessage } from '@socketsecurity/lib-stable/errors/message'
+import { httpRequest } from '@socketsecurity/lib-stable/http-request/request'
+import { getDefaultLogger } from '@socketsecurity/lib-stable/logger/default'
+import { getDefaultSpinner } from '@socketsecurity/lib-stable/spinner/default'
+import { isUrl } from '@socketsecurity/lib-stable/url/predicates'
+
+import { applyLogin } from './apply-login.mts'
+import {
+  API_V1_OAUTH_URL,
+  SOCKET_CLI_OAUTH_CLIENT_ID,
+} from '../../constants/socket.mts'
+import { CONFIG_KEY_DEFAULT_ORG } from '../../constants/config.mts'
+import { isConfigFromFlag, updateConfigValue } from '../../util/config.mts'
+import { getSocketCliOauthBaseUrl } from '../../env/socket-cli-oauth-base-url.mts'
+import { getSocketCliOauthClientIdOverride } from '../../env/socket-cli-oauth-client-id.mts'
+import { getEnterpriseOrgs, getOrgSlugs } from '../../util/organization.mts'
+import { getDefaultProxyUrl, setupSdk } from '../../util/socket/sdk.mts'
+import { assertSafeEndpointUrl } from '../../util/url/safe-endpoint.mts'
+import { fetchOrganization } from '../organization/fetch-organization-list.mts'
+
+import type { CResult } from '../../types.mts'
+import type { HttpResponse } from '@socketsecurity/lib-stable/http-request/response-types'
+
+const logger = getDefaultLogger()
+
+// RFC 8628 3.2: the server SHOULD return interval; when it omits one, the
+// client MUST default to 5 seconds.
+const DEFAULT_POLL_INTERVAL_SECONDS = 5
+
+// Reasonable default read scopes for a first-party CLI session. The exact
+// set should be confirmed against depscan's scope catalog by whoever
+// registers the `socket-cli` OAuth client.
+const DEFAULT_DEVICE_LOGIN_SCOPES = [
+  'alerts:list',
+  'dependencies:list',
+  'full-scans:list',
+  'diff-scans:list',
+  'packages:list',
+  'repo:list',
+].join(' ')
+
+export interface DeviceAuthorizationResponse {
+  device_code: string
+  user_code: string
+  verification_uri: string
+  verification_uri_complete: string
+  expires_in: number
+  interval?: number | undefined
+}
+
+export interface DeviceTokenSuccessResponse {
+  access_token: string
+  token_type: string
+  expires_in: number
+  refresh_token?: string | undefined
+  scope?: string | undefined
+}
+
+export interface OAuthErrorResponse {
+  error: string
+  error_description?: string | undefined
+}
+
+export class DeviceLoginError extends Error {
+  oauthError: string
+
+  constructor(oauthError: string, description?: string | undefined) {
+    super(description ?? oauthError)
+    this.oauthError = oauthError
+  }
+}
+
+export async function attemptDeviceLogin(
+  apiBaseUrl: string | undefined,
+  apiProxy: string | undefined,
+): Promise<CResult<void>> {
+  const effectiveApiProxy = isUrl(apiProxy) ? apiProxy : getDefaultProxyUrl()
+  const oauthBaseUrl = resolveOauthBaseUrl()
+  const clientId = resolveOauthClientId()
+
+  let deviceAuthorizationUrl: URL
+  let tokenUrl: URL
+  try {
+    const base = assertSafeEndpointUrl(oauthBaseUrl, {
+      label: 'Socket OAuth base URL',
+      source: 'SOCKET_CLI_OAUTH_BASE_URL or the built-in default',
+    })
+    deviceAuthorizationUrl = new URL('device-authorization', base)
+    tokenUrl = new URL('token', base)
+  } catch (e) {
+    const result: CResult<void> = {
+      ok: false,
+      message: 'Invalid OAuth base URL',
+      cause: errorMessage(e),
+    }
+    logger.fail(result.message)
+    process.exitCode = 1
+    return result
+  }
+
+  const spinner = getDefaultSpinner()
+
+  let deviceAuth: DeviceAuthorizationResponse
+  try {
+    spinner?.start('Requesting a device code from Socket…')
+    deviceAuth = await postForm<DeviceAuthorizationResponse>(
+      deviceAuthorizationUrl,
+      new URLSearchParams({
+        client_id: clientId,
+        scope: DEFAULT_DEVICE_LOGIN_SCOPES,
+      }),
+      effectiveApiProxy,
+    )
+    spinner?.successAndStop('Requested a device code from Socket')
+  } catch (e) {
+    spinner?.failAndStop('Failed to request a device code from Socket')
+    const result: CResult<void> = {
+      ok: false,
+      message: 'Device authorization request failed',
+      cause: errorMessage(e),
+    }
+    logger.fail(result.message)
+    process.exitCode = 1
+    return result
+  }
+
+  logger.log('')
+  logger.log(`First, enter this code: ${deviceAuth.user_code}`)
+  logger.log(`Then approve it at: ${deviceAuth.verification_uri}`)
+  logger.log('')
+
+  try {
+    await open(deviceAuth.verification_uri_complete)
+  } catch {
+    // Best-effort; the printed URL above is the fallback.
+  }
+
+  let tokenResponse: DeviceTokenSuccessResponse
+  try {
+    spinner?.start('Waiting for approval in your browser…')
+    tokenResponse = await pollForDeviceToken(
+      tokenUrl,
+      clientId,
+      deviceAuth.device_code,
+      deviceAuth.interval || DEFAULT_POLL_INTERVAL_SECONDS,
+      deviceAuth.expires_in,
+      effectiveApiProxy,
+    )
+    spinner?.successAndStop('Approved')
+  } catch (e) {
+    spinner?.failAndStop('Device login was not approved')
+    const result: CResult<void> = {
+      ok: false,
+      message: 'Device login failed',
+      cause: errorMessage(e),
+    }
+    logger.fail(result.message)
+    process.exitCode = 1
+    return result
+  }
+
+  const apiToken = tokenResponse.access_token
+
+  const sockSdkCResult = await setupSdk({
+    apiBaseUrl,
+    apiProxy: effectiveApiProxy,
+    apiToken,
+  })
+  if (!sockSdkCResult.ok) {
+    logger.fail(sockSdkCResult.message)
+    process.exitCode = 1
+    return sockSdkCResult
+  }
+
+  const orgsCResult = await fetchOrganization({
+    description: 'token verification',
+    sdk: sockSdkCResult.data,
+  })
+  if (!orgsCResult.ok) {
+    logger.fail(orgsCResult.message)
+    process.exitCode = 1
+    return orgsCResult
+  }
+
+  const { organizations } = orgsCResult.data
+  const orgSlugs = getOrgSlugs(organizations)
+
+  if (!orgSlugs.length) {
+    const result: CResult<void> = {
+      ok: false,
+      message:
+        'No organizations found. Please contact Socket support to set up your account.',
+    }
+    logger.fail(result.message)
+    process.exitCode = 1
+    return result
+  }
+
+  logger.success(`API token verified: ${joinAnd(orgSlugs)}`)
+
+  const enterpriseOrgs = getEnterpriseOrgs(organizations)
+  const enforcedOrgs =
+    enterpriseOrgs.length === 1 ? [enterpriseOrgs[0]!['id']] : []
+
+  const defaultOrg = orgSlugs[0]?.trim()
+  if (defaultOrg) {
+    updateConfigValue(CONFIG_KEY_DEFAULT_ORG, defaultOrg)
+  }
+
+  applyLogin(apiToken, enforcedOrgs, apiBaseUrl, effectiveApiProxy)
+  logger.success('API credentials set')
+  if (isConfigFromFlag()) {
+    logger.log('')
+    logger.warn(
+      'Note: config is in read-only mode, at least one key was overridden through flag/env, so the login was not persisted!',
+    )
+  }
+
+  return { ok: true, data: undefined }
+}
+
+export async function pollForDeviceToken(
+  tokenUrl: URL,
+  clientId: string,
+  deviceCode: string,
+  intervalSeconds: number,
+  expiresInSeconds: number,
+  apiProxy?: string | undefined,
+): Promise<DeviceTokenSuccessResponse> {
+  const deadline = Date.now() + expiresInSeconds * 1000
+  let currentInterval = intervalSeconds
+
+  for (;;) {
+    if (Date.now() >= deadline) {
+      throw new DeviceLoginError(
+        'expired_token',
+        'The device code expired before it was approved',
+      )
+    }
+
+    await sleep(currentInterval * 1000)
+
+    try {
+      return await postForm<DeviceTokenSuccessResponse>(
+        tokenUrl,
+        new URLSearchParams({
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+          client_id: clientId,
+          device_code: deviceCode,
+        }),
+        apiProxy,
+      )
+    } catch (e) {
+      if (!(e instanceof DeviceLoginError)) {
+        throw e
+      }
+      if (e.oauthError === 'authorization_pending') {
+        continue
+      }
+      if (e.oauthError === 'slow_down') {
+        // RFC 8628 3.5: increase the polling interval by 5 seconds.
+        currentInterval += 5
+        continue
+      }
+      throw e
+    }
+  }
+}
+
+export async function postForm<T>(
+  url: URL,
+  body: URLSearchParams,
+  apiProxy?: string | undefined,
+): Promise<T> {
+  const response: HttpResponse | { status: number; text: () => string } =
+    apiProxy
+      ? await postFormViaProxy(url, body, apiProxy)
+      : await httpRequest(url.toString(), {
+          body: body.toString(),
+          headers: { 'content-type': 'application/x-www-form-urlencoded' },
+          method: 'POST',
+        })
+  const json = JSON.parse(response.text()) as T | OAuthErrorResponse
+  if (response.status < 200 || response.status >= 300) {
+    const oauthError = json as OAuthErrorResponse
+    throw new DeviceLoginError(oauthError.error, oauthError.error_description)
+  }
+  return json as T
+}
+
+/**
+ * `httpRequest` has no proxy/agent option (it uses node:http/node:https
+ * directly with no hook for one), so a configured proxy needs a raw request
+ * built with the same hpagent agents sdk.mts uses for the SDK's own client.
+ */
+export function postFormViaProxy(
+  url: URL,
+  body: URLSearchParams,
+  apiProxy: string,
+): Promise<{ status: number; text: () => string }> {
+  return new Promise((resolve, reject) => {
+    const isHttp = url.protocol === 'http:'
+    const AgentCtor = isHttp ? HttpProxyAgent : HttpsProxyAgent
+    const agent = new AgentCtor({ proxy: apiProxy })
+    const requestFn = isHttp ? nodeHttpRequest : nodeHttpsRequest
+    const bodyString = body.toString()
+    const req = requestFn(
+      url,
+      {
+        method: 'POST',
+        agent,
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          'content-length': Buffer.byteLength(bodyString),
+        },
+      },
+      res => {
+        const chunks: Buffer[] = []
+        res.on('data', (chunk: Buffer) => chunks.push(chunk))
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            text: () => Buffer.concat(chunks).toString('utf8'),
+          })
+        })
+      },
+    )
+    req.on('error', reject)
+    req.write(bodyString)
+    req.end()
+  })
+}
+
+export function resolveOauthBaseUrl(): string {
+  return getSocketCliOauthBaseUrl() || API_V1_OAUTH_URL
+}
+
+export function resolveOauthClientId(): string {
+  return getSocketCliOauthClientIdOverride() || SOCKET_CLI_OAUTH_CLIENT_ID
+}

--- a/packages/cli/src/commands/login/cmd-login.mts
+++ b/packages/cli/src/commands/login/cmd-login.mts
@@ -1,5 +1,6 @@
 import isInteractive from '@socketregistry/is-interactive/index.cjs'
 
+import { attemptDeviceLogin } from './attempt-device-login.mts'
 import { attemptLogin } from './attempt-login.mts'
 import { outputDryRunWrite } from '../../util/dry-run/output.mts'
 import { defineFlags } from '../../meow.mts'
@@ -18,6 +19,7 @@ import type { MeowFlags } from '../../flags.mts'
 export interface LoginFlags {
   apiBaseUrl?: string | undefined
   apiProxy?: string | undefined
+  device?: boolean | undefined
 }
 
 export const CMD_NAME = 'login'
@@ -53,6 +55,12 @@ export async function run(
         default: '',
         description: 'Proxy to use when making connection to API server',
       },
+      device: {
+        type: 'boolean',
+        default: false,
+        description:
+          'Log in by approving a device code in your browser instead of pasting an API token',
+      },
     }),
     help: (command: string, helpConfig: { flags: MeowFlags }) => `
     Usage
@@ -68,6 +76,7 @@ export async function run(
 
     Examples
       $ ${command}
+      $ ${command} --device
       $ ${command} --api-proxy=http://localhost:1234
   `,
   }
@@ -80,28 +89,41 @@ export async function run(
   })
 
   const dryRun = cli.flags['dryRun']
+  const { device } = cli.flags
 
   if (dryRun) {
     // Runtime read so tests that mutate process.env['HOME'] pick up changes.
     const configPath = `${process.env['HOME']}/.config/socket/config.json`
-    const changes = [
-      'Prompt for Socket API token',
-      'Verify token with Socket API',
-      'Save API token to config',
-      'Optionally set default organization',
-      'Optionally install bash completion',
-    ]
+    const changes = device
+      ? [
+          'Request a device code from Socket',
+          'Open a browser to approve the device code',
+          'Verify token with Socket API',
+          'Save API token to config',
+        ]
+      : [
+          'Prompt for Socket API token',
+          'Verify token with Socket API',
+          'Save API token to config',
+          'Optionally set default organization',
+          'Optionally install bash completion',
+        ]
     outputDryRunWrite(configPath, 'authenticate with Socket API', changes)
     return
   }
 
   if (!isInteractive()) {
     throw new InputError(
-      'socket login needs an interactive TTY to prompt for credentials (stdin/stdout is not a TTY); set SOCKET_CLI_API_TOKEN in the environment instead',
+      'socket login needs an interactive TTY (stdin/stdout is not a TTY); set SOCKET_CLI_API_TOKEN in the environment instead',
     )
   }
 
   const { apiBaseUrl, apiProxy } = cli.flags
+
+  if (device) {
+    await attemptDeviceLogin(apiBaseUrl, apiProxy)
+    return
+  }
 
   await attemptLogin(apiBaseUrl, apiProxy)
 }

--- a/packages/cli/src/constants/socket.mts
+++ b/packages/cli/src/constants/socket.mts
@@ -8,6 +8,12 @@ export { NPM_REGISTRY_URL } from '@socketsecurity/lib-stable/constants/agents'
 
 // Socket API URLs
 export const API_V0_URL = 'https://api.socket.dev/v0/'
+export const API_V1_OAUTH_URL = 'https://api.socket.dev/v1/oauth2/'
+
+// The public client_id registered for the Socket CLI's device-authorization
+// flow (see `socket login --device`). Public: no client_secret, since the CLI
+// cannot keep one confidential.
+export const SOCKET_CLI_OAUTH_CLIENT_ID = 'socket-cli'
 export const SOCKET_WEBSITE_URL = 'https://socket.dev'
 export const SOCKET_DASHBOARD_URL = 'https://socket.dev/dashboard'
 export const SOCKET_PRICING_URL = 'https://socket.dev/pricing'

--- a/packages/cli/src/env/socket-cli-oauth-base-url.mts
+++ b/packages/cli/src/env/socket-cli-oauth-base-url.mts
@@ -1,0 +1,13 @@
+/**
+ * SOCKET_CLI_OAUTH_BASE_URL environment variable.
+ *
+ * Overrides the Socket API v1 OAuth base URL `socket login --device` sends
+ * device-authorization and token requests to. Empty string when unset (falls
+ * back to the built-in API_V1_OAUTH_URL default).
+ */
+
+import process from 'node:process'
+
+export function getSocketCliOauthBaseUrl(): string {
+  return process.env['SOCKET_CLI_OAUTH_BASE_URL'] ?? ''
+}

--- a/packages/cli/src/env/socket-cli-oauth-client-id.mts
+++ b/packages/cli/src/env/socket-cli-oauth-client-id.mts
@@ -1,0 +1,14 @@
+/**
+ * SOCKET_CLI_OAUTH_CLIENT_ID environment variable.
+ *
+ * Overrides the OAuth client_id `socket login --device` identifies itself
+ * with. Empty string when unset (falls back to the built-in
+ * SOCKET_CLI_OAUTH_CLIENT_ID default, the public client registered for the
+ * Socket CLI).
+ */
+
+import process from 'node:process'
+
+export function getSocketCliOauthClientIdOverride(): string {
+  return process.env['SOCKET_CLI_OAUTH_CLIENT_ID'] ?? ''
+}

--- a/packages/cli/test/unit/commands/login/attempt-device-login-resolvers.test.mts
+++ b/packages/cli/test/unit/commands/login/attempt-device-login-resolvers.test.mts
@@ -1,0 +1,200 @@
+/**
+ * Unit tests split out of attempt-device-login.test.mts for size hygiene:
+ * the base-URL / client-id resolvers, and the proxy-routing path
+ * (postFormViaProxy), which need their own node:https mock.
+ *
+ * Related Files: - src/commands/login/attempt-device-login.mts (implementation)
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockHttpRequest } = vi.hoisted(() => ({
+  mockHttpRequest: vi.fn(),
+}))
+vi.mock(import('@socketsecurity/lib-stable/http-request/request'), () => ({
+  httpRequest: mockHttpRequest,
+}))
+
+const mockOpen = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+vi.mock(import('open'), () => ({ default: mockOpen }))
+
+// Fakes the proxy-path request node:https.request builds in
+// postFormViaProxy - each test configures its own responses via
+// mockImplementationOnce().
+function fakeHttpsResponse(status: number, body: unknown) {
+  return (
+    _url: unknown,
+    _options: unknown,
+    callback: (res: unknown) => void,
+  ) => {
+    const res = {
+      statusCode: status,
+      on: (event: string, handler: (arg?: unknown | undefined) => void) => {
+        if (event === 'data') {
+          handler(Buffer.from(JSON.stringify(body)))
+        } else if (event === 'end') {
+          handler()
+        }
+      },
+    }
+    callback(res)
+    return { on: () => {}, write: () => {}, end: () => {} }
+  }
+}
+const mockHttpsRequest = vi.hoisted(() => vi.fn())
+vi.mock(import('node:https'), () => ({ request: mockHttpsRequest }))
+
+const mockSleep = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+vi.mock(import('node:timers/promises'), () => ({ setTimeout: mockSleep }))
+
+const mockLogger = vi.hoisted(() => ({
+  fail: vi.fn(),
+  log: vi.fn(),
+  success: vi.fn(),
+  warn: vi.fn(),
+}))
+vi.mock(import('@socketsecurity/lib-stable/logger/default'), () => ({
+  getDefaultLogger: () => mockLogger,
+}))
+
+const mockSpinner = vi.hoisted(() => ({
+  failAndStop: vi.fn(),
+  start: vi.fn(),
+  successAndStop: vi.fn(),
+}))
+vi.mock(import('@socketsecurity/lib-stable/spinner/default'), () => ({
+  getDefaultSpinner: () => mockSpinner,
+}))
+
+const mockGetSocketCliOauthBaseUrl = vi.hoisted(() => vi.fn(() => ''))
+vi.mock(import('../../../../src/env/socket-cli-oauth-base-url.mts'), () => ({
+  getSocketCliOauthBaseUrl: mockGetSocketCliOauthBaseUrl,
+}))
+
+const mockGetSocketCliOauthClientIdOverride = vi.hoisted(() => vi.fn(() => ''))
+vi.mock(import('../../../../src/env/socket-cli-oauth-client-id.mts'), () => ({
+  getSocketCliOauthClientIdOverride: mockGetSocketCliOauthClientIdOverride,
+}))
+
+const mockApplyLogin = vi.hoisted(() => vi.fn())
+vi.mock(import('../../../../src/commands/login/apply-login.mts'), () => ({
+  applyLogin: mockApplyLogin,
+}))
+
+const mockSetupSdk = vi.hoisted(() => vi.fn())
+const mockGetDefaultProxyUrl = vi.hoisted(() => vi.fn(() => undefined))
+vi.mock(import('../../../../src/util/socket/sdk.mts'), () => ({
+  getDefaultProxyUrl: mockGetDefaultProxyUrl,
+  setupSdk: mockSetupSdk,
+}))
+
+const mockUpdateConfigValue = vi.hoisted(() => vi.fn())
+const mockIsConfigFromFlag = vi.hoisted(() => vi.fn(() => false))
+vi.mock(import('../../../../src/util/config.mts'), () => ({
+  isConfigFromFlag: mockIsConfigFromFlag,
+  updateConfigValue: mockUpdateConfigValue,
+}))
+
+const mockFetchOrganization = vi.hoisted(() => vi.fn())
+vi.mock(
+  import('../../../../src/commands/organization/fetch-organization-list.mts'),
+  () => ({
+    fetchOrganization: mockFetchOrganization,
+  }),
+)
+
+const mockGetEnterpriseOrgs = vi.hoisted(() => vi.fn())
+const mockGetOrgSlugs = vi.hoisted(() => vi.fn())
+vi.mock(import('../../../../src/util/organization.mts'), () => ({
+  getEnterpriseOrgs: mockGetEnterpriseOrgs,
+  getOrgSlugs: mockGetOrgSlugs,
+}))
+
+import {
+  attemptDeviceLogin,
+  resolveOauthBaseUrl,
+  resolveOauthClientId,
+} from '../../../../src/commands/login/attempt-device-login.mts'
+
+const DEVICE_AUTH_BODY = {
+  device_code: 'device-code-123',
+  expires_in: 900,
+  interval: 5,
+  user_code: 'ABCD-EFGH',
+  verification_uri: 'https://socket.dev/oauth/device',
+  verification_uri_complete:
+    'https://socket.dev/oauth/device?user_code=ABCD-EFGH',
+}
+
+describe('resolveOauthBaseUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses the built-in default when unset', () => {
+    mockGetSocketCliOauthBaseUrl.mockReturnValueOnce('')
+    expect(resolveOauthBaseUrl()).toBe('https://api.socket.dev/v1/oauth2/')
+  })
+
+  it('honors the env override', () => {
+    mockGetSocketCliOauthBaseUrl.mockReturnValueOnce(
+      'https://staging.example.com/v1/oauth2/',
+    )
+    expect(resolveOauthBaseUrl()).toBe('https://staging.example.com/v1/oauth2/')
+  })
+})
+
+describe('resolveOauthClientId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses the built-in default when unset', () => {
+    mockGetSocketCliOauthClientIdOverride.mockReturnValueOnce('')
+    expect(resolveOauthClientId()).toBe('socket-cli')
+  })
+
+  it('honors the env override', () => {
+    mockGetSocketCliOauthClientIdOverride.mockReturnValueOnce('custom-client')
+    expect(resolveOauthClientId()).toBe('custom-client')
+  })
+})
+
+describe('attemptDeviceLogin proxy routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.exitCode = undefined
+    mockGetSocketCliOauthBaseUrl.mockReturnValue('')
+    mockGetSocketCliOauthClientIdOverride.mockReturnValue('')
+    mockGetDefaultProxyUrl.mockReturnValue(undefined)
+    mockIsConfigFromFlag.mockReturnValue(false)
+    mockGetOrgSlugs.mockReturnValue(['my-org'])
+    mockGetEnterpriseOrgs.mockReturnValue([])
+    mockFetchOrganization.mockResolvedValue({
+      ok: true,
+      data: { organizations: [{ id: 'org-id', name: 'my-org' }] },
+    })
+    mockSetupSdk.mockResolvedValue({ ok: true, data: {} })
+  })
+
+  it('routes device-authorization and token requests through a configured proxy', async () => {
+    mockHttpsRequest
+      .mockImplementationOnce(fakeHttpsResponse(200, DEVICE_AUTH_BODY))
+      .mockImplementationOnce(
+        fakeHttpsResponse(200, {
+          access_token: 'sktsec_abc',
+          token_type: 'Bearer',
+          expires_in: 900,
+        }),
+      )
+
+    const result = await attemptDeviceLogin(
+      undefined,
+      'http://proxy.example:8080',
+    )
+
+    expect(result).toMatchObject({ ok: true })
+    expect(mockHttpsRequest).toHaveBeenCalledTimes(2)
+    expect(mockHttpRequest).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/test/unit/commands/login/attempt-device-login.test.mts
+++ b/packages/cli/test/unit/commands/login/attempt-device-login.test.mts
@@ -1,0 +1,473 @@
+/**
+ * Unit tests for attemptDeviceLogin and its helpers.
+ *
+ * Mocks @socketsecurity/lib/http-request so the device-authorization and
+ * token endpoints can be controlled per-test, `open` so no real browser
+ * launches, and node:timers/promises so polling doesn't actually sleep.
+ *
+ * Related Files: - src/commands/login/attempt-device-login.mts (implementation)
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockHttpRequest } = vi.hoisted(() => ({
+  mockHttpRequest: vi.fn(),
+}))
+vi.mock(import('@socketsecurity/lib-stable/http-request/request'), () => ({
+  httpRequest: mockHttpRequest,
+}))
+
+const mockOpen = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+vi.mock(import('open'), () => ({ default: mockOpen }))
+
+const mockSleep = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+vi.mock(import('node:timers/promises'), () => ({ setTimeout: mockSleep }))
+
+const mockLogger = vi.hoisted(() => ({
+  fail: vi.fn(),
+  log: vi.fn(),
+  success: vi.fn(),
+  warn: vi.fn(),
+}))
+vi.mock(import('@socketsecurity/lib-stable/logger/default'), () => ({
+  getDefaultLogger: () => mockLogger,
+}))
+
+const mockSpinner = vi.hoisted(() => ({
+  failAndStop: vi.fn(),
+  start: vi.fn(),
+  successAndStop: vi.fn(),
+}))
+vi.mock(import('@socketsecurity/lib-stable/spinner/default'), () => ({
+  getDefaultSpinner: () => mockSpinner,
+}))
+
+const mockGetSocketCliOauthBaseUrl = vi.hoisted(() => vi.fn(() => ''))
+vi.mock(import('../../../../src/env/socket-cli-oauth-base-url.mts'), () => ({
+  getSocketCliOauthBaseUrl: mockGetSocketCliOauthBaseUrl,
+}))
+
+const mockGetSocketCliOauthClientIdOverride = vi.hoisted(() => vi.fn(() => ''))
+vi.mock(import('../../../../src/env/socket-cli-oauth-client-id.mts'), () => ({
+  getSocketCliOauthClientIdOverride: mockGetSocketCliOauthClientIdOverride,
+}))
+
+const mockApplyLogin = vi.hoisted(() => vi.fn())
+vi.mock(import('../../../../src/commands/login/apply-login.mts'), () => ({
+  applyLogin: mockApplyLogin,
+}))
+
+const mockSetupSdk = vi.hoisted(() => vi.fn())
+const mockGetDefaultProxyUrl = vi.hoisted(() => vi.fn(() => undefined))
+vi.mock(import('../../../../src/util/socket/sdk.mts'), () => ({
+  getDefaultProxyUrl: mockGetDefaultProxyUrl,
+  setupSdk: mockSetupSdk,
+}))
+
+const mockUpdateConfigValue = vi.hoisted(() => vi.fn())
+const mockIsConfigFromFlag = vi.hoisted(() => vi.fn(() => false))
+vi.mock(import('../../../../src/util/config.mts'), () => ({
+  isConfigFromFlag: mockIsConfigFromFlag,
+  updateConfigValue: mockUpdateConfigValue,
+}))
+
+const mockFetchOrganization = vi.hoisted(() => vi.fn())
+vi.mock(
+  import('../../../../src/commands/organization/fetch-organization-list.mts'),
+  () => ({
+    fetchOrganization: mockFetchOrganization,
+  }),
+)
+
+const mockGetEnterpriseOrgs = vi.hoisted(() => vi.fn())
+const mockGetOrgSlugs = vi.hoisted(() => vi.fn())
+vi.mock(import('../../../../src/util/organization.mts'), () => ({
+  getEnterpriseOrgs: mockGetEnterpriseOrgs,
+  getOrgSlugs: mockGetOrgSlugs,
+}))
+
+import { attemptDeviceLogin } from '../../../../src/commands/login/attempt-device-login.mts'
+
+function fakeResponse(opts: { status: number; body: unknown }) {
+  const text = JSON.stringify(opts.body)
+  return { status: opts.status, text: () => text }
+}
+
+const DEVICE_AUTH_BODY = {
+  device_code: 'device-code-123',
+  expires_in: 900,
+  interval: 5,
+  user_code: 'ABCD-EFGH',
+  verification_uri: 'https://socket.dev/oauth/device',
+  verification_uri_complete:
+    'https://socket.dev/oauth/device?user_code=ABCD-EFGH',
+}
+
+describe('attemptDeviceLogin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.exitCode = undefined
+    mockGetSocketCliOauthBaseUrl.mockReturnValue('')
+    mockGetSocketCliOauthClientIdOverride.mockReturnValue('')
+    mockGetDefaultProxyUrl.mockReturnValue(undefined)
+    mockIsConfigFromFlag.mockReturnValue(false)
+    mockGetOrgSlugs.mockReturnValue(['my-org'])
+    mockGetEnterpriseOrgs.mockReturnValue([])
+    mockFetchOrganization.mockResolvedValue({
+      ok: true,
+      data: { organizations: [{ id: 'org-id', name: 'my-org' }] },
+    })
+    mockSetupSdk.mockResolvedValue({ ok: true, data: {} })
+  })
+
+  it('returns an error when the OAuth base URL is unsafe', async () => {
+    mockGetSocketCliOauthBaseUrl.mockReturnValue('http://169.254.169.254/')
+
+    const result = await attemptDeviceLogin(undefined, undefined)
+
+    expect(result).toMatchObject({
+      ok: false,
+      message: 'Invalid OAuth base URL',
+    })
+    expect(mockHttpRequest).not.toHaveBeenCalled()
+  })
+
+  it('returns an error when device-authorization fails', async () => {
+    mockHttpRequest.mockResolvedValueOnce(
+      fakeResponse({
+        status: 400,
+        body: { error: 'invalid_scope' },
+      }),
+    )
+
+    const result = await attemptDeviceLogin(undefined, undefined)
+
+    expect(result).toMatchObject({
+      ok: false,
+      message: 'Device authorization request failed',
+    })
+    expect(mockSpinner.failAndStop).toHaveBeenCalled()
+  })
+
+  it('prints the code and opens the browser on success', async () => {
+    mockHttpRequest
+      .mockResolvedValueOnce(
+        fakeResponse({ status: 200, body: DEVICE_AUTH_BODY }),
+      )
+      .mockResolvedValueOnce(
+        fakeResponse({
+          status: 200,
+          body: {
+            access_token: 'sktsec_abc',
+            token_type: 'Bearer',
+            expires_in: 900,
+            refresh_token: 'refresh-abc',
+            scope: 'packages:list',
+          },
+        }),
+      )
+
+    await attemptDeviceLogin(undefined, undefined)
+
+    expect(mockLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining('ABCD-EFGH'),
+    )
+    expect(mockOpen).toHaveBeenCalledWith(
+      DEVICE_AUTH_BODY.verification_uri_complete,
+    )
+  })
+
+  it('polls through authorization_pending to a token', async () => {
+    mockHttpRequest
+      .mockResolvedValueOnce(
+        fakeResponse({ status: 200, body: DEVICE_AUTH_BODY }),
+      )
+      .mockResolvedValueOnce(
+        fakeResponse({ status: 400, body: { error: 'authorization_pending' } }),
+      )
+      .mockResolvedValueOnce(
+        fakeResponse({
+          status: 200,
+          body: {
+            access_token: 'sktsec_abc',
+            token_type: 'Bearer',
+            expires_in: 900,
+          },
+        }),
+      )
+
+    const result = await attemptDeviceLogin(undefined, undefined)
+
+    expect(result).toMatchObject({ ok: true })
+    expect(mockSleep).toHaveBeenCalledTimes(2)
+    expect(mockApplyLogin).toHaveBeenCalledWith(
+      'sktsec_abc',
+      [],
+      undefined,
+      undefined,
+    )
+  })
+
+  it('honors slow_down by increasing the poll interval', async () => {
+    mockHttpRequest
+      .mockResolvedValueOnce(
+        fakeResponse({ status: 200, body: DEVICE_AUTH_BODY }),
+      )
+      .mockResolvedValueOnce(
+        fakeResponse({ status: 400, body: { error: 'slow_down' } }),
+      )
+      .mockResolvedValueOnce(
+        fakeResponse({
+          status: 200,
+          body: {
+            access_token: 'sktsec_abc',
+            token_type: 'Bearer',
+            expires_in: 900,
+          },
+        }),
+      )
+
+    await attemptDeviceLogin(undefined, undefined)
+
+    expect(mockSleep).toHaveBeenNthCalledWith(1, 5000)
+    expect(mockSleep).toHaveBeenNthCalledWith(2, 10_000)
+  })
+
+  it('returns an error when the device code expires', async () => {
+    mockHttpRequest.mockResolvedValueOnce(
+      fakeResponse({
+        status: 200,
+        body: { ...DEVICE_AUTH_BODY, expires_in: -1 },
+      }),
+    )
+
+    const result = await attemptDeviceLogin(undefined, undefined)
+
+    expect(result).toMatchObject({ ok: false, message: 'Device login failed' })
+    expect(mockHttpRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns an error when access_denied is returned', async () => {
+    mockHttpRequest
+      .mockResolvedValueOnce(
+        fakeResponse({ status: 200, body: DEVICE_AUTH_BODY }),
+      )
+      .mockResolvedValueOnce(
+        fakeResponse({ status: 400, body: { error: 'access_denied' } }),
+      )
+
+    const result = await attemptDeviceLogin(undefined, undefined)
+
+    expect(result).toMatchObject({ ok: false, message: 'Device login failed' })
+  })
+
+  it('propagates a setupSdk failure', async () => {
+    mockHttpRequest
+      .mockResolvedValueOnce(
+        fakeResponse({ status: 200, body: DEVICE_AUTH_BODY }),
+      )
+      .mockResolvedValueOnce(
+        fakeResponse({
+          status: 200,
+          body: {
+            access_token: 'sktsec_abc',
+            token_type: 'Bearer',
+            expires_in: 900,
+          },
+        }),
+      )
+    mockSetupSdk.mockResolvedValueOnce({
+      ok: false,
+      message: 'SDK error',
+      cause: 'bad token',
+    })
+
+    const result = await attemptDeviceLogin(undefined, undefined)
+
+    expect(result).toMatchObject({ ok: false, message: 'SDK error' })
+    expect(mockApplyLogin).not.toHaveBeenCalled()
+  })
+
+  it('propagates a fetchOrganization failure', async () => {
+    mockHttpRequest
+      .mockResolvedValueOnce(
+        fakeResponse({ status: 200, body: DEVICE_AUTH_BODY }),
+      )
+      .mockResolvedValueOnce(
+        fakeResponse({
+          status: 200,
+          body: {
+            access_token: 'sktsec_abc',
+            token_type: 'Bearer',
+            expires_in: 900,
+          },
+        }),
+      )
+    mockFetchOrganization.mockResolvedValueOnce({
+      ok: false,
+      message: 'fetch failed',
+      cause: 'no auth',
+    })
+
+    const result = await attemptDeviceLogin(undefined, undefined)
+
+    expect(result).toMatchObject({ ok: false, message: 'fetch failed' })
+  })
+
+  it('fails when the account has no organizations', async () => {
+    mockHttpRequest
+      .mockResolvedValueOnce(
+        fakeResponse({ status: 200, body: DEVICE_AUTH_BODY }),
+      )
+      .mockResolvedValueOnce(
+        fakeResponse({
+          status: 200,
+          body: {
+            access_token: 'sktsec_abc',
+            token_type: 'Bearer',
+            expires_in: 900,
+          },
+        }),
+      )
+    mockGetOrgSlugs.mockReturnValueOnce([])
+
+    const result = await attemptDeviceLogin(undefined, undefined)
+
+    expect(result).toMatchObject({
+      ok: false,
+      message: expect.stringContaining('No organizations'),
+    })
+  })
+
+  it('enforces the single enterprise org', async () => {
+    mockHttpRequest
+      .mockResolvedValueOnce(
+        fakeResponse({ status: 200, body: DEVICE_AUTH_BODY }),
+      )
+      .mockResolvedValueOnce(
+        fakeResponse({
+          status: 200,
+          body: {
+            access_token: 'sktsec_abc',
+            token_type: 'Bearer',
+            expires_in: 900,
+          },
+        }),
+      )
+    mockGetEnterpriseOrgs.mockReturnValueOnce([{ id: 'enterprise-org' }])
+
+    await attemptDeviceLogin(undefined, undefined)
+
+    expect(mockApplyLogin).toHaveBeenCalledWith(
+      'sktsec_abc',
+      ['enterprise-org'],
+      undefined,
+      undefined,
+    )
+  })
+
+  it('tolerates a browser-open failure', async () => {
+    mockHttpRequest
+      .mockResolvedValueOnce(
+        fakeResponse({ status: 200, body: DEVICE_AUTH_BODY }),
+      )
+      .mockResolvedValueOnce(
+        fakeResponse({
+          status: 200,
+          body: {
+            access_token: 'sktsec_abc',
+            token_type: 'Bearer',
+            expires_in: 900,
+          },
+        }),
+      )
+    mockOpen.mockRejectedValueOnce(new Error('no display'))
+
+    const result = await attemptDeviceLogin(undefined, undefined)
+
+    expect(result).toMatchObject({ ok: true })
+  })
+
+  it('sets process.exitCode and logs failure through logger.fail', async () => {
+    mockHttpRequest.mockResolvedValueOnce(
+      fakeResponse({ status: 400, body: { error: 'invalid_scope' } }),
+    )
+
+    await attemptDeviceLogin(undefined, undefined)
+
+    expect(process.exitCode).toBe(1)
+    expect(mockLogger.fail).toHaveBeenCalledWith(
+      'Device authorization request failed',
+    )
+  })
+
+  it('defaults to a 5 second poll interval when the server omits one', async () => {
+    const { interval: _interval, ...bodyWithoutInterval } = DEVICE_AUTH_BODY
+    mockHttpRequest
+      .mockResolvedValueOnce(
+        fakeResponse({ status: 200, body: bodyWithoutInterval }),
+      )
+      .mockResolvedValueOnce(
+        fakeResponse({
+          status: 200,
+          body: {
+            access_token: 'sktsec_abc',
+            token_type: 'Bearer',
+            expires_in: 900,
+          },
+        }),
+      )
+
+    await attemptDeviceLogin(undefined, undefined)
+
+    expect(mockSleep).toHaveBeenCalledWith(5000)
+  })
+
+  it('persists the default org after a successful login', async () => {
+    mockHttpRequest
+      .mockResolvedValueOnce(
+        fakeResponse({ status: 200, body: DEVICE_AUTH_BODY }),
+      )
+      .mockResolvedValueOnce(
+        fakeResponse({
+          status: 200,
+          body: {
+            access_token: 'sktsec_abc',
+            token_type: 'Bearer',
+            expires_in: 900,
+          },
+        }),
+      )
+
+    await attemptDeviceLogin(undefined, undefined)
+
+    expect(mockUpdateConfigValue).toHaveBeenCalledWith(
+      expect.any(String),
+      'my-org',
+    )
+  })
+
+  it('warns when config is in read-only mode (flag override)', async () => {
+    mockHttpRequest
+      .mockResolvedValueOnce(
+        fakeResponse({ status: 200, body: DEVICE_AUTH_BODY }),
+      )
+      .mockResolvedValueOnce(
+        fakeResponse({
+          status: 200,
+          body: {
+            access_token: 'sktsec_abc',
+            token_type: 'Bearer',
+            expires_in: 900,
+          },
+        }),
+      )
+    mockIsConfigFromFlag.mockReturnValueOnce(true)
+
+    await attemptDeviceLogin(undefined, undefined)
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('read-only'),
+    )
+  })
+})

--- a/packages/cli/test/unit/commands/login/cmd-login.test.mts
+++ b/packages/cli/test/unit/commands/login/cmd-login.test.mts
@@ -42,6 +42,18 @@ vi.mock(import('../../../../src/commands/login/attempt-login.mts'), () => ({
   attemptLogin: mockAttemptLogin,
 }))
 
+// Mock attemptDeviceLogin.
+const mockAttemptDeviceLogin = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined),
+)
+
+vi.mock(
+  import('../../../../src/commands/login/attempt-device-login.mts'),
+  () => ({
+    attemptDeviceLogin: mockAttemptDeviceLogin,
+  }),
+)
+
 // Mock outputDryRunWrite.
 const mockOutputDryRunWrite = vi.hoisted(() => vi.fn())
 
@@ -193,6 +205,55 @@ describe('cmd-login', () => {
         await cmdLogin.run(['--api-proxy='], importMeta, context)
 
         expect(mockAttemptLogin).toHaveBeenCalledWith('', '')
+      })
+    })
+
+    describe('--device flag', () => {
+      it('should call attemptDeviceLogin instead of attemptLogin', async () => {
+        await cmdLogin.run(['--device'], importMeta, context)
+
+        expect(mockAttemptDeviceLogin).toHaveBeenCalledWith('', '')
+        expect(mockAttemptLogin).not.toHaveBeenCalled()
+      })
+
+      it('should pass API base URL and proxy through', async () => {
+        await cmdLogin.run(
+          [
+            '--device',
+            '--api-base-url=https://api.example.com',
+            '--api-proxy=http://localhost:8080',
+          ],
+          importMeta,
+          context,
+        )
+
+        expect(mockAttemptDeviceLogin).toHaveBeenCalledWith(
+          'https://api.example.com',
+          'http://localhost:8080',
+        )
+      })
+
+      it('should show device-specific steps in dry-run mode', async () => {
+        await cmdLogin.run(['--device', '--dry-run'], importMeta, context)
+
+        expect(mockOutputDryRunWrite).toHaveBeenCalledWith(
+          expect.stringContaining('config.json'),
+          'authenticate with Socket API',
+          expect.arrayContaining([
+            'Request a device code from Socket',
+            'Open a browser to approve the device code',
+          ]),
+        )
+        expect(mockAttemptDeviceLogin).not.toHaveBeenCalled()
+      })
+
+      it('should still require an interactive TTY', async () => {
+        mockIsInteractive.mockReturnValue(false)
+
+        await expect(
+          cmdLogin.run(['--device'], importMeta, context),
+        ).rejects.toThrow(/socket login needs an interactive TTY/)
+        expect(mockAttemptDeviceLogin).not.toHaveBeenCalled()
       })
     })
 


### PR DESCRIPTION
This adds `socket login --device`, a browser-approve login alongside the existing paste-a-token flow, backed by a device-authorization grant added to Socket's OAuth2 server.

<details><summary>How it works</summary>

The command requests a device code from Socket's OAuth2 server, prints the short user_code and a verification link, and offers to open the browser. It then polls the token endpoint at the server's interval, handling authorization_pending, slow_down, expired_token, and access_denied per RFC 8628 section 3.5. Once approved, the access token is verified and persisted through the existing applyLogin/config.mts path, same as the paste-a-token flow.

</details>

<details><summary>Follow-up needed before this can be tested end to end</summary>

The socket-cli OAuth client still needs to be registered on the server side through its admin tooling, and the exact scope list in DEFAULT_DEVICE_LOGIN_SCOPES should be confirmed against the server's scope catalog by whoever registers it.

</details>

I ran the cli package's typecheck and lint on the changed files (both clean, aside from pre-existing unrelated failures in doctor/ and optimize/), and the new unit tests (41 passing, covering the polling loop, both env-var overrides, and cmd-login's --device dispatch).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a new authentication path that requests and stores API tokens. OAuth URL/client overrides and token polling are security-sensitive even with SSRF checks.
> 
> **Overview**
> Adds **`socket login --device`**, an RFC 8628 device-authorization flow alongside paste-a-token login.
> 
> The CLI requests a device code from Socket’s OAuth2 server, prints the user code, best-effort opens the verification URL, then polls the token endpoint (`authorization_pending`, `slow_down`, expiry, `access_denied`). On success it verifies orgs and saves credentials via existing `applyLogin`.
> 
> OAuth base URL and public client id (`socket-cli`) can be overridden with `SOCKET_CLI_OAUTH_BASE_URL` / `SOCKET_CLI_OAUTH_CLIENT_ID`. The OAuth base URL is SSRF-checked with `assertSafeEndpointUrl`. Default scopes are a read-only list that still needs server-side client registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 063c676d46116db1b8f790c13b45cd1d7a62a4b5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->