### PR TITLE
fix(mcp): trust the hosted deployment's Host over a strict Origin allowlist

### DIFF
--- a/packages/cli/src/commands/mcp/transport-http.mts
+++ b/packages/cli/src/commands/mcp/transport-http.mts
@@ -263,10 +263,20 @@ export async function runHttpTransport(
       host === 'localhost' ||
       host === '127.0.0.1' ||
       allowedHosts.includes(host)
-    const isValidOrigin = origin
-      ? isLocalhostOrigin(origin) ||
+    // DNS-rebinding protection (the reason Origin is checked at all) only
+    // matters when the request could be reaching a private/loopback listener
+    // a malicious webpage isn't supposed to reach. Once Host matches a known
+    // hosted deployment, the only credential that matters is the Bearer token
+    // OAuthIntrospector checks — there's no ambient/cookie-based credential
+    // for a forged cross-origin request to ride on, so an Origin mismatch
+    // there isn't a real CSRF signal. It only breaks legitimate non-browser
+    // MCP clients (Claude Desktop, Codex, etc.) whose HTTP stacks happen to
+    // set an Origin header. Only localhost targets keep the strict allowlist.
+    const isValidOrigin = !origin
+      ? isAllowedHost
+      : allowedHosts.includes(host) ||
+        isLocalhostOrigin(origin) ||
         (allowedOrigins as readonly string[]).includes(origin)
-      : isAllowedHost
 
     if (!isValidOrigin) {
       logger.warn(

--- a/packages/cli/test/unit/commands/mcp/transport-http.test.mts
+++ b/packages/cli/test/unit/commands/mcp/transport-http.test.mts
@@ -425,6 +425,25 @@ describe('runHttpTransport — Host and Origin validation (DNS rebinding)', () =
     expect(response).not.toContain('403')
   })
 
+  it('accepts a non-allowlisted Origin once Host matches the hosted deployment', async () => {
+    // Claude Desktop's custom connector (and other native MCP clients) send
+    // an Origin header their HTTP stack sets automatically; Bearer-token
+    // auth, not Origin, is what actually gates the hosted deployment. This
+    // is the regression case for that report.
+    const { port } = await startServer()
+    const response = await rawRequest(
+      port,
+      `POST / HTTP/1.1\r\n` +
+        `Host: mcp.socket.dev\r\n` +
+        `Origin: https://claude.ai\r\n` +
+        `Content-Type: application/json\r\n` +
+        `Accept: application/json, text/event-stream\r\n` +
+        `Content-Length: 2\r\n` +
+        `Connection: close\r\n\r\n{}`,
+    )
+    expect(response).not.toContain('403')
+  })
+
   it('rejects a request with no Origin and a non-allowlist Host (logs "missing")', async () => {
     const { port } = await startServer()
     // Send via raw TCP with a Host that's none of the allowed values


### PR DESCRIPTION
LLM Description written by Claude Code:Claude Sonnet 5
-----
1:1 port of the fix in SocketDev/socket-mcp#214 - socket-cli's MCP HTTP transport carries an independent, byte-for-byte structurally identical copy of the same Origin-validation bug.

<details>
<summary>Root cause</summary>

`transport-http.mts`'s origin check gates every request on a fixed Origin allowlist. Claude Desktop's connector sends `Origin: https://claude.ai`, which isn't on that list, so it gets a bare 403 - it never learns to start the auth flow.

That Origin check exists for DNS-rebinding protection: a malicious webpage in a browser tab could otherwise reach a locally-bound MCP server through the user's browser. That threat model doesn't extend to the hosted deployment - `mcp.socket.dev`/`mcp.socket-staging.dev` are real public hosts, not rebindable private listeners, and the only credential that matters there is the Bearer token `OAuthIntrospector` checks (no cookies involved). Gating the hosted host on a fixed Origin allowlist doesn't add real CSRF protection; it just breaks any non-browser MCP client whose HTTP stack happens to set an Origin header.
</details>

<details>
<summary>Fix</summary>

Once `Host` matches a known hosted deployment, any Origin (or none) now passes. The strict allowlist stays in force for the localhost/dev case, which is the DNS-rebinding threat it actually protects against.
</details>

Test plan: `pnpm run test:unit test/unit/commands/mcp/transport-http.test.mts` - 53/53 pass. Added a regression test reproducing the exact reported request shape (`Host: mcp.socket.dev` + `Origin: https://claude.ai`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request gating in the MCP HTTP transport; hosted paths now trust Host over Origin while loopback keeps strict checks, and hosted access still depends on Bearer token introspection.
> 
> **Overview**
> **Relaxes Origin checks for hosted MCP deployments** so native clients (e.g. Claude Desktop with `Origin: https://claude.ai`) are not rejected with 403 before OAuth can run.
> 
> When `Host` matches a known hosted hostname (`mcp.socket.dev` / `mcp.socket-staging.dev`), requests with **any** `Origin` (or none) are accepted. The strict Origin allowlist and localhost-origin rules remain for loopback/dev targets, where DNS-rebinding protection still applies.
> 
> A unit test covers `Host: mcp.socket.dev` plus a non-allowlisted `Origin` and expects no 403.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef716663d8c65553e6706327e991dceb39ca7fdb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->