### PR TITLE
fix(release): stop the coana bump from hand-writing versions

### DIFF
--- a/.claude/skills/bump-coana/SKILL.md
+++ b/.claude/skills/bump-coana/SKILL.md
@@ -37,22 +37,37 @@ fi
 1. Read `package.json` in the repository root.
 2. Find the current `@coana-tech/cli` version in `devDependencies` and note it as `CURRENT_VERSION`.
 3. Update `@coana-tech/cli` to the new version.
-4. Bump the patch version of the package (e.g., `1.1.59` → `1.1.60`).
-5. Write the updated `package.json`.
+4. Write the updated `package.json`.
+
+🚨 **Do NOT touch the top-level `version` field.** The release workflow owns it:
+between releases the manifest holds the last released version, and
+`scripts/release/bump.mts` derives and writes the next one in-run. Hand-writing
+it invents a version that never releases and breaks the next release — a manifest
+already sitting on the version being released has no line for the bump to
+advance.
 
 **Values to extract**:
 - `CURRENT_VERSION`: The old @coana-tech/cli version (for PR body)
-- `NEW_PKG_VERSION`: The bumped package.json version (for changelog)
 
 ### Step 3: Update CHANGELOG.md
 
 1. Read `CHANGELOG.md` in the repository root.
-2. Add a new version entry after the header section (which ends with "The format is based on...").
-3. Use today's date in `YYYY-MM-DD` format.
+2. Find the `## [Unreleased]` heading. If it is absent — the previous release
+   consumes it — recreate it directly after the header section (which ends with
+   "The format is based on...").
+3. Add the entry under `## [Unreleased]`, in its `### Changed` subsection,
+   creating that subsection if it is missing. If a Coana line is already there
+   from an earlier unreleased bump, update it in place rather than adding a
+   second one.
 
-**Entry format**:
+🚨 **Never write a `## [<version>]` heading.** Release headings belong to the
+release workflow, which promotes the whole `## [Unreleased]` block under the
+version it derives. Writing one here both names a version that may never exist
+and consumes the block, leaving the real release with empty notes.
+
+**Resulting shape**:
 ```markdown
-## [NEW_PKG_VERSION](https://github.com/SocketDev/socket-cli/releases/tag/vNEW_PKG_VERSION) - YYYY-MM-DD
+## [Unreleased]
 
 ### Changed
 - Updated the Coana CLI to v `COANA_VERSION`.
@@ -105,7 +120,8 @@ Replace `CURRENT_VERSION` and `COANA_VERSION` with actual values.
 
 - Branch: `coana-<VERSION>` pushed to origin
 - PR: Created targeting `v1.x` branch
-- Files modified: `package.json`, `CHANGELOG.md`, `pnpm-lock.yaml`
+- Files modified: `package.json` (the `@coana-tech/cli` devDependency only, never
+  the top-level `version`), `CHANGELOG.md` (under `## [Unreleased]`), `pnpm-lock.yaml`
 
 Report the PR URL to the user when complete.
 
@@ -120,3 +136,6 @@ Report the PR URL to the user when complete.
 
 - Do NOT add any AI/Claude co-authorship or attribution to the commit message or PR.
 - Do NOT include "Generated with Claude Code" or similar text anywhere.
+- Do NOT bump `package.json`'s `version` or write a `## [<version>]` changelog
+  heading. Both belong to the release workflow. Hand-writing them has produced
+  versions that never released and cost a real release its notes entirely.

--- a/scripts/release/bump.mts
+++ b/scripts/release/bump.mts
@@ -53,6 +53,8 @@ const rootPath = path.join(
 
 const REGISTRY_URL = 'https://registry.npmjs.org'
 
+const VERSION_FIELD_PATTERN = /("version":\s*")[^"]+(")/
+
 interface PackageJsonShape {
   name?: string | undefined
   repository?: { url?: string | undefined } | string | undefined
@@ -158,11 +160,10 @@ function readPackageJson(): { parsed: PackageJsonShape; raw: string } {
  * is the one line a reviewer expects.
  */
 export function writeManifestVersion(raw: string, version: string): string {
-  const replaced = raw.replace(
-    /("version":\s*")[^"]+(")/,
-    (_m, pre: string, post: string) => `${pre}${version}${post}`,
-  )
-  if (replaced === raw) {
+  // Test for the field before replacing: a manifest already sitting on
+  // `version` rewrites to itself, and comparing output to input cannot tell
+  // that no-op apart from a missing field.
+  if (!VERSION_FIELD_PATTERN.test(raw)) {
     throw new Error(
       '[bump] could not rewrite the package.json version field.\n' +
         '  Where: the root package.json, at bump time.\n' +
@@ -170,7 +171,10 @@ export function writeManifestVersion(raw: string, version: string): string {
         '  Fix: restore the version field, then re-dispatch.',
     )
   }
-  return replaced
+  return raw.replace(
+    VERSION_FIELD_PATTERN,
+    (_m, pre: string, post: string) => `${pre}${version}${post}`,
+  )
 }
 
 function emitOutputs(outputs: Record<string, string>): void {

--- a/test/release-bump.test.mts
+++ b/test/release-bump.test.mts
@@ -31,6 +31,23 @@ describe('writeManifestVersion', () => {
     )
   })
 
+  // A manifest already sitting on the target rewrites to itself. The prior
+  // `replaced === raw` guard read that no-op as a missing field and failed the
+  // release with "no top-level version line" for a manifest whose version was
+  // present and well-formed — the exact failure that broke the 1.1.160 run,
+  // where a hand-written bump had already put 1.1.160 in the manifest.
+  it('is a no-op when the manifest already holds the target version', () => {
+    const raw = [
+      '{',
+      '  "name": "socket",',
+      '  "version": "1.1.160",',
+      '  "description": "CLI for Socket.dev"',
+      '}',
+      '',
+    ].join('\n')
+    expect(writeManifestVersion(raw, '1.1.160')).toBe(raw)
+  })
+
   it('throws when the manifest has no version field', () => {
     const raw = '{\n  "name": "socket"\n}\n'
     expect(() => writeManifestVersion(raw, '1.1.160')).toThrow(


### PR DESCRIPTION
## Summary

The `bump-coana` skill bumped `package.json`'s `version` itself and wrote its own `## [<version>]` changelog heading. Both belong to the release workflow, and the skill's versions of them caused real damage on `v1.x`:

- Changelog headings for `1.1.160`, a version with no tag, no GitHub release, and nothing on npm — written twice, by #1502 and #1510.
- **v1.1.159 shipped with empty notes.** #1501's hand-written heading consumed the `## [Unreleased]` block, so when the real release ran it found nothing to promote.
- The first `1.1.160` release attempt **failed outright**: with the manifest already hand-written to `1.1.160`, `writeManifestVersion`'s rewrite was byte-identical, and its `replaced === raw` guard reported "no top-level `version` line" against a manifest whose version field was present and well-formed.

## Changes

**`.claude/skills/bump-coana/SKILL.md`**
- Step 2 no longer touches the top-level `version`, and says why: the release owns that field, and hand-writing it breaks the next release.
- Step 3 adds the entry under `## [Unreleased]`, **recreating the heading when the previous release consumed it**. Having nowhere to put notes is what motivated the invented headings, so the fix has to cover that case or it will recur.
- Explicit "never write a `## [<version>]` heading", plus a matching line under Important Notes.

**`scripts/release/bump.mts`**
- Separate the two failures the old guard conflated: test for the version field, then replace. A manifest already holding the target version now passes through as a no-op instead of failing the release. The base comes from release tags and the registry, never the manifest, so an already-correct manifest is not a reason to stop.

**`test/release-bump.test.mts`**
- Add the missing no-op case. Verified against the old implementation: it throws on this input, the new one does not, and both the missing-field and empty-version cases still throw.

## Verification

- `pnpm run lint` — 0 errors
- `pnpm run check:tsc` — clean, both projects
- `pnpm test:unit test/release-bump.test.mts` — 5/5

No changelog entry: internal tooling, excluded per the repo's changelog rules.

## Follow-up not included here

Step 5 still commits with `git commit -n`, which skips the `commit-msg` PII guard that CLAUDE.md says not to work around. Left alone since the intent was probably to skip the pre-commit lint hook — `DISABLE_PRECOMMIT_LINT=1` would do that without disarming the guard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release bump script on the npm-publish path; the fix is narrow but release infrastructure is sensitive.
> 
> **Overview**
> Stops the **bump-coana** skill from editing release-owned metadata and hardens the CI **release bump** when `package.json` already matches the derived version.
> 
> The skill now only bumps `@coana-tech/cli` in devDependencies, logs Coana changes under **`## [Unreleased]`** (recreating that section if a release consumed it), and explicitly forbids touching the top-level **`version`** or adding **`## [<version>]`** changelog headings—behavior that had invented unreleased versions and left real releases with empty notes.
> 
> **`writeManifestVersion`** in `scripts/release/bump.mts` checks for a `version` field before replacing, so a manifest already at the target version is a no-op instead of throwing “no version line.” A unit test covers that case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a42956a3cfd7d652bd1f0e09563de0630471a6a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->