### PR TITLE
fix(build): resolve vendored blessed requires

### DIFF
--- a/.config/rollup.dist.config.mjs
+++ b/.config/rollup.dist.config.mjs
@@ -74,6 +74,22 @@ const SOCKET_SECURITY_REGISTRY = '@socketsecurity/registry'
 const UTILS = 'utils'
 const VENDOR = 'vendor'
 
+// A fresh regexp per call: socketModifyPlugin advances lastIndex, so a shared
+// instance would make chunks skip each other's matches.
+function newBareBlessedRequireRegExp() {
+  return /(?<=require[$\w]*(?:\.resolve)?\(["'])blessed(?=(?:\/[^"']+)?["']\))/g
+}
+
+// '.' rather than '' keeps a require from a file sitting in blessed's own root
+// from becoming an absolute-looking specifier.
+function relativeBlessedPath(filepath) {
+  return (
+    normalizePath(
+      path.relative(path.dirname(filepath), constants.blessedPath),
+    ) || '.'
+  )
+}
+
 async function copyInitGradle() {
   const filepath = path.join(constants.srcPath, 'commands/manifest/init.gradle')
   const destPath = path.join(constants.distPath, 'init.gradle')
@@ -197,22 +213,26 @@ async function copyExternalPackages() {
       await removeEmptyDirs(thePath)
     }),
   )
-  // Rewire 'blessed' inside 'blessed-contrib'.
+  // Rewire 'blessed' inside 'blessed-contrib', and inside blessed's own vendor
+  // files, which reach for it by bare name too.
   await Promise.all(
-    (
-      await fastGlob.glob(['**/*.js'], {
+    [blessedPath, blessedContribPath].map(async cwd => {
+      const filepaths = await fastGlob.glob(['**/*.js'], {
         absolute: true,
-        cwd: blessedContribPath,
+        cwd,
         ignore: [NODE_MODULES_GLOB_RECURSIVE],
       })
-    ).map(async p => {
-      const relPath = path.relative(path.dirname(p), blessedPath)
-      const content = await fs.readFile(p, 'utf8')
-      const modded = content.replace(
-        /(?<=require\(["'])blessed(?=(?:\/[^"']+)?["']\))/g,
-        () => relPath,
+      await Promise.all(
+        filepaths.map(async p => {
+          const relPath = relativeBlessedPath(p)
+          const content = await fs.readFile(p, 'utf8')
+          const modded = content.replace(
+            newBareBlessedRequireRegExp(),
+            () => relPath,
+          )
+          await fs.writeFile(p, modded, 'utf8')
+        }),
       )
-      await fs.writeFile(p, modded, 'utf8')
     }),
   )
 }
@@ -563,6 +583,11 @@ export default async () => {
           )
         },
         plugins: [
+          // Runs after copyExternalPackages() and overwrites what it rewired.
+          socketModifyPlugin({
+            find: newBareBlessedRequireRegExp(),
+            replace: () => relativeBlessedPath(path.join(rootPath, relPath)),
+          }),
           nodeResolve({
             exportConditions: ['node'],
             extensions: ['.mjs', '.js', '.json'],

--- a/test/external-bare-requires.test.mts
+++ b/test/external-bare-requires.test.mts
@@ -1,0 +1,91 @@
+/**
+ * Guards that nothing under external/ reaches for a bundled package by bare
+ * name. Node resolves bare specifiers only through node_modules directories,
+ * and external/ is not one, so such a require throws "Cannot find module" in
+ * the published package even though the file ships correctly on disk.
+ */
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const rootPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '..')
+const externalPath = path.join(rootPath, 'external')
+
+// Mirrors EXTERNAL_PACKAGES in .config/rollup.base.config.mjs. Scoped to what
+// the build vendors into external/, because unbundled optional peers reached by
+// bare name there (blessed's pty.js/term.js terminal widget, node-gyp under
+// @socketsecurity/registry) are a separate, longstanding question.
+const bundledNames = new Set([
+  '@socketsecurity/registry',
+  'blessed',
+  'blessed-contrib',
+])
+
+const bareRequireRegExp =
+  /require[$\w]*(?:\.resolve)?\(\s*['"]([^'"]+)['"]\s*\)/g
+
+function findScripts(dirPath: string): string[] {
+  const scriptPaths: string[] = []
+  for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+    const entryPath = path.join(dirPath, entry.name)
+    if (entry.isDirectory()) {
+      scriptPaths.push(...findScripts(entryPath))
+    } else if (entry.name.endsWith('.js')) {
+      scriptPaths.push(entryPath)
+    }
+  }
+  return scriptPaths.sort()
+}
+
+function packageNameFromSpecifier(specifier: string): string | undefined {
+  if (
+    !specifier ||
+    specifier.startsWith('.') ||
+    specifier.startsWith('#') ||
+    specifier.startsWith('node:') ||
+    path.isAbsolute(specifier)
+  ) {
+    return undefined
+  }
+  const segments = specifier.split('/')
+  return specifier.startsWith('@')
+    ? segments.slice(0, 2).join('/')
+    : segments[0]
+}
+
+describe('external bare requires', () => {
+  it('never name a bundled package', () => {
+    if (!existsSync(externalPath)) {
+      throw new Error(
+        `Missing build output at ${externalPath}.\n` +
+          `→ This test checks what ships, so it needs a built external/.\n` +
+          `→ Run: pnpm build:dist:src`,
+      )
+    }
+    const scriptPaths = findScripts(externalPath)
+    expect(scriptPaths.length).toBeGreaterThan(0)
+
+    const findings: string[] = []
+    for (const scriptPath of scriptPaths) {
+      const relPath = path.relative(rootPath, scriptPath).replace(/\\/g, '/')
+      const source = readFileSync(scriptPath, 'utf8')
+      bareRequireRegExp.lastIndex = 0
+      let match
+      while ((match = bareRequireRegExp.exec(source)) !== null) {
+        const specifier = match[1]!
+        const pkgName = packageNameFromSpecifier(specifier)
+        if (!pkgName || !bundledNames.has(pkgName)) {
+          continue
+        }
+        const finding = `${relPath} requires "${specifier}"`
+        if (!findings.includes(finding)) {
+          findings.push(finding)
+        }
+      }
+    }
+
+    expect(findings).toEqual([])
+  })
+})


### PR DESCRIPTION
`socket threat-feed` crashes the moment it draws its table, on every run, for everyone, dying with `Cannot find module 'blessed/lib/widgets/box'`. It is present in 1.1.160 and in the current `latest`, 1.1.162, and `socket analytics` and `socket audit-log` load the same widgets.

<details>
<summary>Why the module is unreachable</summary>

The published package ships `blessed` at `external/blessed/`, but four vendored files still ask for it by its bare name. Node only resolves a bare name like `blessed/lib/widgets/box` by walking up through `node_modules` directories. `external/` is not one, and `external/blessed` has no `package.json`, so the module cannot be found even though the file is sitting right there on disk.
</details>

<details>
<summary>Why the existing rewrite did not catch it</summary>

`copyExternalPackages()` already rewrites these requires to relative paths. It just runs too early to matter.

The dist config exports an array of rollup configs, and rollup runs them in order:

1. The first config bundles `src/` into `dist/`. Its `writeBundle` hook calls `copyExternalPackages()`, which rewrites `require('blessed/…')` to a relative path across `external/blessed-contrib/**/*.js`.
2. The configs after it bundle `src/external/blessed-contrib/**/*.mjs` straight back out to those same files. They mark `blessed` as `external`, so the requires they emit stay bare, and they carry no rewrite of their own.

Step 2 lands on top of step 1's work. The rewrite happens, then gets overwritten.

Separately, the rewrite globs with `cwd: blessedContribPath`, so it never looks inside blessed itself. That is why `external/blessed/vendor/tng.js` keeps its bare `require('blessed/lib/colors')`.
</details>

<details>
<summary>What changed</summary>

- The blessed-contrib bundle config gets its own `socketModifyPlugin`, so the requires it emits are already relative at the moment they are written and there is nothing left to clobber. The plugin runs in `renderChunk`, on final emitted code, and computes the relative path from that specific output file's depth.
- The rewrite inside `copyExternalPackages()` now walks blessed's own tree as well as blessed-contrib's, which covers `vendor/tng.js`.
- Both share two small helpers. `newBareBlessedRequireRegExp()` hands back a fresh regexp per call, because `socketModifyPlugin` advances `lastIndex` and a shared instance would let chunks skip each other's matches. `relativeBlessedPath()` falls back to `'.'` so a file sitting in blessed's own root cannot produce an absolute-looking specifier.
</details>

<details>
<summary>The four files, and the new guard</summary>

Scanning the shipped 1.1.162 tarball turns up eight bare requires across four files:

```
external/blessed/vendor/tng.js                    blessed/lib/colors
external/blessed-contrib/lib/widget/table.js      blessed/lib/widgets/box
external/blessed-contrib/lib/widget/table.js      blessed/lib/widgets/list
external/blessed-contrib/lib/widget/table.js      blessed/lib/widgets/node
external/blessed-contrib/lib/widget/charts/bar.js blessed/lib/widgets/node
external/blessed-contrib/lib/widget/charts/bar.js blessed/lib/widgets/box
external/blessed-contrib/lib/widget/charts/line.js blessed/lib/widgets/box
external/blessed-contrib/lib/widget/charts/line.js blessed/lib/widgets/node
```

`test/external-bare-requires.test.mts` walks the built `external/` tree and fails on any bare require of a package the build vendors there. Run against 1.1.162 its rule reports exactly those eight and nothing else.

It is deliberately scoped to the three names in `EXTERNAL_PACKAGES` rather than to "any undeclared package". Widening it that far also picks up `braces`, `micromatch`, `picomatch` and `node-gyp` under `external/@socketsecurity/registry/`, plus `pty.js` and `term.js` from blessed's optional terminal widget. Those are longstanding and unrelated to this crash, and they deserve their own look rather than being swept in here.
</details>

<details>
<summary>Known gap</summary>

The crash tears down the alt screen without restoring terminal state, leaving a one-line scroll region and the tty in raw mode until the user runs `reset`. That is a separate cleanup bug that outlives any require-path fix, and it is not addressed here.
</details>

Refs SURF-1445, SURF-1639.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes published packaging and module resolution for vendored TUI dependencies; impact is broad for blessed-based commands but scoped to build output with a regression test.
> 
> **Overview**
> Fixes runtime **`Cannot find module 'blessed/…'`** crashes when TUI commands (e.g. threat-feed) render tables, because vendored files under **`external/`** still used bare **`blessed`** specifiers that Node cannot resolve there.
> 
> The dist build now rewrites those requires in **two places that actually stick**: **`copyExternalPackages()`** walks **`blessed`** as well as **`blessed-contrib`**, and the **blessed-contrib Rollup bundle** gets a **`socketModifyPlugin`** so emitted **`require('blessed/…')`** become **relative paths** at write time instead of being overwritten by a later bundle pass. Shared helpers **`newBareBlessedRequireRegExp()`** and **`relativeBlessedPath()`** avoid regexp **`lastIndex`** bugs and edge cases at blessed’s root.
> 
> Adds **`test/external-bare-requires.test.mts`**, which fails if built **`external/**/*.js`** still bare-requires **`blessed`**, **`blessed-contrib`**, or **`@socketsecurity/registry`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 668365a848aecb0e7b59586e84abe8fcfe56d47e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->