### PR TITLE
chore(release): add a script for accruing an Unreleased changelog note

### DIFF
--- a/.claude/skills/bump-coana/SKILL.md
+++ b/.claude/skills/bump-coana/SKILL.md
@@ -51,15 +51,18 @@ advance.
 
 ### Step 3: Update CHANGELOG.md
 
-1. Read `CHANGELOG.md` in the repository root.
-2. Find the `## [Unreleased]` heading. If it is absent — the previous release
-   consumes it — recreate it directly after the header section (which ends with
-   "The format is based on..."), spelled exactly `## [Unreleased]` and nothing
-   else.
-3. Add the entry under `## [Unreleased]`, in its `### Changed` subsection,
-   creating that subsection if it is missing. If a Coana line is already there
-   from an earlier unreleased bump, update it in place rather than adding a
-   second one.
+Do not hand-edit the file. Run the helper, which owns the shape:
+
+```bash
+node scripts/release/add-unreleased.mts \
+  --replace '^Updated the Coana CLI to v ' \
+  "Updated the Coana CLI to v \`$COANA_VERSION\`."
+```
+
+It puts the entry under `## [Unreleased]` in the `### Changed` section,
+recreating either when the previous release consumed it, and `--replace`
+rewrites a Coana line left by an earlier unreleased bump instead of stacking a
+second one. Rerunning it for the same version changes nothing.
 
 🚨 **Never write a `## [<version>]` heading.** Release headings belong to the
 release workflow, which promotes the whole `## [Unreleased]` block under the
@@ -73,7 +76,8 @@ equality (case-insensitively, but otherwise exactly), so a heading like
 nothing, falls back to a section derived from the commits in range, and inserts
 its own heading *above* the block it could not see — stranding the entry below a
 released version, where no release will ever pick it up. Dates belong only on
-release headings, which the workflow writes.
+release headings, which the workflow writes. (The helper repairs such a heading
+if it finds one; hand-editing is what puts one there.)
 
 **Resulting shape**:
 ```markdown
@@ -81,10 +85,7 @@ release headings, which the workflow writes.
 
 ### Changed
 - Updated the Coana CLI to v `COANA_VERSION`.
-
 ```
-
-**Note**: Include a blank line after the entry.
 
 ### Step 4: Update Lock File
 

--- a/scripts/release/add-unreleased.mts
+++ b/scripts/release/add-unreleased.mts
@@ -5,18 +5,12 @@
  *   the way a human does. The counterpart to `bump.mts`, which promotes the
  *   block at release time.
  *
- *   This exists so a caller never has to reimplement the shape. Both things it
- *   deliberately cannot touch — `package.json`'s `version` and the
- *   `## [X.Y.Z]` headings — belong to the release workflow, and a caller that
- *   wrote them has already cost a release its notes: v1.1.161 shipped with
- *   commit-derived notes because a hand-written heading had consumed the block
- *   the release meant to promote.
+ *   This exists so a caller never has to reimplement the shape.
  *
  *   Usage:
  *     node scripts/release/add-unreleased.mts [flags] <entry>
  *
- *   Example — the Coana bump, which reruns on every Coana release and so must
- *   update its own line rather than stack a new one each time:
+ *   Example — the Coana bump, which reruns on every Coana release:
  *     node scripts/release/add-unreleased.mts \
  *       --replace '^Updated the Coana CLI to v ' \
  *       'Updated the Coana CLI to v `15.10.28`.'

--- a/scripts/release/add-unreleased.mts
+++ b/scripts/release/add-unreleased.mts
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * @file Accrue one note under CHANGELOG.md's `## [Unreleased]` heading from the
+ *   command line, so automation that bumps a dependency here writes its note
+ *   the way a human does. The counterpart to `bump.mts`, which promotes the
+ *   block at release time.
+ *
+ *   This exists so a caller never has to reimplement the shape. Both things it
+ *   deliberately cannot touch — `package.json`'s `version` and the
+ *   `## [X.Y.Z]` headings — belong to the release workflow, and a caller that
+ *   wrote them has already cost a release its notes: v1.1.161 shipped with
+ *   commit-derived notes because a hand-written heading had consumed the block
+ *   the release meant to promote.
+ *
+ *   Usage:
+ *     node scripts/release/add-unreleased.mts [flags] <entry>
+ *
+ *   Example — the Coana bump, which reruns on every Coana release and so must
+ *   update its own line rather than stack a new one each time:
+ *     node scripts/release/add-unreleased.mts \
+ *       --replace '^Updated the Coana CLI to v ' \
+ *       'Updated the Coana CLI to v `15.10.28`.'
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import process from 'node:process'
+
+import { addUnreleasedEntry } from './changelog.mts'
+import { isMainModule } from '../lib/is-main-module.mts'
+import { runMain } from '../lib/run-main.mts'
+
+import type { ScriptMeta } from '../lib/run-main.mts'
+
+const DEFAULT_FILE = 'CHANGELOG.md'
+const DEFAULT_SECTION = 'Changed'
+
+export interface AddUnreleasedArgs {
+  readonly entry: string
+  readonly file: string
+  readonly replace: RegExp | undefined
+  readonly section: string
+}
+
+/**
+ * Parse the script's argv. Pure — exported for tests.
+ *
+ * `--` never reaches here: `runMain` refuses a bare one, because the truncation
+ * it causes drops flags silently.
+ */
+export function parseArgs(argv: readonly string[]): AddUnreleasedArgs {
+  const positional: string[] = []
+  let file = DEFAULT_FILE
+  let replace: RegExp | undefined
+  let section = DEFAULT_SECTION
+  for (let i = 0, { length } = argv; i < length; i += 1) {
+    const arg = argv[i]!
+    if (arg.startsWith('--')) {
+      const value = argv[i + 1]
+      if (value === undefined) {
+        throw new Error(
+          `[add-unreleased] ${arg} needs a value.\n` +
+            `  Fix: pass one, e.g. \`${arg} <value>\`.`,
+        )
+      }
+      i += 1
+      if (arg === '--file') {
+        file = value
+      } else if (arg === '--replace') {
+        // Unicode mode for parity with the patterns in changelog.mts. Not
+        // global: `addUnreleasedEntry` matches once per bullet, and a lastIndex
+        // carried between bullets would skip every other one.
+        replace = new RegExp(value, 'u')
+      } else if (arg === '--section') {
+        section = value
+      } else {
+        throw new Error(
+          `[add-unreleased] unknown flag ${arg}.\n` +
+            '  Known: --file, --replace, --section.',
+        )
+      }
+    } else {
+      positional.push(arg)
+    }
+  }
+  if (positional.length !== 1) {
+    throw new Error(
+      `[add-unreleased] expected exactly one entry, saw ${positional.length}.\n` +
+        '  Where: the argv for add-unreleased.\n' +
+        '  Fix: quote the entry as a single argument, e.g. ' +
+        "`node scripts/release/add-unreleased.mts 'Updated the Coana CLI to v `15.10.28`.'`.",
+    )
+  }
+  // A leading `- ` is how the line reads in the file, so a caller passing one
+  // is quoting the changelog rather than misusing the script. Accept it.
+  const entry = positional[0]!.replace(/^-\s+/, '').trim()
+  if (!entry) {
+    throw new Error('[add-unreleased] the entry is empty.')
+  }
+  return { entry, file, replace, section }
+}
+
+function log(message: string): void {
+  process.stdout.write(`[add-unreleased] ${message}\n`)
+}
+
+function main(): void {
+  const { entry, file, replace, section } = parseArgs(process.argv.slice(2))
+  const changelog = readFileSync(file, 'utf8')
+  const updated = addUnreleasedEntry({ changelog, entry, replace, section })
+  if (updated === changelog) {
+    log(`${file} already reads "${entry}" under ## [Unreleased] / ${section}.`)
+    return
+  }
+  writeFileSync(file, updated)
+  log(`${file}, under ## [Unreleased] / ${section}:`)
+  process.stdout.write(`  - ${entry}\n`)
+}
+
+const SCRIPT_META: ScriptMeta = {
+  describe:
+    "adds one note under CHANGELOG.md's ## [Unreleased] heading, leaving the version and the release headings to the release workflow",
+  help: `Usage: node scripts/release/add-unreleased.mts [flags] <entry>
+
+  --file <path>      changelog to edit (default: ${DEFAULT_FILE})
+  --replace <regex>  rewrite the first bullet in the section whose text matches,
+                     instead of appending a second one — for a note that reruns,
+                     such as a dependency bump updating its own line
+  --section <name>   Keep a Changelog section (default: ${DEFAULT_SECTION})
+
+  <entry> is the bullet's text; a leading "- " is optional. The block is created
+  when the previous release consumed it, so there is always somewhere to write.
+
+  This never touches package.json's version or a ## [X.Y.Z] heading. Both belong
+  to the release workflow, which derives the version from the release tags and
+  promotes the whole ## [Unreleased] block under a heading it writes itself.`,
+}
+
+if (isMainModule(import.meta.url)) {
+  runMain(main, SCRIPT_META)
+}

--- a/scripts/release/changelog.mts
+++ b/scripts/release/changelog.mts
@@ -349,11 +349,7 @@ export interface AddUnreleasedEntryConfig {
  *
  * NOTHING ELSE MOVES. The release owns `package.json`'s version and every
  * `## [X.Y.Z]` heading — it derives the version from the tags and promotes this
- * block under a heading it writes itself. A caller that writes either invents a
- * version that may never ship and consumes the block the release meant to
- * promote, which has already cost a release its notes. So an accruing note goes
- * here and only here, whether a human, the `/bump-coana` skill, or another
- * repo's automation is writing it.
+ * block under a heading it writes itself.
  *
  * The block is created when the previous release consumed it, and a decorated
  * heading is repaired, so there is always somewhere for the entry to go that

--- a/scripts/release/changelog.mts
+++ b/scripts/release/changelog.mts
@@ -35,21 +35,40 @@ function parseMarkdown(source: string): Root {
 }
 
 /**
- * 0-based line indexes of the document's level-2 (`## `) headings, from
+ * 0-based line indexes of the document's headings at `depth`, from
  * parser-reported positions.
  */
-function h2LineIndexes(source: string): number[] {
+function headingLineIndexes(source: string, depth: number): number[] {
   const indexes: number[] = []
   for (const node of parseMarkdown(source).children) {
     if (
       node.type === 'heading' &&
-      node.depth === 2 &&
+      node.depth === depth &&
       node.position?.start.line !== undefined
     ) {
       indexes.push(node.position.start.line - 1)
     }
   }
   return indexes
+}
+
+function h2LineIndexes(source: string): number[] {
+  return headingLineIndexes(source, 2)
+}
+
+/** `'### Changed'` → `'Changed'`. */
+function headingText(line: string): string {
+  return line.trim().replace(/^#+\s*/, '')
+}
+
+/** Drop leading and trailing blank lines, in place. */
+function trimBlankEdges(lines: string[]): void {
+  while (lines.length && !lines[0]!.trim()) {
+    lines.shift()
+  }
+  while (lines.length && !lines[lines.length - 1]!.trim()) {
+    lines.pop()
+  }
 }
 
 function hasListItem(node: Nodes): boolean {
@@ -223,6 +242,159 @@ export function unreleasedRange(
   const start = headings[at]!
   const end = at + 1 < headings.length ? headings[at + 1]! : lines.length
   return { end, start }
+}
+
+/**
+ * Line index of the `## [Unreleased]` heading, tolerating a decorated variant
+ * such as `## [Unreleased] - 2026-08-27`, or undefined when there is none.
+ *
+ * `unreleasedRange` matches the heading for equality, so a decorated one is
+ * invisible to the release: the block is never promoted and its notes strand
+ * under a heading no release will ever pick up — this is how v1.1.161 shipped
+ * with commit-derived notes. The writer finds the decorated heading so it can
+ * repair it, rather than adding a second block the release also cannot see.
+ */
+function unreleasedHeadingIndex(lines: readonly string[]): number | undefined {
+  return h2LineIndexes(lines.join('\n')).find(index =>
+    /^\[unreleased\]/i.test(headingText(lines[index]!)),
+  )
+}
+
+/**
+ * Rank of `section` in `SECTION_ORDER`, with anything unrecognized sorting last
+ * so a bespoke section keeps its place at the end of the block.
+ */
+function sectionRank(section: string): number {
+  const at = SECTION_ORDER.findIndex(
+    known => known.toLowerCase() === section.toLowerCase(),
+  )
+  return at === -1 ? SECTION_ORDER.length : at
+}
+
+/**
+ * Write `bullet` into `body`'s `### <section>` block, creating that section in
+ * `SECTION_ORDER` position when it is missing. When `replace` matches the text
+ * of a bullet already in the section, that bullet is rewritten in place rather
+ * than a second one appended.
+ */
+function writeSectionEntry(
+  body: readonly string[],
+  section: string,
+  bullet: string,
+  replace: RegExp | undefined,
+): string[] {
+  const lines = [...body]
+  const h3s = headingLineIndexes(lines.join('\n'), 3)
+  const at = h3s.find(
+    index => headingText(lines[index]!).toLowerCase() === section.toLowerCase(),
+  )
+  if (at === undefined) {
+    const before = h3s.find(
+      index => sectionRank(headingText(lines[index]!)) > sectionRank(section),
+    )
+    if (before === undefined) {
+      let end = lines.length
+      while (end > 0 && !lines[end - 1]!.trim()) {
+        end -= 1
+      }
+      lines.splice(end, 0, ...(end ? [''] : []), `### ${section}`, bullet)
+    } else {
+      lines.splice(before, 0, `### ${section}`, bullet, '')
+    }
+    return lines
+  }
+  const next = h3s.find(index => index > at) ?? lines.length
+  if (replace) {
+    // A global or sticky regex carries lastIndex between calls, so a caller's
+    // /g would make every other test fail. Match with a stateless copy.
+    const matcher =
+      replace.global || replace.sticky
+        ? new RegExp(replace.source, replace.flags.replace(/[gy]/gu, ''))
+        : replace
+    for (let i = at + 1; i < next; i += 1) {
+      const line = lines[i]!
+      const text = /^\s*-\s+/.exec(line)
+        ? line.replace(/^\s*-\s+/, '')
+        : undefined
+      if (text !== undefined && matcher.test(text)) {
+        lines[i] = bullet
+        return lines
+      }
+    }
+  }
+  let insertAt = next
+  while (insertAt > at + 1 && !lines[insertAt - 1]!.trim()) {
+    insertAt -= 1
+  }
+  lines.splice(insertAt, 0, bullet)
+  return lines
+}
+
+export interface AddUnreleasedEntryConfig {
+  readonly changelog: string
+  // The bullet's text, without the leading `- `.
+  readonly entry: string
+  // Tested against the TEXT of each bullet already in the section (the `- ` is
+  // stripped first). The first match is rewritten instead of a second bullet
+  // being appended, so a repeated bump updates its own line.
+  readonly replace?: RegExp | undefined
+  // Keep a Changelog section the entry belongs under. Defaults to `Changed`.
+  readonly section?: string | undefined
+}
+
+/**
+ * Add `entry` to the changelog's `## [Unreleased]` block and return the whole
+ * file. The counterpart to `promoteChangelog`: this is how a note accrues, that
+ * is how a release consumes it.
+ *
+ * NOTHING ELSE MOVES. The release owns `package.json`'s version and every
+ * `## [X.Y.Z]` heading — it derives the version from the tags and promotes this
+ * block under a heading it writes itself. A caller that writes either invents a
+ * version that may never ship and consumes the block the release meant to
+ * promote, which has already cost a release its notes. So an accruing note goes
+ * here and only here, whether a human, the `/bump-coana` skill, or another
+ * repo's automation is writing it.
+ *
+ * The block is created when the previous release consumed it, and a decorated
+ * heading is repaired, so there is always somewhere for the entry to go that
+ * the release can actually see.
+ */
+export function addUnreleasedEntry(config: AddUnreleasedEntryConfig): string {
+  const cfg = { __proto__: null, ...config } as AddUnreleasedEntryConfig
+  const lines = cfg.changelog.split('\n')
+
+  const heading = unreleasedHeadingIndex(lines)
+  if (heading === undefined) {
+    lines.splice(
+      h2LineIndexes(lines.join('\n'))[0] ?? lines.length,
+      0,
+      UNRELEASED_HEADING,
+      '',
+    )
+  } else {
+    lines[heading] = UNRELEASED_HEADING
+  }
+  // Present by construction: the heading was either found or just inserted.
+  const range = unreleasedRange(lines)!
+
+  const body = writeSectionEntry(
+    lines.slice(range.start + 1, range.end),
+    cfg.section ?? 'Changed',
+    `- ${cfg.entry}`,
+    cfg.replace,
+  )
+  const head = lines.slice(0, range.start)
+  const tail = lines.slice(range.end)
+  trimBlankEdges(head)
+  trimBlankEdges(body)
+  return [
+    ...(head.length ? [...head, ''] : []),
+    UNRELEASED_HEADING,
+    '',
+    ...body,
+    '',
+    ...tail,
+  ].join('\n')
 }
 
 export interface PromoteChangelogConfig {

--- a/test/release-add-unreleased.test.mts
+++ b/test/release-add-unreleased.test.mts
@@ -1,0 +1,324 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseArgs } from '../scripts/release/add-unreleased.mts'
+import {
+  addUnreleasedEntry,
+  changelogHeading,
+  promoteChangelog,
+} from '../scripts/release/changelog.mts'
+
+const PREAMBLE = [
+  '# Changelog',
+  '',
+  'All notable changes to this project will be documented in this file.',
+  '',
+  'The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).',
+  '',
+].join('\n')
+
+const RELEASED = [
+  '## [1.1.162](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.162) - 2026-08-28',
+  '',
+  '### Changed',
+  '- Updated the Coana CLI to v `15.10.26`.',
+  '',
+].join('\n')
+
+const COANA = /^Updated the Coana CLI to v /u
+
+function build(...blocks: readonly string[]): string {
+  return [PREAMBLE, ...blocks].join('\n')
+}
+
+describe('addUnreleasedEntry', () => {
+  it('adds the entry under an existing Changed section', () => {
+    const changelog = build(
+      ['## [Unreleased]', '', '### Changed', '- Something else.', ''].join(
+        '\n',
+      ),
+      RELEASED,
+    )
+    expect(addUnreleasedEntry({ changelog, entry: 'Bumped a thing.' })).toBe(
+      build(
+        [
+          '## [Unreleased]',
+          '',
+          '### Changed',
+          '- Something else.',
+          '- Bumped a thing.',
+          '',
+        ].join('\n'),
+        RELEASED,
+      ),
+    )
+  })
+
+  // The previous release consumed the block. Having nowhere to put a note is
+  // what drove callers to invent `## [<version>]` headings in the first place.
+  it('recreates the block when the previous release consumed it', () => {
+    const changelog = build(RELEASED)
+    expect(
+      addUnreleasedEntry({
+        changelog,
+        entry: 'Updated the Coana CLI to v `15.10.28`.',
+      }),
+    ).toBe(
+      build(
+        [
+          '## [Unreleased]',
+          '',
+          '### Changed',
+          '- Updated the Coana CLI to v `15.10.28`.',
+          '',
+        ].join('\n'),
+        RELEASED,
+      ),
+    )
+  })
+
+  it('creates the section when the block has none', () => {
+    const changelog = build(['## [Unreleased]', ''].join('\n'), RELEASED)
+    expect(addUnreleasedEntry({ changelog, entry: 'A note.' })).toBe(
+      build(
+        ['## [Unreleased]', '', '### Changed', '- A note.', ''].join('\n'),
+        RELEASED,
+      ),
+    )
+  })
+
+  it('creates the section in SECTION_ORDER position', () => {
+    const changelog = build(
+      [
+        '## [Unreleased]',
+        '',
+        '### Added',
+        '- A flag.',
+        '',
+        '### Fixed',
+        '- A bug.',
+        '',
+      ].join('\n'),
+      RELEASED,
+    )
+    expect(addUnreleasedEntry({ changelog, entry: 'A note.' })).toBe(
+      build(
+        [
+          '## [Unreleased]',
+          '',
+          '### Added',
+          '- A flag.',
+          '',
+          '### Changed',
+          '- A note.',
+          '',
+          '### Fixed',
+          '- A bug.',
+          '',
+        ].join('\n'),
+        RELEASED,
+      ),
+    )
+  })
+
+  // A bump reruns on every upstream release. Without `replace` the block would
+  // accumulate one stale bullet per run.
+  it('rewrites a matching bullet in place instead of stacking', () => {
+    const changelog = build(
+      [
+        '## [Unreleased]',
+        '',
+        '### Changed',
+        '- Updated the Coana CLI to v `15.10.26`.',
+        '',
+        '### Fixed',
+        '- A bug.',
+        '',
+      ].join('\n'),
+      RELEASED,
+    )
+    const updated = addUnreleasedEntry({
+      changelog,
+      entry: 'Updated the Coana CLI to v `15.10.28`.',
+      replace: COANA,
+    })
+    expect(updated).not.toContain('15.10.26.')
+    expect(
+      updated.match(/- Updated the Coana CLI to v `15\.10\.28`\./gu),
+    ).toHaveLength(1)
+    expect(updated).toContain('### Fixed\n- A bug.')
+  })
+
+  it('only replaces within the named section', () => {
+    const changelog = build(
+      [
+        '## [Unreleased]',
+        '',
+        '### Fixed',
+        '- Updated the Coana CLI to v `15.10.26`.',
+        '',
+      ].join('\n'),
+      RELEASED,
+    )
+    const updated = addUnreleasedEntry({
+      changelog,
+      entry: 'Updated the Coana CLI to v `15.10.28`.',
+      replace: COANA,
+    })
+    expect(updated).toContain(
+      '### Fixed\n- Updated the Coana CLI to v `15.10.26`.',
+    )
+    expect(updated).toContain(
+      '### Changed\n- Updated the Coana CLI to v `15.10.28`.',
+    )
+  })
+
+  // `unreleasedRange` matches the heading for equality, so a dated one is
+  // invisible to the release: its notes strand under a heading no release will
+  // pick up. This is exactly how v1.1.161 shipped with the wrong notes.
+  it('repairs a decorated Unreleased heading rather than adding a second block', () => {
+    const changelog = build(
+      ['## [Unreleased] - 2026-08-27', '', '### Changed', '- A note.', ''].join(
+        '\n',
+      ),
+      RELEASED,
+    )
+    const updated = addUnreleasedEntry({ changelog, entry: 'Another note.' })
+    expect(updated).not.toContain('## [Unreleased] - 2026-08-27')
+    expect(updated.match(/^## \[Unreleased\]$/gmu)).toHaveLength(1)
+    expect(updated).toContain('### Changed\n- A note.\n- Another note.')
+  })
+
+  it('matches a lower-cased heading', () => {
+    const changelog = build(
+      ['## [unreleased]', '', '### Changed', '- A note.', ''].join('\n'),
+      RELEASED,
+    )
+    const updated = addUnreleasedEntry({ changelog, entry: 'Another note.' })
+    expect(updated.match(/^## \[[Uu]nreleased\]$/gmu)).toHaveLength(1)
+    expect(updated).toContain('- A note.\n- Another note.')
+  })
+
+  // Structure comes from the parser, so markdown inside a fence is content.
+  it('ignores a heading lookalike inside a code fence', () => {
+    const changelog = build(
+      [
+        '## [Unreleased]',
+        '',
+        '### Changed',
+        '- Documented the shape:',
+        '',
+        '  ```markdown',
+        '  ### Fixed',
+        '  ## [1.0.0] - 2020-01-01',
+        '  ```',
+        '',
+      ].join('\n'),
+      RELEASED,
+    )
+    const updated = addUnreleasedEntry({ changelog, entry: 'A note.' })
+    expect(updated).toContain('  ### Fixed\n  ## [1.0.0] - 2020-01-01')
+    expect(updated).toContain('- Documented the shape:')
+    expect(updated.indexOf('- A note.')).toBeGreaterThan(
+      updated.indexOf('```markdown'),
+    )
+    expect(updated.indexOf('- A note.')).toBeLessThan(
+      updated.indexOf('## [1.1.162]'),
+    )
+  })
+
+  it('leaves the released blocks byte-for-byte', () => {
+    const changelog = build(RELEASED)
+    const updated = addUnreleasedEntry({ changelog, entry: 'A note.' })
+    expect(updated.slice(updated.indexOf('## [1.1.162]'))).toBe(
+      changelog.slice(changelog.indexOf('## [1.1.162]')),
+    )
+  })
+
+  it('is idempotent for a rerun at the same version', () => {
+    const once = addUnreleasedEntry({
+      changelog: build(RELEASED),
+      entry: 'Updated the Coana CLI to v `15.10.28`.',
+      replace: COANA,
+    })
+    expect(
+      addUnreleasedEntry({
+        changelog: once,
+        entry: 'Updated the Coana CLI to v `15.10.28`.',
+        replace: COANA,
+      }),
+    ).toBe(once)
+  })
+
+  // The whole point of accruing here: the release must be able to promote it.
+  it('writes a block that promoteChangelog then promotes', () => {
+    const changelog = addUnreleasedEntry({
+      changelog: build(RELEASED),
+      entry: 'Updated the Coana CLI to v `15.10.28`.',
+      replace: COANA,
+    })
+    const heading = changelogHeading(
+      '1.1.163',
+      '2026-09-01',
+      'https://github.com/SocketDev/socket-cli',
+    )
+    const promoted = promoteChangelog({
+      changelog,
+      derivedSection: `${heading}\n\n### Fixed\n- derived`,
+      heading,
+    })
+    expect(promoted.source).toBe('unreleased')
+    expect(promoted.section).toBe(
+      `${heading}\n\n### Changed\n- Updated the Coana CLI to v \`15.10.28\`.`,
+    )
+    expect(promoted.changelog).not.toContain('[Unreleased]')
+  })
+})
+
+describe('parseArgs', () => {
+  it('defaults the file and section', () => {
+    expect(parseArgs(['A note.'])).toEqual({
+      entry: 'A note.',
+      file: 'CHANGELOG.md',
+      replace: undefined,
+      section: 'Changed',
+    })
+  })
+
+  it('reads every flag', () => {
+    const args = parseArgs([
+      '--section',
+      'Fixed',
+      '--file',
+      'docs/CHANGELOG.md',
+      '--replace',
+      '^Updated ',
+      'A note.',
+    ])
+    expect(args.section).toBe('Fixed')
+    expect(args.file).toBe('docs/CHANGELOG.md')
+    expect(args.replace?.source).toBe('^Updated ')
+    // Global would carry lastIndex between bullets and skip every other one.
+    expect(args.replace?.global).toBe(false)
+  })
+
+  it('tolerates a leading bullet marker on the entry', () => {
+    expect(parseArgs(['- A note.']).entry).toBe('A note.')
+  })
+
+  it('refuses an unknown flag', () => {
+    expect(() => parseArgs(['--nope', 'x', 'A note.'])).toThrow(/unknown flag/u)
+  })
+
+  it('refuses a flag with no value', () => {
+    expect(() => parseArgs(['A note.', '--section'])).toThrow(/needs a value/u)
+  })
+
+  it('refuses anything but exactly one entry', () => {
+    expect(() => parseArgs([])).toThrow(/exactly one entry/u)
+    expect(() => parseArgs(['one', 'two'])).toThrow(/exactly one entry/u)
+  })
+
+  it('refuses an empty entry', () => {
+    expect(() => parseArgs(['   '])).toThrow(/entry is empty/u)
+  })
+})


### PR DESCRIPTION
## Summary

#1515 wrote down the rule that the release owns `package.json`'s `version` and every `## [X.Y.Z]` heading. A rule was all it was — every caller still hand-built the `## [Unreleased]` block from prose, and the caller that got it wrong is the one nobody here reviews: Coana's release automation, which opens the `upgrading coana to version …` PRs.

The cost so far:

- **v1.1.161 shipped with the wrong notes.** The bot's hand-written `## [1.1.161]` heading consumed the `[Unreleased]` block, so `promoteChangelog` found nothing to promote and fell back to commit-derived notes. The actual user-facing change — the Coana 15.10.25 bump — was stranded below the release heading.
- **Every bump PR since has needed a human fixup commit** reverting the version and rewriting the heading (#1516 "Fix", #1518 "Update package.json").

Nothing in CI catches it on a PR, so it fails silently each time.

## Changes

`addUnreleasedEntry()` in `changelog.mts` — the counterpart to `promoteChangelog`. It finds or creates the `## [Unreleased]` block and the `### Changed` section (in `SECTION_ORDER` position), and with `--replace` rewrites a matching bullet in place, so a bump that reruns on every upstream release updates its own line instead of stacking one per run.

It reuses `unreleasedRange()` and the same parsed-not-matched structure rule as `promoteChangelog`, so the writer and the reader can't drift: markdown inside a fence stays content, and the block this writes is by construction one the release can see. There's a test asserting exactly that round trip.

It also repairs a decorated `## [Unreleased] - 2026-08-27` heading. That form is invisible to `unreleasedRange()`, which matches for equality — a human wrote one on #1516 while fixing up a bump PR, and the entry under it was stranded until a later bump happened to overwrite the line.

`scripts/release/add-unreleased.mts` exposes it to non-JS callers, in the house `isMainModule` + `runMain(main, SCRIPT_META)` shape so it inherits `--describe` / `--help` and the bare-`--` refusal:

```bash
node scripts/release/add-unreleased.mts \
  --replace '^Updated the Coana CLI to v ' \
  'Updated the Coana CLI to v `15.10.28`.'
```

`/bump-coana` now runs that instead of describing the shape in prose, and [coana-tech/coana-package-manager#2378](https://github.com/coana-tech/coana-package-manager/pull/2378) switches the bot to the same call — so the human path and the bot path become one implementation, tested here.

## Why here and not in the caller

That Coana PR originally carried a ~60-line changelog editor embedded in a YAML `run:` heredoc. @BarrensZeppelin's review asked for this instead, and he's right: the convention belongs to this repo, the parse half is already installed here, and a helper can be unit-tested where a heredoc can't. Keeping it there also meant re-implementing `h2` detection with regex and losing the code-fence correctness this repo explicitly tests for.

## Verification

- `pnpm exec vitest run test/release-add-unreleased.test.mts test/release-version.test.mts test/release-bump.test.mts` — 53 pass (19 new, 34 existing unaffected by the `h2LineIndexes` → `headingLineIndexes` refactor).
- New cases cover: existing section, recreated block, created section, `SECTION_ORDER` placement, in-place replace, replace scoped to its own section, decorated heading repaired, lower-cased heading, heading lookalike inside a fence, released blocks left byte-for-byte, idempotent rerun, and the `addUnreleasedEntry` → `promoteChangelog` round trip. Plus `parseArgs` flags and refusals.
- Ran the CLI against the real `CHANGELOG.md` on `v1.x`: creates the block, updates in place on a version bump, no-ops on a rerun.
- `node scripts/check.mts` passes; `tsc --noEmit` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release changelog write path used by automation; mistakes could still strand notes, but the change replaces error-prone hand edits with tested logic aligned to `promoteChangelog`.
> 
> **Overview**
> Adds **`addUnreleasedEntry`** in `changelog.mts` and a **`add-unreleased.mts`** CLI so Coana bumps and other automation write `CHANGELOG.md` under **`## [Unreleased]`** instead of hand-editing. The writer mirrors **`promoteChangelog`** (same parsing rules, fenced-code safety) and only touches the unreleased block—not `package.json` version or **`## [X.Y.Z]`** headings.
> 
> Behavior includes recreating **`[Unreleased]`** after a release consumes it, inserting **`### Changed`** (and other sections) in **`SECTION_ORDER`**, optional **`--replace`** to update a matching bullet in place (for repeated Coana bumps), and normalizing decorated **`## [Unreleased] - date`** headings so releases can still promote the block.
> 
> The **`/bump-coana`** skill now runs the CLI instead of prose instructions for manual changelog edits. **`test/release-add-unreleased.test.mts`** covers edge cases and an **`addUnreleasedEntry` → `promoteChangelog`** round trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15fd47ad0a0dd1803ced52aa2e23740bd71eb91a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->