### PR TITLE
upgrading coana to version 15.10.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+- Updated the Coana CLI to v `15.10.29`.
+
 ## [1.1.164](https://github.com/SocketDev/socket-cli/releases/tag/v1.1.164) - 2026-09-01
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.4",
     "@biomejs/biome": "2.2.4",
-    "@coana-tech/cli": "15.10.28",
+    "@coana-tech/cli": "15.10.29",
     "@cyclonedx/cdxgen": "12.1.2",
     "@dotenvx/dotenvx": "1.49.0",
     "@eslint/compat": "1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,8 +135,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       '@coana-tech/cli':
-        specifier: 15.10.28
-        version: 15.10.28
+        specifier: 15.10.29
+        version: 15.10.29
       '@cyclonedx/cdxgen':
         specifier: 12.1.2
         version: 12.1.2
@@ -824,8 +824,8 @@ packages:
     resolution: {integrity: sha512-hAs5PPKPCQ3/Nha+1fo4A4/gL85fIfxZwHPehsjCJ+BhQH2/yw6/xReuaPA/RfNQr6iz1PcD7BZcE3ctyyl3EA==}
     cpu: [x64]
 
-  '@coana-tech/cli@15.10.28':
-    resolution: {integrity: sha512-QUIz2shui9XXoGhXj4Xy/kUvjhPbQgHx1cjxUa6C1KeSgyZEsGEgJ4DCSgvhEFr0rwQGNR1sxiYbJwGKnPgKRA==}
+  '@coana-tech/cli@15.10.29':
+    resolution: {integrity: sha512-e+V6qgRNhwrpvzy81pYl4MO4p+/AhswCD5Hfle86yayKYH3k7DPhf5LnDpMs9JT66W0fIcOi9R8vJQ1AAKYIFg==}
     hasBin: true
 
   '@colors/colors@1.5.0':
@@ -5699,7 +5699,7 @@ snapshots:
   '@cdxgen/cdxgen-plugins-bin@2.0.2':
     optional: true
 
-  '@coana-tech/cli@15.10.28': {}
+  '@coana-tech/cli@15.10.29': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- Upgrades `@coana-tech/cli` from `15.10.28` to `15.10.29`.
- The changelog note lands under `## [Unreleased]`; the release workflow picks the Socket CLI version and promotes the block.

## Coana Changelog
For details on what's included in this Coana release, see the [Coana Changelogs](https://docs.coana.tech/changelogs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine patch dependency bump with lockfile and changelog only; scan/fix behavior may shift with Coana’s release notes but Socket CLI code is unchanged.
> 
> **Overview**
> Bumps the bundled **Coana** analysis CLI from `15.10.28` to **`15.10.29`** by updating the `@coana-tech/cli` devDependency and `pnpm-lock.yaml`.
> 
> Adds a **Changed** note under `## [Unreleased]` in `CHANGELOG.md` so the next Socket CLI release can promote it. No Socket CLI application source changes—behavior for reachability, manifest generation, and `socket fix` follows whatever is in Coana `15.10.29` (see [Coana changelogs](https://docs.coana.tech/changelogs)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d8d655adb21497f725717ee6e3cb8e4cfd5e553. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->